### PR TITLE
Fix DeepEP TMA constraint violation for MoE CUDA graph batch sizes

### DIFF
--- a/modelopt/deploy/llm/generate.py
+++ b/modelopt/deploy/llm/generate.py
@@ -126,9 +126,16 @@ class LLM(TRTLLM):
 
         cuda_graph_config = None
         if max_batch_size > 0:
+            batch_sizes = [2**i for i in range(int((max_batch_size - 1).bit_length()))] + [
+                max_batch_size
+            ]
+            if ep > 1:
+                # DeepEP low-latency dispatch requires (num_ranks * num_max_dispatch_tokens_per_rank) % 4 == 0.
+                # num_max_dispatch_tokens_per_rank equals the CUDA-graph batch size, so filter out
+                # any batch size that would violate the constraint.
+                batch_sizes = [b for b in batch_sizes if (ep * b) % 4 == 0]
             cuda_graph_config = CudaGraphConfig(
-                batch_sizes=[2**i for i in range(int((max_batch_size - 1).bit_length()))]
-                + [max_batch_size],
+                batch_sizes=batch_sizes,
                 max_batch_size=max_batch_size,
                 enable_padding=True,
             )


### PR DESCRIPTION
## Summary

- `test_ptq_mixtral` was failing on 2-GPU machines with a `RuntimeError` from DeepEP inside TRT-LLM
- Root cause: `LLM.__init__` in `generate.py` built a `CudaGraphConfig` with `batch_sizes=[1, 2]` for `max_batch_size=2`. Building the CUDA graph for batch size 1 with `ep=2` passed `num_max_dispatch_tokens_per_rank=1` to DeepEP, violating its TMA constraint: `(num_ranks * num_max_dispatch_tokens_per_rank) % 4 == 0` → `(2 * 1) % 4 = 2 ≠ 0`
- Fix: when `ep > 1`, filter `batch_sizes` to only include values satisfying the constraint. `enable_padding=True` is already set so smaller actual batches are padded up to the next valid size at runtime.

## Test plan

- [ ] Re-run 2-gpu CI: https://github.com/NVIDIA/Model-Optimizer/actions/runs/24475378208/job/71526114398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CUDA graph batch-size configuration for Mixture-of-Experts deployments to improve memory alignment and performance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->