### PR TITLE
EAGLE parallel draft with auto regression; kv cache in EAGLE training

### DIFF
--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -835,7 +835,7 @@ class _DynamicEagleGPTModel(EagleModel):
                         dtype=hidden_states.dtype,
                         device=hidden_states.device,
                     ),
-                    gathered_features[:-1, :, :],
+                    gathered_features[:-1, :, :],  # type: ignore[index]
                 )
             )
         )

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -1066,7 +1066,7 @@ class _DynamicEagleGPTModel(EagleModel):
                     **(extra_block_kwargs or {}),
                 )
 
-                eagle_logits_0.append(eagle_logits_[-input_ids.shape[1] :])
+                eagle_logits_0.append(eagle_logits_)
             eagle_logits_0 = torch.cat(eagle_logits_0, dim=0)
 
         # If labels are not provided, return the original logits. We only return after
@@ -1137,7 +1137,7 @@ class _DynamicEagleGPTModel(EagleModel):
                 inference_context=eagle_inference_context,
                 **(extra_block_kwargs or {}),
             )
-            eagle_logits_1.append(eagle_logits_[-input_ids.shape[1] :])
+            eagle_logits_1.append(eagle_logits_)
         eagle_logits_1 = torch.cat(eagle_logits_1, dim=0)
 
         for i in range(self.eagle_config.parallel_draft_step):
@@ -1187,7 +1187,7 @@ class _DynamicEagleGPTModel(EagleModel):
                 inference_context=eagle_inference_context,
                 **(extra_block_kwargs or {}),
             )
-            eagle_logits_2.append(eagle_logits_[-input_ids.shape[1] :])
+            eagle_logits_2.append(eagle_logits_)
         eagle_logits_2 = torch.cat(eagle_logits_2, dim=0)
 
         for i in range(self.eagle_config.parallel_draft_step):
@@ -1237,7 +1237,7 @@ class _DynamicEagleGPTModel(EagleModel):
                 inference_context=eagle_inference_context,
                 **(extra_block_kwargs or {}),
             )
-            eagle_logits_3.append(eagle_logits_[-input_ids.shape[1] :])
+            eagle_logits_3.append(eagle_logits_)
         eagle_logits_3 = torch.cat(eagle_logits_3, dim=0)
 
         for i in range(self.eagle_config.parallel_draft_step):

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -843,7 +843,7 @@ class _DynamicEagleGPTModel(EagleModel):
         rotary_pos_emb = self.eagle_module.rotary_pos_emb(padded_input_ids.shape[-1])
 
         attn_mask = attention_mask.clone().detach()
-        attn_mask[:, :, :-1, :-1] = attention_mask[:, :, 1:, 1:]
+        attn_mask[:, :, :-1, :-1] = attn_mask[:, :, 1:, 1:]
         attn_mask[:, :, -1, :] = True
         attn_mask[:, :, :, -1] = True
 

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -1404,6 +1404,8 @@ class _DynamicEagleGPTModel(EagleModel):
             )
             if self.config.sequence_parallel:
                 gathered_embedding = gather_from_sequence_parallel_region(eagle_inputs["embedding"])
