### PR TITLE
Fix low_memory_mode meta-device crash on fused-MoE models

### DIFF
--- a/modelopt/torch/quantization/plugins/accelerate.py
+++ b/modelopt/torch/quantization/plugins/accelerate.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Quantization support for accelerate modified models."""
 
+import glob
+import os
 import warnings
 from contextlib import contextmanager
 from typing import Any
@@ -25,8 +27,11 @@ from accelerate.hooks import AlignDevicesHook, SequentialHook
 from accelerate.utils import get_max_memory, infer_auto_device_map
 from accelerate.utils.dataclasses import CustomDtype
 from accelerate.utils.offload import PrefixedDataset
+from safetensors import safe_open
 
 import modelopt.torch.quantization as mtq
+
+from .huggingface import _is_fused_experts_module
 
 __all__ = ["init_quantized_weights"]
 
@@ -102,6 +107,52 @@ def weight_access_and_writeback_context(module):
             _writeback_params_to_weights_map(mod, hook)
             if was_materialized:
                 hook.post_forward(mod, None)
+
+
+def _materialize_fused_experts_from_checkpoint(model, checkpoint):
+    """Fuse separate on-disk per-expert weights into the meta fused-MoE params.
+
+    load_checkpoint_and_dispatch matches keys verbatim and does not run transformers'
+    expert fusion, so the fused gate_up_proj/down_proj have no on-disk key and stay on
+    meta (dispatch then raises). Rebuild them from the local safetensors before dispatch.
+    Holds every routed expert in CPU RAM, so it does not stream or offload.
+    """
+    fused = [
+        (name, m)
+        for name, m in model.named_modules()
+        if _is_fused_experts_module(m) and m.gate_up_proj.device.type == "meta"
+    ]
+    if not fused:
+        return
+
+    # Map each checkpoint key to its shard (lazy header read, no tensor data).
+    key_to_file = {}
+    for shard in glob.glob(os.path.join(checkpoint, "*.safetensors")):
+        with safe_open(shard, framework="pt") as f:
+            key_to_file.update(dict.fromkeys(f.keys(), shard))
+
+    handles = {}
+
+    def _tensor(key):
+        shard = key_to_file[key]
+        if shard not in handles:
+            handles[shard] = safe_open(shard, framework="pt")
+        return handles[shard].get_tensor(key)
+
+    for name, module in fused:
+        if f"{name}.0.gate_proj.weight" not in key_to_file:
+            continue  # already fused on disk, or an unhandled layout
+        dtype = module.gate_up_proj.dtype
+        gate_up, down = [], []
+        for e in range(module.num_experts):
+            gate = _tensor(f"{name}.{e}.gate_proj.weight")
+            up = _tensor(f"{name}.{e}.up_proj.weight")
+            gate_up.append(torch.cat([gate, up], dim=0))
+            down.append(_tensor(f"{name}.{e}.down_proj.weight"))
+        module.gate_up_proj = torch.nn.Parameter(
+            torch.stack(gate_up).to(dtype), requires_grad=False
+        )
+        module.down_proj = torch.nn.Parameter(torch.stack(down).to(dtype), requires_grad=False)
 
 
 @contextmanager
@@ -224,6 +275,8 @@ def init_quantized_weights(
         mtq.quantize(model, quant_cfg)
         mtq.compress(model, config=mtq.CompressConfig(quant_gemm=quant_gemm))
         _device_map = get_model_device_map(model, gpu_mem_percentage)
+
+        _materialize_fused_experts_from_checkpoint(model, pretrained_model_name_or_path)
 
         return load_checkpoint_and_dispatch(
             model,

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -949,3 +949,70 @@ class TestNormalizeFusedExpertsQuantizerName:
             _normalize_fused_experts_quantizer_name("moe.layers.3.gate.weight")
             == "moe.layers.3.gate.weight"
         )
+
+
+# ---------------------------------------------------------------------------
+# Reproduction + fix guard for the low_memory_mode fused-MoE meta-device bug:
+# HF checkpoints store experts as separate per-expert projections that
+# load_checkpoint_and_dispatch does not fuse, leaving the 3-D fused params on meta.
+# ---------------------------------------------------------------------------
+def _write_separate_expert_checkpoint(tmp_path):
+    """Write a checkpoint with SEPARATE per-expert weights; return the fused refs."""
+    from safetensors.torch import save_file
+
+    gate_up_ref = torch.randn(NUM_EXPERTS, 2 * INTERMEDIATE_DIM, HIDDEN_DIM) * 0.02
+    down_ref = torch.randn(NUM_EXPERTS, HIDDEN_DIM, INTERMEDIATE_DIM) * 0.02
+    state_dict = {"moe.gate.weight": torch.randn(NUM_EXPERTS, HIDDEN_DIM) * 0.02}
+    for e in range(NUM_EXPERTS):
+        state_dict[f"moe.experts.{e}.gate_proj.weight"] = gate_up_ref[
+            e, :INTERMEDIATE_DIM, :
+        ].contiguous()
+        state_dict[f"moe.experts.{e}.up_proj.weight"] = gate_up_ref[
+            e, INTERMEDIATE_DIM:, :
+        ].contiguous()
+        state_dict[f"moe.experts.{e}.down_proj.weight"] = down_ref[e].contiguous()
+    save_file(state_dict, str(tmp_path / "model.safetensors"))
+    return gate_up_ref, down_ref
+
+
+class TestLowMemoryFusedExpertsLoading:
+    def test_low_memory_load_materializes_fused_experts(self, tmp_path):
+        """Raw accelerate load raises on meta (the bug); ModelOpt fuses first, so the
+        production (quantized) path loads correct fused tensors and dispatch succeeds."""
+        pytest.importorskip("accelerate")
+        from accelerate import init_empty_weights, load_checkpoint_and_dispatch
+
+        from modelopt.torch.quantization.plugins.accelerate import (
+            _materialize_fused_experts_from_checkpoint,
+        )
+
+        gate_up_ref, down_ref = _write_separate_expert_checkpoint(tmp_path)
+
+        # Reproduction: raw load leaves the fused params on meta and dispatch raises.
+        with init_empty_weights():
+            broken = _TinyMoEModel()
+        with pytest.raises((NotImplementedError, ValueError), match="meta"):
+            load_checkpoint_and_dispatch(broken, str(tmp_path), device_map={"": "cpu"})
+
+        # Fix, in production order: quantize so experts become the _QuantFusedExperts
+        # wrapper, then materialize before dispatch.
+        with init_empty_weights():
+            model = _TinyMoEModel()
+        expert_type = type(model.moe.experts)
+        if QuantModuleRegistry.get(expert_type) is not None:
+            QuantModuleRegistry.unregister(expert_type)
+        register_fused_experts_on_the_fly(model)
+        try:
+            model.moe.experts = QuantModuleRegistry.convert(model.moe.experts)
+            _materialize_fused_experts_from_checkpoint(model, str(tmp_path))
+            load_checkpoint_and_dispatch(model, str(tmp_path), device_map={"": "cpu"})
+
+            experts = model.moe.experts
+            assert torch.allclose(experts.gate_up_proj, gate_up_ref)
+            assert torch.allclose(experts.down_proj, down_ref)
+            # storage-offset expert-index recovery must survive the param swap
+            for i in range(NUM_EXPERTS):
+                assert experts._get_expert_idx_from_gate_up(experts.gate_up_proj[i]) == i
+        finally:
+            if QuantModuleRegistry.get(expert_type) is not None:
+                QuantModuleRegistry.unregister(expert_type)


### PR DESCRIPTION
In low_memory_mode, init_quantized_weights builds the model on the meta
device, quantizes and compresses it, then loads the weights with
accelerate.load_checkpoint_and_dispatch. accelerate matches checkpoint
keys verbatim and does no weight conversion.

transformers 5.0+ keeps MoE experts as fused 3-D parameters
(experts.gate_up_proj / experts.down_proj), but HF checkpoints store the
unfused per-expert gate_proj / up_proj / down_proj and let from_pretrained
fuse them at load time. Since the low-memory path bypasses from_pretrained,
that fusion never runs: the fused parameters have no matching on-disk key,
stay on the meta device, and dispatch then raises ("Cannot copy out of
meta tensor" or "... is on the meta device"). This hits GLM-5.2
(glm_moe_dsa) and any transformers-5 fused-MoE whose checkpoint stores
unfused experts.

The fix rebuilds those parameters before dispatch: for each fused-expert
module still on meta, read its per-expert weights lazily from the local
safetensors and fuse them (gate_up_proj[e] = cat([gate_proj[e],
up_proj[e]]), down_proj[e] per expert), the inverse of
moe_utils._export_fused_experts. Modules whose gate_up_proj is already on
disk are left alone and load normally.

This holds every routed expert in CPU RAM before dispatch, so it does not
lower peak host memory the way accelerate's streaming load does. For
models that do not fit in CPU RAM under low_memory_mode, the normal
from_pretrained device_map path still works (it streams and fuses
incrementally); fusing per layer into a temporary checkpoint to restore
streaming is a possible follow-up.

Tests: a CPU unit test with synthetic transformers-5 fused experts
reproduces the meta crash, then checks the fix on the real path where
experts are wrapped by _QuantFusedExperts, including that storage-offset
expert-index recovery survives rebuilding the parameter.

transformers references (pinned to v5.6.2):
- fused 3-D experts.gate_up_proj/down_proj params and the chunk(2) forward:
  https://github.com/huggingface/transformers/blob/aa935fb53dc38b56f10cc86b3a74354c2e99412f/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py#L508-L530
- the load-time fusion this path bypasses (glm_moe_dsa aliases the
  qwen2_moe WeightConverter that from_pretrained runs to merge per-expert
  gate_proj/up_proj into gate_up_proj):
  https://github.com/huggingface/transformers/blob/aa935fb53dc38b56f10cc86b3a74354c2e99412f/src/transformers/conversion_mapping.py#L235-L249

Signed-off-by: Aaron Batilo <AaronBatilo@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed loading and materialization of quantized models with fused mixture-of-experts modules from checkpoint files in memory-constrained environments

* **Tests**
  * Added regression test for low-memory checkpoint loading with fused expert modules, verifying correct parameter reconstruction and expert index recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->