### PR TITLE
Fix weight-only prequant layernorm export

### DIFF
--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -121,6 +121,11 @@ def _is_enabled_quantizer(quantizer):
     return False
 
 
+def _has_pre_quant_scale(module: nn.Module) -> bool:
+    input_quantizer = getattr(module, "input_quantizer", None)
+    return input_quantizer is not None and hasattr(input_quantizer, "_pre_quant_scale")
+
+
 def _save_component_state_dict_safetensors(
     component: nn.Module,
     component_export_dir: Path,
@@ -407,6 +412,7 @@ def _fuse_shared_input_modules(
                 and group_quant_format is not None
                 and group_quant_format != QUANTIZATION_NONE
                 and "awq" in group_quant_format
+                and all(_has_pre_quant_scale(module) for module in modules)
                 and tensor in output_to_layernorm
             ):
                 with fsdp2_aware_weight_update(model, output_to_layernorm[tensor]):

--- a/tests/unit/torch/export/test_unified_export_hf.py
+++ b/tests/unit/torch/export/test_unified_export_hf.py
@@ -18,6 +18,7 @@
 from collections import OrderedDict
 
 import torch
+from _test_utils.torch.export.utils import SmallQKVModel
 from _test_utils.torch.quantization.tied_modules import (
     make_tied_linear_pair,
     wrap_in_parent_with_tied_keys,
@@ -29,7 +30,10 @@ from modelopt.torch.export.model_utils import (
     _reorder_canonical_first,
 )
 from modelopt.torch.export.quant_utils import sync_tied_input_amax
-from modelopt.torch.export.unified_export_hf import _export_quantized_weight
+from modelopt.torch.export.unified_export_hf import (
+    _export_quantized_weight,
+    requantize_resmooth_fused_llm_layers,
+)
 
 
 def test_collect_canonical_tied_patterns_dict_style():
@@ -113,6 +117,22 @@ def test_sync_tied_input_amax_no_op_for_untied_modules():
 
     assert torch.allclose(enc_q.amax, torch.tensor(2.0))
     assert torch.allclose(dec_q.amax, torch.tensor(5.0))
+
+
+def test_requantize_resmooth_skips_layernorm_without_pre_quant_scale():
+    """INT4 blockwise weight-only export has no pre-quant scale to fold into layernorm."""
+    model = SmallQKVModel(dim=4, device="cpu", apply_embed=True)
+    mtq.quantize(model, mtq.INT4_BLOCKWISE_WEIGHT_ONLY_CFG)
+    modules = [model.q_proj, model.k_proj, model.v_proj]
+    layernorm_weight = model.input_layernorm.weight.detach().clone()
+
+    for module in modules:
+        assert not hasattr(module.input_quantizer, "_pre_quant_scale")
+
+    requantize_resmooth_fused_llm_layers(model)
+
+    assert torch.equal(model.input_layernorm.weight, layernorm_weight)
+    assert all(not getattr(module, "fused_with_prequant", False) for module in modules)
 
 
 def _calibrate_through_both_children(parent):


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes HF export for INT4 blockwise weight-only checkpoints. The export path previously used the coarse `int4_awq` format label to enter AWQ layernorm pre-quant fusion, even when the recipe had no input pre-quant scale state. The fusion gate now checks that all fused modules actually carry `_pre_quant_scale` before folding layernorm weights.

### Usage

```python
# Existing recipe path; no usage change.
python examples/llm_ptq/hf_ptq.py \
  --pyt_ckpt_path <hf-model> \
  --recipe general/ptq/int4_blockwise_weight_only \
  --export_path <output>
```

### Testing

- `/Users/weimingc/miniconda3/envs/modelopt/bin/python -m pytest tests/unit/torch/export/test_unified_export_hf.py -q`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/python -m pytest tests/unit/torch/export -q`
- Remote GPU e2e smoke: `hf_ptq.py` with `meta-llama/Llama-3.1-8B-Instruct`, `general/ptq/int4_blockwise_weight_only`, `--calib_size 64`, and `--skip_generate` completed export and artifact validation.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

The regression test covers the export preprocessing path for the weight-only recipe and verifies layernorm pre-quant fusion is skipped when `_pre_quant_scale` is absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantized model handling so layernorm fusion only happens when all relevant inputs support the needed pre-quantization scale.
  * Prevents unintended layernorm changes in INT4 weight-only models that do not include this scale, helping preserve model behavior during export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->