+            else:
+                gathered_embedding = eagle_inputs["embedding"]
             if self.eagle_config.parallel_draft_step > 1:
                 # Replace dummy hidden_states with embedding for mask tokens
                 padded_hidden_states[

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -1408,6 +1408,11 @@ class _DynamicEagleGPTModel(EagleModel):
 
             draft_tokens.append(draft_token)
 
+            # Remove mask tokens from eagle_ids before adding draft_token
+            # Remove added hidden_states before
+            eagle_ids = eagle_ids[:, : -self.eagle_config.parallel_draft_step + 1]
+            hidden_states = hidden_states[: -self.eagle_config.parallel_draft_step + 1]
+
             eagle_ids = torch.cat((eagle_ids, draft_token), dim=-1)
             hidden_states = torch.cat(
                 (

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -845,7 +845,7 @@ class _DynamicEagleGPTModel(EagleModel):
         rotary_pos_emb = self.eagle_module.rotary_pos_emb(padded_input_ids.shape[-1])
 
         attn_mask = attention_mask.clone().detach()
-        attn_mask[:, :, :-1, :-1] = attn_mask[:, :, 1:, 1:]
+        attn_mask[:, :, :-1, :-1] = attention_mask[:, :, 1:, 1:]
         attn_mask[:, :, -1, :] = True
         attn_mask[:, :, :, -1] = True
 
@@ -914,6 +914,55 @@ class _DynamicEagleGPTModel(EagleModel):
             eagle_inputs["attention_mask"] = attn_mask
             eagle_inputs["position_ids"] = position_ids
             eagle_inputs["rotary_pos_emb"] = rotary_pos_emb
+
+            if self.config.sequence_parallel:
+                gathered_hidden_states = gather_from_sequence_parallel_region(hidden_states)
+            else:
+                gathered_hidden_states = hidden_states
+            eagle_inputs["hidden_states"] = gathered_hidden_states
+
+            for i in range(self.eagle_config.parallel_draft_step - 1):
+                eagle_inputs["input_ids"] = torch.cat(
+                    (
+                        eagle_inputs["input_ids"],
+                        torch.full(
+                            padded_input_ids.shape,
+                            getattr(self, f"mask_token_{i}"),
+                            device=padded_input_ids.device,
+                            dtype=padded_input_ids.dtype,
+                        ),
+                    ),
+                    dim=-1,
+                )
+
+                eagle_inputs["hidden_states"] = torch.cat(
+                    (
+                        eagle_inputs["hidden_states"],
+                        torch.zeros(
+                            (1 + i, b, h), dtype=hidden_states.dtype, device=hidden_states.device
+                        ),
+                        gathered_hidden_states[: -(1 + i)],
+                    ),
+                    dim=0,
+                )
+
+                eagle_inputs["position_ids"] = torch.cat(
+                    (eagle_inputs["position_ids"], position_ids), dim=-1
+                )
+
+                if rotary_pos_emb is not None:
+                    eagle_inputs["rotary_pos_emb"] = torch.cat(
+                        (eagle_inputs["rotary_pos_emb"], rotary_pos_emb), dim=0
+                    )
+
+            if self.config.sequence_parallel:
+                eagle_inputs["hidden_states"] = scatter_to_sequence_parallel_region(
+                    eagle_inputs["hidden_states"]
+                )
+
+            eagle_inputs["attention_mask"] = set_multi_step_attention_mask(
+                attn_mask, self.eagle_config.parallel_draft_step
+            )
         elif features.shape[0] == hidden_states.shape[0]:
             eagle_inputs["input_ids"] = torch.cat(
                 (padded_input_ids, padded_input_ids),

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -140,7 +140,7 @@ def dict_to_config(
 
 
 def mcore_version_higher_than(target_version: str):
-    """Check if megatron-core is least this version."""
+    """Check if megatron-core is greater than this version."""
     return Version(megatron.core.__version__) > Version(target_version)
 
 
@@ -239,13 +239,13 @@ def set_multi_step_attention_mask(attn_mask, step):
     =======================================================================================================================
     """  # noqa: E501
     s = attn_mask.shape[-1]
-    for iter in range(2, step + 1):
-        # iter starts from 2nd step
+    for step_idx in range(2, step + 1):
+        # step_idx starts from 2nd step
         mask_0 = attn_mask.clone().detach()
-        mask_0[:, :, iter - 2, :] = True
+        mask_0[:, :, step_idx - 2, :] = True
         mask_0[:, :, :, :-1] = mask_0[:, :, :, 1:]
         mask_1 = attn_mask.new_ones(attn_mask.shape[0], attn_mask.shape[1], s, s).bool()
-        for i in range(iter - 1, s - 1):
+        for i in range(step_idx - 1, s - 1):
             mask_1[:, :, i, i] = False
 
         attn_mask = torch.cat((mask_0, mask_1), dim=-1)

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -790,7 +790,9 @@ class _DynamicEagleGPTModel(EagleModel):
         eagle_inputs["position_ids"] = torch.empty(
             0, dtype=position_ids.dtype, device=position_ids.device
         )
-        eagle_inputs["rotary_pos_emb"] = rotary_pos_emb
+        eagle_inputs["rotary_pos_emb"] = torch.empty(
+            0, dtype=rotary_pos_emb.dtype, device=rotary_pos_emb.device
+        )
         if self.config.sequence_parallel:
             gathered_hidden_states = gather_from_sequence_parallel_region(hidden_states)
             gathered_features = (
@@ -831,13 +833,15 @@ class _DynamicEagleGPTModel(EagleModel):
                         eagle_inputs["hidden_states"],
                         gathered_hidden_states
                         if step == 0
-                        else (
-                            torch.zeros(
-                                (1, b, h),
-                                dtype=hidden_states.dtype,
-                                device=hidden_states.device,
-                            ),
-                            feature[:-1, :, :],
+                        else torch.cat(
+                            (
+                                torch.zeros(
+                                    (1, b, h),
+                                    dtype=hidden_states.dtype,
+                                    device=hidden_states.device,
+                                ),
+                                feature[:-1, :, :],
+                            )
                         ),
                     ),
                     dim=0,

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -1441,8 +1441,9 @@ class _DynamicEagleGPTModel(EagleModel):
 
             # Remove mask tokens from eagle_ids before adding draft_token
             # Remove added hidden_states before
-            eagle_ids = eagle_ids[:, : -self.eagle_config.parallel_draft_step + 1]
-            hidden_states = hidden_states[: -self.eagle_config.parallel_draft_step + 1]
+            if self.eagle_config.parallel_draft_step > 1:
+                eagle_ids = eagle_ids[:, : -self.eagle_config.parallel_draft_step + 1]
+                hidden_states = hidden_states[: -self.eagle_config.parallel_draft_step + 1]
 
             eagle_ids = torch.cat((eagle_ids, draft_token), dim=-1)
             hidden_states = torch.cat(

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -945,7 +945,8 @@ class _DynamicEagleGPTModel(EagleModel):
         )
 
         # Update inference_context.sequence_len_offset after each call of eagle_module
-        inference_context.sequence_len_offset += eagle_inputs["input_ids"].shape[1]
+        if inference_context is not None:
+            inference_context.sequence_len_offset += eagle_inputs["input_ids"].shape[1]
 
         if hasattr(self.eagle_module, "eagle_output_layer"):
             eagle_logits, _ = self.eagle_module.eagle_output_layer(eagle_hidden_states)

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -1085,6 +1085,7 @@ class _DynamicEagleGPTModel(EagleModel):
             if self.eagle_freeze_base_model:
                 loss = 0.0 * loss
 
+        acc = []
         eagle_hidden_states_pre_norm = None
         for ttt_step in range(ttt_steps):
             eagle_logits = []
@@ -1136,7 +1137,6 @@ class _DynamicEagleGPTModel(EagleModel):
                 )
 
             if self.eagle_report_acc and not self.training:
-                acc = []
                 with torch.no_grad():
                     for i in range(self.eagle_config.parallel_draft_step):
                         gathered_logits = gather_from_tensor_model_parallel_region(
@@ -1152,12 +1152,12 @@ class _DynamicEagleGPTModel(EagleModel):
                         )
                         acc.append(top1_p)
 
-                if get_tensor_model_parallel_rank() == 0:
-                    print(
-                        f"{torch.distributed.get_rank():3}/{torch.distributed.get_world_size():3}"
-                        f"EAGLE 1st Top-1: {acc}",
-                        flush=True,
-                    )
+        if self.eagle_report_acc and not self.training and get_tensor_model_parallel_rank() == 0:
+            print(
+                f"{torch.distributed.get_rank():3}/{torch.distributed.get_world_size():3}"
+                f"EAGLE Top-1: {acc}",
+                flush=True,
+            )
 
         return loss
 

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -780,15 +780,9 @@ class _DynamicEagleGPTModel(EagleModel):
 
         eagle_inputs = {}
 
-        eagle_inputs["input_ids"] = torch.empty(
-            0, dtype=padded_input_ids.dtype, device=padded_input_ids.device
-        )
-        eagle_inputs["position_ids"] = torch.empty(
-            0, dtype=position_ids.dtype, device=position_ids.device
-        )
-        eagle_inputs["rotary_pos_emb"] = torch.empty(
-            0, dtype=rotary_pos_emb.dtype, device=rotary_pos_emb.device
-        )
+        eagle_inputs["position_ids"] = position_ids
+        eagle_inputs["rotary_pos_emb"] = rotary_pos_emb
+
         if self.config.sequence_parallel:
             gathered_hidden_states = gather_from_sequence_parallel_region(hidden_states)
             gathered_features = (
@@ -797,56 +791,34 @@ class _DynamicEagleGPTModel(EagleModel):
         else:
             gathered_hidden_states = hidden_states
             gathered_features = features
-        eagle_inputs["hidden_states"] = torch.empty(
-            0, dtype=gathered_hidden_states.dtype, device=gathered_hidden_states.device
+
+        eagle_inputs["input_ids"] = (
+            padded_input_ids
+            if parallel_draft_step == 1
+            else torch.full(
+                padded_input_ids.shape,
+                getattr(self, f"mask_token_{parallel_draft_step - 2}"),
+                device=padded_input_ids.device,
+                dtype=padded_input_ids.dtype,
+            )
         )
 
-        for step in range(ttt_step):
-            for i in range(parallel_draft_step):
-                eagle_inputs["input_ids"] = torch.cat(
-                    (
-                        eagle_inputs["input_ids"],
-                        padded_input_ids
-                        if i == 0
-                        else torch.full(
-                            padded_input_ids.shape,
-                            getattr(self, f"mask_token_{i - 1}"),
-                            device=padded_input_ids.device,
-                            dtype=padded_input_ids.dtype,
-                        ),
+        if gathered_features is not None:
+            feature = gathered_features[-s:]
+        eagle_inputs["hidden_states"] = (
+            gathered_hidden_states
+            if ttt_step == 1
+            else torch.cat(
+                (
+                    torch.zeros(
+                        (1, b, h),
+                        dtype=hidden_states.dtype,
+                        device=hidden_states.device,
                     ),
-                    dim=-1,
+                    feature[:-1, :, :],
                 )
-
-                if step > 0:
-                    feature = gathered_features[-s:]
-                eagle_inputs["hidden_states"] = torch.cat(
-                    (
-                        eagle_inputs["hidden_states"],
-                        gathered_hidden_states
-                        if step == 0
-                        else torch.cat(
-                            (
-                                torch.zeros(
-                                    (1, b, h),
-                                    dtype=hidden_states.dtype,
-                                    device=hidden_states.device,
-                                ),
-                                feature[:-1, :, :],
-                            )
-                        ),
-                    ),
-                    dim=0,
-                )
-
-                eagle_inputs["position_ids"] = torch.cat(
-                    (eagle_inputs["position_ids"], position_ids), dim=-1
-                )
-
-                if rotary_pos_emb is not None:
-                    eagle_inputs["rotary_pos_emb"] = torch.cat(
-                        (eagle_inputs["rotary_pos_emb"], rotary_pos_emb), dim=0
-                    )
+            )
+        )
 
         if self.config.sequence_parallel:
             eagle_inputs["hidden_states"] = scatter_to_sequence_parallel_region(

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -201,7 +201,7 @@ def set_multi_step_attention_mask(attn_mask, step):
 
     ttt_step=0
                   | i1 i2 i3 i4 i5 i6 i7 -- | m0 m0 m0 m0 m0 m0 m0 -- | m1 m1 m1 m1 m1 m1 m1 -- |
-                  | h0 h1 h2 h3 h4 h5 h6 h7 | h0 h1 h2 h3 h4 h5 h6 h7 | h0 h1 h2 h3 h4 h5 h6 h7 |
+                  | h0 h1 h2 h3 h4 h5 h6 h7 | M0 M0 M0 M0 M0 M0 M0 M0 | M1 M1 M1 M1 M1 M1 M1 M1 |
     =============================================================================================
     F1 l1 | i1 h0 |  x                      |                         |                         |
     F2 l2 | i2 h1 |  x  x                   |                         |                         |
@@ -212,28 +212,28 @@ def set_multi_step_attention_mask(attn_mask, step):
     F7 l7 | i7 h6 |  x  x  x  x  x  x  x    |                         |                         |
     -- -- | -- h7 |  o  o  o  o  o  o  o  o |                         |                         |
     =============================================================================================
-    -- -- | m0 -- |                         |                         |                         |
-    G2 l2 | m0 h1 |  x  o                   |     x                   |                         |
-    G3 l3 | m0 h2 |  x  x  o                |        x                |                         |
-    G4 l4 | m0 h3 |  x  x  x  o             |           x             |                         |
-    G5 l5 | m0 h4 |  x  x  x  x  o          |              x          |                         |
-    G6 l6 | m0 h5 |  x  x  x  x  x  o       |                 x       |                         |
-    G7 l7 | m0 h6 |  x  x  x  x  x  x  o    |                    x    |                         |
-    -- -- | -- h7 |                         |                         |                         |
+    -- -- | m0 M0 |                         |                         |                         |
+    G2 l2 | m0 M0 |  x  o                   |     x                   |                         |
+    G3 l3 | m0 M0 |  x  x  o                |        x                |                         |
+    G4 l4 | m0 M0 |  x  x  x  o             |           x             |                         |
+    G5 l5 | m0 M0 |  x  x  x  x  o          |              x          |                         |
+    G6 l6 | m0 M0 |  x  x  x  x  x  o       |                 x       |                         |
+    G7 l7 | m0 M0 |  x  x  x  x  x  x  o    |                    x    |                         |
+    -- -- | -- M0 |                         |                         |                         |
     =============================================================================================
-    -- -- | m1 -- |                         |                         |                         |
-    -- -- | m1 h1 |                         |                         |                         |
-    H3 l3 | m1 h2 |  x  o  o                |     x  o                |        x                |
-    H4 l4 | m1 h3 |  x  x  o  o             |        x  o             |           x             |
-    H5 l5 | m1 h4 |  x  x  x  o  o          |           x  o          |              x          |
-    H6 l6 | m1 h5 |  x  x  x  x  o  o       |              x  o       |                 x       |
-    H7 l7 | m1 h6 |  x  x  x  x  x  o  o    |                 x  o    |                    x    |
-    -- -- | -- h7 |                         |                         |                         |
+    -- -- | m1 M0 |                         |                         |                         |
+    -- -- | m1 M1 |                         |                         |                         |
+    H3 l3 | m1 M1 |  x  o  o                |     x  o                |        x                |
+    H4 l4 | m1 M1 |  x  x  o  o             |        x  o             |           x             |
+    H5 l5 | m1 M1 |  x  x  x  o  o          |           x  o          |              x          |
+    H6 l6 | m1 M1 |  x  x  x  x  o  o       |              x  o       |                 x       |
+    H7 l7 | m1 M1 |  x  x  x  x  x  o  o    |                 x  o    |                    x    |
+    -- -- | -- M1 |                         |                         |                         |
 
 
     ttt_step=1
                   | i1 i2 i3 i4 i5 i6 i7 -- | i1 i2 i3 i4 i5 i6 i7 -- | m0 m0 m0 m0 m0 m0 m0 -- | m1 m1 m1 m1 m1 m1 m1 -- |
-                  | h0 h1 h2 h3 h4 h5 h6 h7 | -- F1 F2 F3 F4 F5 F6 F7 | -- F1 F2 F3 F4 F5 F6 F7 | -- F1 F2 F3 F4 F5 F6 F7 |
+                  | h0 h1 h2 h3 h4 h5 h6 h7 | -- F1 F2 F3 F4 F5 F6 F7 | M0 M0 M0 M0 M0 M0 M0 M0 | M1 M1 M1 M1 M1 M1 M1 M1 |
     =======================================================================================================================
     -- -- | i1 -- |                         |                         |                         |                         |
     J2 l2 | i2 F1 |  x  o                   |     x                   |                         |                         |
@@ -244,23 +244,23 @@ def set_multi_step_attention_mask(attn_mask, step):
     J7 l7 | i7 F6 |  x  x  x  x  x  x  o    |                    x    |                         |                         |
     -- -- | -- F7 |                         |                         |                         |                         |
     =======================================================================================================================
-    -- -- | m0 -- |                         |                         |                         |                         |
-    -- -- | m0 -- |                         |                         |                         |                         |
-    K3 l3 | m0 F2 |  x  o  o                |     x  o                |        x                |                         |                         |
-    K4 l4 | m0 F3 |  x  x  o  o             |        x  o             |           x             |                         |
-    K5 l5 | m0 F4 |  x  x  x  o  o          |           x  o          |              x          |                         |
-    K6 l6 | m0 F5 |  x  x  x  x  o  o       |              x  o       |                 x       |                         |
-    K7 l7 | m0 F6 |  x  x  x  x  x  o  o    |                 x  o    |                    x    |                         |
-    -- -- | -- F7 |                         |                         |                         |                         |
+    -- -- | m0 M0 |                         |                         |                         |                         |
+    -- -- | m0 M0 |                         |                         |                         |                         |
+    K3 l3 | m0 M0 |  x  o  o                |     x  o                |        x                |                         |                         |
+    K4 l4 | m0 M0 |  x  x  o  o             |        x  o             |           x             |                         |
+    K5 l5 | m0 M0 |  x  x  x  o  o          |           x  o          |              x          |                         |
+    K6 l6 | m0 M0 |  x  x  x  x  o  o       |              x  o       |                 x       |                         |
+    K7 l7 | m0 M0 |  x  x  x  x  x  o  o    |                 x  o    |                    x    |                         |
+    -- -- | -- M0 |                         |                         |                         |                         |
     =======================================================================================================================
-    -- -- | m1 -- |                         |                         |                         |                         |
-    -- -- | m1 -- |                         |                         |                         |                         |
-    -- -- | m1 -- |                         |                         |                         |                         |
-    N4 l4 | m1 F3 |  x                      |     x                   |        x                |          x              |
-    N5 l5 | m1 F4 |  x  x                   |        x                |           x             |             x           |
-    N6 l6 | m1 F5 |  x  x  x                |           x             |              x          |                x        |
-    N7 l7 | m1 F6 |  x  x  x  x             |              x          |                 x       |                   x     |
-    -- -- | -- F7 |                         |                         |                         |                         |
+    -- -- | m1 M1 |                         |                         |                         |                         |
+    -- -- | m1 M1 |                         |                         |                         |                         |
+    -- -- | m1 M1 |                         |                         |                         |                         |
+    N4 l4 | m1 M1 |  x                      |     x                   |        x                |          x              |
+    N5 l5 | m1 M1 |  x  x                   |        x                |           x             |             x           |
+    N6 l6 | m1 M1 |  x  x  x                |           x             |              x          |                x        |
+    N7 l7 | m1 M1 |  x  x  x  x             |              x          |                 x       |                   x     |
+    -- -- | -- M1 |                         |                         |                         |                         |
     =======================================================================================================================
     """  # noqa: E501
     s = attn_mask.shape[-1]
@@ -782,16 +782,14 @@ class _DynamicEagleGPTModel(EagleModel):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         position_ids: torch.Tensor,
-        features: torch.Tensor | None = None,
         ttt_step: int = 0,
         parallel_draft_index: int = 0,
     ):
         """Getting EAGLE module inputs."""
-        b = hidden_states.shape[1]
-        h = hidden_states.shape[2]
-
         # [b, 1]
-        id_padding = torch.zeros((b, 1), dtype=input_ids.dtype, device=input_ids.device)
+        id_padding = torch.zeros(
+            (input_ids.shape[0], 1), dtype=input_ids.dtype, device=input_ids.device
+        )
         padded_input_ids = torch.cat((input_ids[:, 1:], id_padding), dim=-1)
 
         rotary_pos_emb = self.eagle_module.rotary_pos_emb(padded_input_ids.shape[-1])
@@ -816,34 +814,14 @@ class _DynamicEagleGPTModel(EagleModel):
             )
         )
 
-        if self.config.sequence_parallel:
-            gathered_hidden_states = gather_from_sequence_parallel_region(hidden_states)
-            gathered_features = (
-                None if features is None else gather_from_sequence_parallel_region(features)
-            )
-        else:
-            gathered_hidden_states = hidden_states
-            gathered_features = features
-
-        eagle_inputs["hidden_states"] = (
-            gathered_hidden_states
-            if ttt_step == 0
-            else torch.cat(
-                (
-                    torch.zeros(
-                        (1, b, h),
-                        dtype=hidden_states.dtype,
-                        device=hidden_states.device,
-                    ),
-                    gathered_features[:-1, :, :],  # type: ignore[index]
-                )
-            )
+        eagle_inputs["embedding"] = self.embedding(
+            input_ids=eagle_inputs["input_ids"],
+            position_ids=eagle_inputs["position_ids"],
         )
 
-        if self.config.sequence_parallel:
-            eagle_inputs["hidden_states"] = scatter_to_sequence_parallel_region(
-                eagle_inputs["hidden_states"]
-            )
+        eagle_inputs["hidden_states"] = (
+            hidden_states if parallel_draft_index == 0 else eagle_inputs["embedding"]
+        )
 
         eagle_inputs["attention_mask"] = set_multi_step_attention_mask(
             attn_mask, ttt_step + parallel_draft_index
@@ -852,11 +830,6 @@ class _DynamicEagleGPTModel(EagleModel):
         eagle_inputs["rotary_pos_emb"] = torch.cat(
             [rotary_pos_emb] * (ttt_step + parallel_draft_index + 1),
             dim=0,
-        )
-
-        eagle_inputs["embedding"] = self.embedding(
-            input_ids=eagle_inputs["input_ids"],
-            position_ids=eagle_inputs["position_ids"],
         )
 
         return eagle_inputs
@@ -1086,7 +1059,6 @@ class _DynamicEagleGPTModel(EagleModel):
                 loss = 0.0 * loss
 
         acc = []
-        eagle_hidden_states_pre_norm = None
         for ttt_step in range(ttt_steps):
             eagle_logits = []
             for i in range(self.eagle_config.parallel_draft_step):
@@ -1095,7 +1067,6 @@ class _DynamicEagleGPTModel(EagleModel):
                     hidden_states=eagle_module_input_hidden_states,
                     attention_mask=attention_mask,
                     position_ids=position_ids,
-                    features=eagle_hidden_states_pre_norm,
                     ttt_step=ttt_step,
                     parallel_draft_index=i,
                 )
@@ -1114,7 +1085,29 @@ class _DynamicEagleGPTModel(EagleModel):
 
                 eagle_logits.append(eagle_logits_)
             eagle_logits = torch.cat(eagle_logits, dim=0)
-            eagle_hidden_states_pre_norm = next_eagle_hidden_states_pre_norm
+            eagle_module_input_hidden_states = next_eagle_hidden_states_pre_norm
+            if self.config.sequence_parallel:
+                eagle_module_input_hidden_states = gather_from_sequence_parallel_region(
+                    eagle_module_input_hidden_states
+                )
+            eagle_module_input_hidden_states = torch.cat(
+                (
+                    torch.zeros(
+                        (
+                            1,
+                            eagle_module_input_hidden_states.shape[1],
+                            eagle_module_input_hidden_states.shape[2],
+                        ),
+                        dtype=eagle_module_input_hidden_states.dtype,
+                        device=eagle_module_input_hidden_states.device,
+                    ),
+                    eagle_module_input_hidden_states[:-1, :, :],
+                )
+            )
+            if self.config.sequence_parallel:
+                eagle_module_input_hidden_states = scatter_to_sequence_parallel_region(
+                    eagle_module_input_hidden_states
+                )
 
             # Discard kv cache for the last parallel_draft_step - 1 tokens
             # as the next ttt_step will only base on the first token in the
@@ -1393,12 +1386,12 @@ class _DynamicEagleGPTModel(EagleModel):
                 eagle_ids = torch.cat(
                     (eagle_ids, getattr(self, f"mask_token_{i}").view((1, 1))), dim=-1
                 )
+                # Pad dummy hidden_states for mask tokens
+                # They will be replaced by embeddings after padding
                 hidden_states = torch.cat((hidden_states, hidden_states[-1:]), dim=0)
             padded_eagle_ids, seq_len, padded_hidden_states = right_padding(
                 eagle_ids, hidden_states
             )
-            if self.config.sequence_parallel:
-                padded_hidden_states = scatter_to_sequence_parallel_region(padded_hidden_states)
             eagle_attention_mask, eagle_position_ids = get_default_attention_mask_and_position_ids(
                 padded_eagle_ids
             )
@@ -1409,6 +1402,17 @@ class _DynamicEagleGPTModel(EagleModel):
                 input_ids=padded_eagle_ids,
                 position_ids=eagle_position_ids,
             )
+            if self.config.sequence_parallel:
+                gathered_embedding = gather_from_sequence_parallel_region(eagle_inputs["embedding"])
+            if self.eagle_config.parallel_draft_step > 1:
+                # Replace dummy hidden_states with embedding for mask tokens
+                padded_hidden_states[
+                    seq_len - self.eagle_config.parallel_draft_step + 1 : seq_len
+                ] = gathered_embedding[
+                    seq_len - self.eagle_config.parallel_draft_step + 1 : seq_len
+                ]
+            if self.config.sequence_parallel:
+                padded_hidden_states = scatter_to_sequence_parallel_region(padded_hidden_states)
             eagle_inputs["hidden_states"] = padded_hidden_states
             eagle_inputs["attention_mask"] = eagle_attention_mask
 

--- a/modelopt/torch/speculative/plugins/megatron_eagle.py
+++ b/modelopt/torch/speculative/plugins/megatron_eagle.py
@@ -309,11 +309,13 @@ def set_multi_step_attention_mask(attn_mask, step):
     s = attn_mask.shape[-1]
     for iter in range(2, step + 1):
         # iter starts from 2nd step
-        zero_mask = torch.ones(attn_mask.shape[0], attn_mask.shape[1], attn_mask.shape[2], s).bool()
+        zero_mask = attn_mask.new_ones(
+            attn_mask.shape[0], attn_mask.shape[1], attn_mask.shape[2], s
+        ).bool()
         mask_0 = attn_mask.clone().detach()[:, :, -s:, :]
-        mask_0[:, :, iter - 2] = True
+        mask_0[:, :, iter - 2, :] = True
         mask_0[:, :, :, :-1] = mask_0[:, :, :, 1:]
-        mask_1 = torch.ones(attn_mask.shape[0], attn_mask.shape[1], s, s).bool()
+        mask_1 = attn_mask.new_ones(attn_mask.shape[0], attn_mask.shape[1], s, s).bool()
         for i in range(iter - 1, s - 1):
             mask_1[:, :, i, i] = False
 

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -331,7 +331,9 @@ class AcceptanceRateValidation:
 
         if ground_truth is None:
             ground_truth = self.get_ground_truth(input_ids, osl)
-        ground_truth = self.check_data_consistency_across_ranks(ground_truth)
+        ground_truth = self.check_data_consistency_across_ranks(
+            ground_truth, fail_when_mismatch=False
+        )
 
         cnt = 0
         draft_tokens = None

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -294,7 +294,9 @@ class AcceptanceRateValidation:
         """This function checks the data consistency across all ranks in the group.
 
         Use rank 0 data as the golden set to broadcast to all ranks.
-        Each rank will then compare to this data and through error if different.
+        Each rank compares its data against this golden set and either raises
+        (when fail_when_mismatch=True) or emits a warning while forcing every
+        rank to adopt rank 0's data.
         """
         if not torch.distributed.is_initialized():
             return data

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -290,7 +290,7 @@ class AcceptanceRateValidation:
 
         return input_ids
 
-    def check_data_consistency_across_ranks(self, data, group=None, fail_when_mismatch=True):
+    def check_data_consistency_across_ranks(self, data, group=None, fail_when_mismatch=False):
         """This function checks the data consistency across all ranks in the group.
 
         Use rank 0 data as the golden set to broadcast to all ranks.
@@ -331,9 +331,7 @@ class AcceptanceRateValidation:
 
         if ground_truth is None:
             ground_truth = self.get_ground_truth(input_ids, osl)
-        ground_truth = self.check_data_consistency_across_ranks(
-            ground_truth, fail_when_mismatch=False
-        )
+        ground_truth = self.check_data_consistency_across_ranks(ground_truth)
 
         cnt = 0
         draft_tokens = None
@@ -348,16 +346,12 @@ class AcceptanceRateValidation:
 
             if tree_paths:
                 input_id, draft_tokens, pred_tokens = self.model.tree_decode(input_ids, tree=tree)
-                pred_tokens = self.check_data_consistency_across_ranks(
-                    pred_tokens, fail_when_mismatch=False
-                )
+                pred_tokens = self.check_data_consistency_across_ranks(pred_tokens)
             else:
                 input_id, draft_tokens = self.model.pseudo_speculative_generate(
                     input_ids, steps=steps
                 )
-                draft_tokens = self.check_data_consistency_across_ranks(
-                    draft_tokens, fail_when_mismatch=False
-                )
+                draft_tokens = self.check_data_consistency_across_ranks(draft_tokens)
 
             input_id = self.check_data_consistency_across_ranks(input_id)
             input_ids = torch.cat((input_ids, input_id), dim=-1)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? new feature

**Overview:** 
This PR adds 2 features:
1) Integrate parallel draft with auto regression in EAGLE training and inference. Now when parallel_draft_step > 1, multiple tokens are generated in each step in training/inference. All parallel draft tokens will be used as context for the next ttt_step training.
2) Use kv cache in EAGLE training. The attention mask is no longer a seq-len**2 square mask, but a q-len*k-len rectangle mask. This reduces memory consumption and avoid redundant computation. 

## Usage
No API change.


## Testing
Offline tested with Qwen3-30B and Llama3.2-1B. Passed nmm-sandbox regression test.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inference context can be passed through speculative decoding and top-level generation flows; public entry points accept an optional inference context.
  * Multi-draft generation now supports per-draft/per-step progression with per-step KV/cache updates, cumulative loss, and per-draft accuracy tracking.

* **Refactor**
  * Replaced fixed multi-step assembly with loop-based per-step construction for inputs, attention masks, and sequence-parallel handling to simplify draft propagation.

* **Chores**
  * Cross-rank consistency checks now warn by default; strict failure is opt-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->