### PR TITLE
Fix distributed amax error handling

### DIFF
--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -1352,16 +1352,16 @@ class TensorQuantizer(nn.Module):
     def sync_amax_across_distributed_group(self, parallel_group: DistributedProcessGroup):
         """Synchronize the amax across all ranks in the given group."""
         if parallel_group.is_initialized() and getattr(self, "_amax", None) is not None:
-            try:
-                dist.all_reduce(self._amax, op=dist.ReduceOp.MAX, group=parallel_group.group)
-            except RuntimeError as e:
-                # This error happens if the distributed backend is using GPU and
-                # the tensor is not on GPU (or vice versa).
+            if (
+                self._amax.device.type == "cpu"
+                and dist.get_backend(parallel_group.group) == dist.Backend.NCCL
+            ):
                 warnings.warn(
-                    f"Failed to synchronize amax: {e}, probably because the tensor is on a device which is not"
-                    "supported by the current distributed backend. This warning can be ignored"
-                    "if happening during modelopt restore."
+                    "Failed to synchronize amax because the tensor is on CPU, but NCCL only supports CUDA "
+                    "tensors. This warning can be ignored if happening during modelopt restore."
                 )
+                return
+            dist.all_reduce(self._amax, op=dist.ReduceOp.MAX, group=parallel_group.group)
 
     @contextlib.contextmanager
     def disable_pre_quant_scale(self):

--- a/tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py
+++ b/tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py
@@ -19,6 +19,7 @@ import contextlib
 
 import pytest
 import torch
+from _test_utils.torch.distributed.utils import spawn_multiprocess_job
 from _test_utils.torch.quantization.tensor_quantizer_common import (
     BlockQuantTester,
     TensorQuantizerTester,
@@ -29,6 +30,22 @@ from modelopt.torch.quantization import tensor_quant
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
 from modelopt.torch.quantization.extensions import get_cuda_ext_mx
 from modelopt.torch.quantization.nn.modules import tensor_quantizer
+from modelopt.torch.utils.distributed import DistributedProcessGroup
+
+
+def _test_sync_cpu_amax_with_nccl(rank, size):
+    quantizer = tensor_quantizer.TensorQuantizer()
+    quantizer._amax = torch.tensor(float(rank))
+
+    with pytest.warns(UserWarning, match="tensor is on CPU, but NCCL only supports CUDA tensors"):
+        quantizer.sync_amax_across_distributed_group(DistributedProcessGroup())
+
+    assert quantizer.amax.device.type == "cpu"
+    assert quantizer.amax == rank
+
+
+def test_sync_cpu_amax_with_nccl(need_2_gpus):
+    spawn_multiprocess_job(2, _test_sync_cpu_amax_with_nccl, backend="nccl")
 
 
 class TestTensorQuantizerCuda(TensorQuantizerTester):

--- a/tests/unit/torch/quantization/test_dist.py
+++ b/tests/unit/torch/quantization/test_dist.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import Mock, patch
+
+import pytest
 import torch
 import torch.distributed as dist
 from _test_utils.torch.distributed.utils import spawn_multiprocess_job
@@ -45,3 +48,33 @@ def _test_data_parallel_helper(rank, size):
 
 def test_data_parallel(skip_on_windows):
     spawn_multiprocess_job(2, _test_data_parallel_helper, backend="gloo")
+
+
+def test_sync_amax_skips_cpu_tensor_with_nccl():
+    quantizer = TensorQuantizer()
+    quantizer._amax = torch.tensor(1.0)
+    parallel_group = Mock()
+    parallel_group.is_initialized.return_value = True
+
+    with (
+        patch.object(dist, "get_backend", return_value=dist.Backend.NCCL),
+        patch.object(dist, "all_reduce") as all_reduce,
+        pytest.warns(UserWarning, match="tensor is on CPU, but NCCL only supports CUDA tensors"),
+    ):
+        quantizer.sync_amax_across_distributed_group(parallel_group)
+
+    all_reduce.assert_not_called()
+
+
+def test_sync_amax_propagates_collective_errors():
+    quantizer = TensorQuantizer()
+    quantizer._amax = torch.tensor(1.0)
+    parallel_group = Mock()
+    parallel_group.is_initialized.return_value = True
+
+    with (
+        patch.object(dist, "get_backend", return_value=dist.Backend.GLOO),
+        patch.object(dist, "all_reduce", side_effect=RuntimeError("out of memory")),
+        pytest.raises(RuntimeError, match="out of memory"),
+    ):
+        quantizer.sync_amax_across_distributed_group(parallel_group)

--- a/tests/unit/torch/quantization/test_dist.py
+++ b/tests/unit/torch/quantization/test_dist.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock, patch
-
-import pytest
 import torch
 import torch.distributed as dist
 from _test_utils.torch.distributed.utils import spawn_multiprocess_job
@@ -48,17 +45,3 @@ def _test_data_parallel_helper(rank, size):
 
 def test_data_parallel(skip_on_windows):
     spawn_multiprocess_job(2, _test_data_parallel_helper, backend="gloo")
-
-
-def test_sync_amax_propagates_collective_errors():
-    quantizer = TensorQuantizer()
-    quantizer._amax = torch.tensor(1.0)
-    parallel_group = Mock()
-    parallel_group.is_initialized.return_value = True
-
-    with (
-        patch.object(dist, "get_backend", return_value=dist.Backend.GLOO),
-        patch.object(dist, "all_reduce", side_effect=RuntimeError("out of memory")),
-        pytest.raises(RuntimeError, match="out of memory"),
-    ):
-        quantizer.sync_amax_across_distributed_group(parallel_group)

--- a/tests/unit/torch/quantization/test_dist.py
+++ b/tests/unit/torch/quantization/test_dist.py
@@ -50,22 +50,6 @@ def test_data_parallel(skip_on_windows):
     spawn_multiprocess_job(2, _test_data_parallel_helper, backend="gloo")
 
 
-def test_sync_amax_skips_cpu_tensor_with_nccl():
-    quantizer = TensorQuantizer()
-    quantizer._amax = torch.tensor(1.0)
-    parallel_group = Mock()
-    parallel_group.is_initialized.return_value = True
-
-    with (
-        patch.object(dist, "get_backend", return_value=dist.Backend.NCCL),
-        patch.object(dist, "all_reduce") as all_reduce,
-        pytest.warns(UserWarning, match="tensor is on CPU, but NCCL only supports CUDA tensors"),
-    ):
-        quantizer.sync_amax_across_distributed_group(parallel_group)
-
-    all_reduce.assert_not_called()
-
-
 def test_sync_amax_propagates_collective_errors():
     quantizer = TensorQuantizer()
     quantizer._amax = torch.tensor(1.0)


### PR DESCRIPTION
## Description

`TensorQuantizer.sync_amax_across_distributed_group` currently catches every `RuntimeError` from `dist.all_reduce` and converts it to a warning. This can mask failures such as NCCL OOMs, allowing ranks to diverge and hang in later collectives.

This PR handles only the intended unsupported-device case before entering the collective:

- skip distributed amax synchronization when the amax tensor is on CPU and the process-group backend is NCCL
- retain the existing restore-oriented warning for that case
- let all errors from supported collectives propagate normally

## Tests

- `pytest_pwd tests/unit/torch/quantization/test_dist.py -q`
- `pre-commit run --files modelopt/torch/quantization/nn/modules/tensor_quantizer.py tests/unit/torch/quantization/test_dist.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed quantization synchronization for NCCL runs when the quantization range tensor is on CPU.
  * Added an explicit warning and an early exit to prevent unsupported all-reduce attempts.

* **Tests**
  * Added a multi-process CUDA/NCCL test covering CPU-based range tensors, verifying the warning is emitted and the value stays on CPU as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->