### PR TITLE
[Example]: Calibration-free FP8/NVFP4 PTQ for speculative-decoding drafters

### DIFF
--- a/examples/specdec_bench/run.py
+++ b/examples/specdec_bench/run.py
@@ -305,7 +305,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="EAGLE3",
-        choices=["EAGLE3", "EAGLE", "DRAFT_TARGET", "NGRAM", "MTP", "DFLASH", "NONE"],
+        choices=["EAGLE3", "EAGLE", "DRAFT_TARGET", "NGRAM", "MTP", "DFLASH", "DSPARK", "NONE"],
         help="Speculative algorithm to use",
     )
     parser.add_argument("--model_dir", type=str, required=True, help="Path to the model directory")

--- a/examples/specdec_bench/run.py
+++ b/examples/specdec_bench/run.py
@@ -188,6 +188,7 @@ def run_simple(args):
         sampling_kwargs=sampling_kwargs,
         speculative_algorithm=args.speculative_algorithm,
         draft_model_dir=args.draft_model_dir,
+        draft_quantization=args.draft_quantization,
         speculative_num_steps=args.draft_length,
         speculative_num_draft_tokens=args.block_size,
         tensor_parallel_size=args.tp_size,
@@ -315,6 +316,14 @@ if __name__ == "__main__":
         required=False,
         default=None,
         help="Path to the draft model directory",
+    )
+    parser.add_argument(
+        "--draft_quantization",
+        type=str,
+        required=False,
+        default=None,
+        help="Quantization method of the draft checkpoint (e.g. modelopt, modelopt_fp4). "
+        "Read from the draft's config.json when omitted; set it only to override.",
     )
     parser.add_argument(
         "--runtime_params",

--- a/examples/specdec_bench/run.py
+++ b/examples/specdec_bench/run.py
@@ -306,7 +306,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="EAGLE3",
-        choices=["EAGLE3", "EAGLE", "DRAFT_TARGET", "NGRAM", "MTP", "DFLASH", "NONE"],
+        choices=["EAGLE3", "EAGLE", "DRAFT_TARGET", "NGRAM", "MTP", "DFLASH", "DSPARK", "NONE"],
         help="Speculative algorithm to use",
     )
     parser.add_argument("--model_dir", type=str, required=True, help="Path to the model directory")

--- a/examples/specdec_bench/specdec_bench/models/auto_deploy.py
+++ b/examples/specdec_bench/specdec_bench/models/auto_deploy.py
@@ -93,6 +93,8 @@ def create_auto_deploy_model(model_path: str, max_concurrent_requests: int, kwar
         )
     elif speculative_algorithm == "NONE":
         specdec = None
+    elif speculative_algorithm == "DSPARK":
+        raise NotImplementedError("DSPARK is only supported by --engine VLLM.")
 
     max_num_tokens = kwargs.get("max_num_tokens", 8192)
 

--- a/examples/specdec_bench/specdec_bench/models/sglang.py
+++ b/examples/specdec_bench/specdec_bench/models/sglang.py
@@ -49,6 +49,8 @@ class SGLANGModel(Model):
             speculative_algorithm = "LOOKAHEAD"
         elif speculative_algorithm == "NONE":
             speculative_algorithm = None
+        elif speculative_algorithm == "DSPARK":
+            raise NotImplementedError("DSPARK is only supported by --engine VLLM.")
 
         engine_kwargs = {
             "model_path": model_dir,

--- a/examples/specdec_bench/specdec_bench/models/trtllm_torch_api.py
+++ b/examples/specdec_bench/specdec_bench/models/trtllm_torch_api.py
@@ -125,6 +125,8 @@ def create_executor(model_path: str, max_concurrent_requests, kwargs):
         )
     elif kwargs.get("speculative_algorithm", None) == "NONE":
         specdec = None
+    elif kwargs.get("speculative_algorithm", None) == "DSPARK":
+        raise NotImplementedError("DSPARK is only supported by --engine VLLM.")
     else:
         specdec = None
 

--- a/examples/specdec_bench/specdec_bench/models/vllm.py
+++ b/examples/specdec_bench/specdec_bench/models/vllm.py
@@ -28,6 +28,16 @@ except ImportError:
     vllm = None
 
 
+# Forwarded from ``--runtime_params`` ``engine_args.<key>``; extend as needed.
+PASSTHROUGH_ENGINE_ARGS = (
+    "mamba_backend",
+    "mamba_ssm_cache_dtype",
+    "mamba_cache_mode",
+    "mamba_cache_philox_rounds",
+    "enable_mamba_cache_stochastic_rounding",
+)
+
+
 class VLLMModel(Model):
     # Cross-engine ``--max_seq_len`` (run.py) lands in kwargs under the
     # vLLM-native name ``max_model_len`` (see run.py's ``_MAX_SEQ_LEN_KEY``)
@@ -114,6 +124,13 @@ class VLLMModel(Model):
                 "model": kwargs.get("draft_model_dir"),
                 "num_speculative_tokens": kwargs.get("speculative_num_draft_tokens", 8),
             }
+        elif kwargs.get("speculative_algorithm") == "DSPARK":
+            specdec = {
+                "method": "dspark",
+                "model": kwargs.get("draft_model_dir"),
+                "num_speculative_tokens": kwargs.get("speculative_num_draft_tokens", 7),
+                "draft_sample_method": kwargs.get("draft_sample_method", "greedy"),
+            }
         elif kwargs.get("speculative_algorithm") == "NONE":
             specdec = None
 
@@ -133,8 +150,9 @@ class VLLMModel(Model):
             max_num_seqs=max_concurrent_requests * num_speculative_tokens,
             skip_tokenizer_init=False,
             async_scheduling=kwargs.get("async_scheduling", True),
-            enforce_eager=False,
+            enforce_eager=kwargs.get("enforce_eager", False),
             max_model_len=kwargs.get("max_model_len"),
+            **{key: kwargs[key] for key in PASSTHROUGH_ENGINE_ARGS if kwargs.get(key) is not None},
         )
         self.engine_args = engine_args
         self.model = AsyncLLM.from_engine_args(engine_args)

--- a/examples/specdec_bench/specdec_bench/models/vllm.py
+++ b/examples/specdec_bench/specdec_bench/models/vllm.py
@@ -119,12 +119,9 @@ class VLLMModel(Model):
         elif kwargs.get("speculative_algorithm") == "NONE":
             specdec = None
 
-        # A quantized draft checkpoint has to declare its own quantization. vLLM otherwise
-        # copies the target's onto the draft (config/speculative.py, "Align the
-        # quantization of draft model"), so a quantized drafter under a bf16 target is
-        # built as if it were bf16 and dies loading the packed weights. The drafter's
-        # config.json already records the format, so read it back rather than making the
-        # caller repeat it; --draft_quantization overrides.
+        # vLLM copies the target's quantization onto the draft, so a quantized drafter under
+        # a bf16 target is built as bf16 and dies loading the packed weights. Read the format
+        # from the drafter's own config.json; --draft_quantization overrides.
         if specdec is not None and specdec.get("model"):
             draft_quantization = kwargs.get("draft_quantization")
             if draft_quantization is None:

--- a/examples/specdec_bench/specdec_bench/models/vllm.py
+++ b/examples/specdec_bench/specdec_bench/models/vllm.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import asyncio
+import json
+import os
 import time
 
 from .base import Model
@@ -116,6 +118,24 @@ class VLLMModel(Model):
             }
         elif kwargs.get("speculative_algorithm") == "NONE":
             specdec = None
+
+        # A quantized draft checkpoint has to declare its own quantization. vLLM otherwise
+        # copies the target's onto the draft (config/speculative.py, "Align the
+        # quantization of draft model"), so a quantized drafter under a bf16 target is
+        # built as if it were bf16 and dies loading the packed weights. The drafter's
+        # config.json already records the format, so read it back rather than making the
+        # caller repeat it; --draft_quantization overrides.
+        if specdec is not None and specdec.get("model"):
+            draft_quantization = kwargs.get("draft_quantization")
+            if draft_quantization is None:
+                draft_config = os.path.join(specdec["model"], "config.json")
+                if os.path.isfile(draft_config):
+                    with open(draft_config) as f:
+                        quant_config = json.load(f).get("quantization_config") or {}
+                    draft_quantization = quant_config.get("quant_method")
+            if draft_quantization:
+                specdec["quantization"] = draft_quantization
+                print(f"Draft model quantization: {draft_quantization}")
 
         if specdec is None:
             num_speculative_tokens = 1

--- a/examples/specdec_bench/specdec_bench/models/vllm.py
+++ b/examples/specdec_bench/specdec_bench/models/vllm.py
@@ -171,6 +171,23 @@ class VLLMModel(Model):
             async_scheduling=kwargs.get("async_scheduling", True),
             enforce_eager=enforce_eager,
             max_model_len=kwargs.get("max_model_len"),
+            # Engine knobs a model card may pin, passed through from
+            # --runtime_params engine_args.<key>. Only keys the caller actually set are
+            # forwarded, so vLLM keeps its own defaults otherwise. Hybrid Mamba models
+            # need these: on Nemotron-3.5-Lightning the SSM-cache settings decide whether
+            # the first draft token is accepted, and leaving them at vLLM's defaults costs
+            # ~65% of acceptance length while every later position looks normal.
+            **{
+                key: kwargs[key]
+                for key in (
+                    "mamba_backend",
+                    "mamba_ssm_cache_dtype",
+                    "mamba_cache_mode",
+                    "mamba_cache_philox_rounds",
+                    "enable_mamba_cache_stochastic_rounding",
+                )
+                if kwargs.get(key) is not None
+            },
         )
         self.engine_args = engine_args
         self.model = AsyncLLM.from_engine_args(engine_args)

--- a/examples/specdec_bench/specdec_bench/models/vllm.py
+++ b/examples/specdec_bench/specdec_bench/models/vllm.py
@@ -116,6 +116,17 @@ class VLLMModel(Model):
                 "model": kwargs.get("draft_model_dir"),
                 "num_speculative_tokens": kwargs.get("speculative_num_draft_tokens", 8),
             }
+        elif kwargs.get("speculative_algorithm") == "DSPARK":
+            # Match draft sampling to the target's verify mode: a greedy target with a
+            # probabilistic draft (or the reverse) crushes acceptance at temp > 0.
+            temperature = sampling_kwargs.get("temperature", 1.0)
+            specdec = {
+                "method": "dspark",
+                "model": kwargs.get("draft_model_dir"),
+                "num_speculative_tokens": kwargs.get("speculative_num_draft_tokens", 7),
+                "draft_sample_method": kwargs.get("dspark_draft_sample_method")
+                or ("greedy" if temperature == 0 else "probabilistic"),
+            }
         elif kwargs.get("speculative_algorithm") == "NONE":
             specdec = None
 
@@ -139,6 +150,14 @@ class VLLMModel(Model):
         else:
             num_speculative_tokens = specdec.get("num_speculative_tokens", 3)
 
+        # DSpark's block-parallel draft can outgrow the pre-allocated workspace during
+        # CUDA-graph capture; acceptance length is unaffected by graph capture, so skip it.
+        # SPECDEC_ENFORCE_EAGER=1 forces the same for other algorithms.
+        enforce_eager = (
+            kwargs.get("speculative_algorithm") == "DSPARK"
+            or os.environ.get("SPECDEC_ENFORCE_EAGER") == "1"
+        )
+
         engine_args = AsyncEngineArgs(
             model=model_dir,
             tokenizer=kwargs.get("tokenizer_path"),
@@ -150,7 +169,7 @@ class VLLMModel(Model):
             max_num_seqs=max_concurrent_requests * num_speculative_tokens,
             skip_tokenizer_init=False,
             async_scheduling=kwargs.get("async_scheduling", True),
-            enforce_eager=False,
+            enforce_eager=enforce_eager,
             max_model_len=kwargs.get("max_model_len"),
         )
         self.engine_args = engine_args

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calibration-free PTQ for a speculative-decoding drafter.
+
+Every scale is derived from the weights, so this needs no dataset and no forward pass, and
+never imports the drafter's modeling code: each 2-D weight is wrapped in a throwaway
+``nn.Linear`` under its checkpoint name, and ModelOpt's usual ``quantizer_name`` patterns
+select over those names. Works for any drafter layout (DSpark / DFlash / EAGLE3 / Medusa),
+including exported ones that ship no importable model class.
+
+``fp8`` and ``nvfp4`` need a static activation amax, normally measured on calibration data;
+a fixed ``input_scale`` of 1.0 is applied instead. Acceptance length is governed by
+clipping rather than resolution, and AL sits on a flat plateau from input_scale ~0.3 to 4.0
+(Qwen3-8B + DSpark, MT-Bench: +0.1% for FP8, -3.9% for NVFP4), so the scale only has to be
+big enough. AWQ is not offered: ``awq_lite`` silently degrades to RTN without a
+``forward_loop``.
+
+Example:
+    python quantize_drafter.py \
+        --drafter_path nvidia/MiniMax-M3-DSpark \
+        --qformat fp8 \
+        --export_path ./MiniMax-M3-DSpark-FP8
+"""
+
+import argparse
+import copy
+import json
+import shutil
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from safetensors.torch import load_file, save_file
+
+import modelopt.torch.quantization as mtq
+from modelopt.recipe.presets import QUANT_CFG_CHOICES
+from modelopt.torch.export.quant_utils import (
+    get_activation_scaling_factor,
+    get_quant_config,
+    get_quantization_format,
+    get_weight_block_size,
+    get_weight_scaling_factor,
+    get_weight_scaling_factor_2,
+    to_quantized_weight,
+)
+from modelopt.torch.quantization.config import need_calibration
+from modelopt.torch.quantization.utils import is_quantized_linear
+
+# INT8/INT4 are absent on purpose: they quantize cleanly but vLLM's ModelOpt backend
+# cannot serve them.
+SUPPORTED_QFORMATS = [
+    "w4a16_nvfp4",
+    "nvfp4",
+    "fp8",
+    "fp8_pc_pt",
+]
+
+# All 2-D, so the flat view treats them as GEMMs, but none is one: markov_w1/embed_tokens
+# are embeddings (ModelOpt's presets skip these via `parent_class`, which the flat view
+# cannot see), and confidence_head has a single output whose per-channel scale is 0-dim.
+# All tiny. `fc` is left to the presets; `lm_head` is excluded by the preset itself.
+DEFAULT_EXCLUDE = ["*markov_head*", "*confidence_head*", "*embed_tokens*"]
+
+# Sidecars carried over to the export, and -- with the weights and config.json -- the only
+# files fetched when --drafter_path is a repo id rather than a local directory.
+SIDECAR_FILES = ("tokenizer.json", "tokenizer_config.json", "generation_config.json")
+
+# The amax that yields input_scale 1.0 for FP8. NVFP4 divides by 6*448, so the same amax
+# records as 0.1667 there; both mean the same activation range.
+FP8_E4M3_MAX = 448.0
+STATIC_ACT_AMAX = FP8_E4M3_MAX
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--drafter_path", required=True, help="HF repo id or local dir of the drafter checkpoint."
+    )
+    parser.add_argument("--export_path", required=True, help="Output directory.")
+    parser.add_argument(
+        "--qformat",
+        default="w4a16_nvfp4",
+        choices=SUPPORTED_QFORMATS,
+        help="Quantization format. All are calibration-free; fp8 and nvfp4 additionally "
+        "quantize activations, using a fixed input_scale of 1.0.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=["bfloat16", "float16", "float32"],
+        help="Compute dtype the weights are cast to before quantizing.",
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="*",
+        default=[],
+        metavar="PATTERN",
+        help="Extra fnmatch patterns to leave unquantized, in `quantizer_name` form. "
+        f"Appended to the defaults ({' '.join(DEFAULT_EXCLUDE)}), which always apply.",
+    )
+    parser.add_argument(
+        "--quantize_lm_head",
+        action="store_true",
+        help="Also quantize lm_head -- the largest drafter tensor, but it feeds the "
+        "acceptance test directly, so measure AL first.",
+    )
+    return parser.parse_args()
+
+
+def auto_map_modules(config: dict, source_dir: Path) -> set[Path]:
+    """Module files an ``auto_map`` points at, relative to ``source_dir``.
+
+    Values are either ``"modeling_x.XModel"`` or, for tokenizers, a list whose entries may
+    be null (``[null, "tokenization_x.XTokenizerFast"]``); a ``repo--`` prefix points at
+    another repository and is not a local file. A value may also carry a package path
+    (``"pkg/modeling_x.XModel"``), which is preserved so the exported reference resolves.
+
+    The config is untrusted -- it may come straight off the Hub -- so references that
+    escape ``source_dir`` are dropped rather than followed.
+    """
+    modules = set()
+    for value in (config.get("auto_map") or {}).values():
+        for ref in value if isinstance(value, list) else [value]:
+            if not isinstance(ref, str) or "." not in ref:
+                continue
+            relative = Path(ref.split("--")[-1].rsplit(".", 1)[0] + ".py")
+            candidate = (source_dir / relative).resolve()
+            if relative.is_absolute() or not candidate.is_relative_to(source_dir.resolve()):
+                print(f"Skipping auto_map entry outside the checkpoint: {ref}")
+                continue
+            modules.add(relative)
+    return modules
+
+
+def load_drafter(drafter_path: str) -> tuple[Path, dict[str, torch.Tensor]]:
+    """Resolve a local dir or HF repo id to (dir, state_dict)."""
+    local_dir = Path(drafter_path)
+    if not local_dir.is_dir():
+        from huggingface_hub import snapshot_download
+
+        # A drafter that ships custom modeling code references it from auto_map, and the
+        # export carries that config verbatim -- so those .py files have to be fetched too
+        # or the exported references dangle.
+        local_dir = Path(
+            snapshot_download(
+                drafter_path,
+                allow_patterns=["*.safetensors", "config.json", "*.py", *SIDECAR_FILES],
+            )
+        )
+
+    shards = sorted(local_dir.glob("*.safetensors"))
+    assert shards, f"No .safetensors found under {local_dir}"
+    state_dict: dict[str, torch.Tensor] = {}
+    for shard in shards:
+        state_dict.update(load_file(shard))
+    return local_dir, state_dict
+
+
+def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -> nn.Module:
+    """Expose every 2-D weight as an nn.Linear whose module name is its checkpoint key.
+
+    Nested ModuleDicts so ``named_modules()`` reproduces the dotted checkpoint keys, which
+    is what ``quantizer_name`` patterns match against.
+    """
+    root = nn.ModuleDict()
+    for key, weight in state_dict.items():
+        if weight.dim() != 2 or not key.endswith(".weight"):
+            continue
+        *parents, leaf = key[: -len(".weight")].split(".")
+        node = root
+        for part in parents:
+            if part not in node:
+                node[part] = nn.ModuleDict()
+            node = node[part]
+        out_features, in_features = weight.shape
+        # On meta, so nn.Linear skips allocating and randomly initializing a weight that
+        # the next line replaces anyway.
+        with torch.device("meta"):
+            linear = nn.Linear(in_features, out_features, bias=False, dtype=dtype)
+        linear.weight = nn.Parameter(weight.to(dtype), requires_grad=False)
+        node[leaf] = linear
+    return root
+
+
+def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -> int:
+    """Give every static ``input_quantizer`` the same fixed amax. Returns how many were set.
+
+    Skips dynamic quantizers and any that already have an amax, so it composes as a
+    fallback rather than an overwrite.
+    """
+    count = 0
+    for _, module in root.named_modules():
+        if not is_quantized_linear(module):
+            continue
+        input_quantizer = getattr(module, "input_quantizer", None)
+        if input_quantizer is None or not input_quantizer.is_enabled:
+            continue
+        if getattr(input_quantizer, "_dynamic", False):
+            continue
+        if getattr(input_quantizer, "amax", None) is not None:
+            continue
+        # Keep amax in fp32, as ModelOpt does everywhere else -- casting to the weight
+        # dtype would round a measured amax through bf16's 8-bit mantissa.
+        input_quantizer.amax = torch.tensor(amax, dtype=torch.float32)
+        count += 1
+    return count
+
+
+def resolve_activation_scales(root: nn.Module, quant_cfg: dict) -> None:
+    """Establish activation scales for a format that quantizes activations statically.
+
+    The single place deciding where a static amax comes from: real calibration would call
+    ``mtq.calibrate`` here, ahead of the fixed fallback.
+    """
+    if not need_calibration(quant_cfg):
+        return
+    n = set_static_activation_amax(root)
+    print(f"Set {n} static activation amax values (fixed, input_scale 1.0) -- not calibrated.")
+
+
+def build_quant_cfg(qformat: str, exclude: list[str], quantize_lm_head: bool) -> dict:
+    """Take the shipped preset and layer the drafter-specific exclusions on top."""
+    quant_cfg = copy.deepcopy(QUANT_CFG_CHOICES[qformat])
+    if quantize_lm_head:
+        # The preset disables *all* of lm_head's quantizers. Re-enabling only the weight
+        # one would leave a W+A format exporting lm_head with no input_scale while the
+        # config still advertises it as fully quantized, which a runtime fails to load.
+        for quantizer in ("weight_quantizer", "input_quantizer"):
+            quant_cfg["quant_cfg"].append(
+                {"quantizer_name": f"*lm_head*{quantizer}", "enable": True}
+            )
+    for pattern in DEFAULT_EXCLUDE + exclude:
+        quant_cfg["quant_cfg"].append({"quantizer_name": pattern, "enable": False})
+    return quant_cfg
+
+
+def export_quantized_state_dict(
+    root: nn.Module, state_dict: dict[str, torch.Tensor], dtype: torch.dtype
+) -> dict[str, torch.Tensor]:
+    """Pack each quantized weight and emit it alongside its scales.
+
+    Unified-HF naming (``w.weight_scale`` etc). Untouched tensors carry through in ``dtype``.
+    """
+    export_sd = {k: v.to(dtype) for k, v in state_dict.items()}
+    for name, module in root.named_modules():
+        if not is_quantized_linear(module) or not module.weight_quantizer.is_enabled:
+            continue
+        quantization = get_quantization_format(module)
+        assert quantization is not None, f"{name}: enabled quantizer resolved to no format"
+        weight_scale = get_weight_scaling_factor(module)
+        weight_scale_2 = get_weight_scaling_factor_2(module)
+        # The packing helpers index the scale as ``scale[:, None]``, which a 0-dim scale
+        # cannot satisfy. One row of weights, so leave it in ``dtype``.
+        if weight_scale is not None and weight_scale.dim() == 0 and module.weight.shape[0] == 1:
+            print(f"Skipping {name}: single-output projection, per-channel scale is scalar")
+            continue
+        export_sd[f"{name}.weight"] = to_quantized_weight(
+            module.weight,
+            weight_scale,
+            quantization,
+            weight_scale_2,
+            get_weight_block_size(module),
+        )
+        export_sd[f"{name}.weight_scale"] = weight_scale
+        if weight_scale_2 is not None:
+            export_sd[f"{name}.weight_scale_2"] = weight_scale_2
+        # Without this the runtime has no activation scale and the format silently degrades.
+        activation_scale = get_activation_scaling_factor(module)
+        if activation_scale is not None:
+            export_sd[f"{name}.input_scale"] = activation_scale
+    return export_sd
+
+
+def main():
+    args = parse_args()
+    dtype = getattr(torch, args.dtype)
+
+    source_dir, state_dict = load_drafter(args.drafter_path)
+    root = build_linear_view(state_dict, dtype)
+
+    quant_cfg = build_quant_cfg(args.qformat, args.exclude, args.quantize_lm_head)
+
+    mtq.quantize(root, quant_cfg)  # no forward_loop: scales come from the weights
+    resolve_activation_scales(root, quant_cfg)
+
+    mtq.print_quant_summary(root)
+
+    export_sd = export_quantized_state_dict(root, state_dict, dtype)
+
+    export_dir = Path(args.export_path)
+    export_dir.mkdir(parents=True, exist_ok=True)
+    save_file(export_sd, export_dir / "model.safetensors", metadata={"format": "pt"})
+
+    config = json.loads((source_dir / "config.json").read_text())
+    hf_quant_config = get_quant_config(root)
+    # ``get_quant_config`` only knows the linear view, so tensors it never saw (norms, 1-D
+    # weights) are missing and a loader walking the checkpoint expects a scale for them.
+    quantized = {
+        name
+        for name, module in root.named_modules()
+        if is_quantized_linear(module)
+        and f"{name}.weight" in export_sd
+        and f"{name}.weight_scale" in export_sd
+    }
+    unquantized = sorted(
+        key[: -len(".weight")]
+        for key in state_dict
+        if key.endswith(".weight") and key[: -len(".weight")] not in quantized
+    )
+    exclude_modules = hf_quant_config["quantization"].get("exclude_modules", [])
+    for name in unquantized:
+        if name not in exclude_modules:
+            exclude_modules.append(name)
+        # Runtimes match against their own module prefix, which is nested relative to the
+        # checkpoint key (vLLM builds the draft's ``fc`` at ``model.fc``).
+        wildcard = f"*{name}"
+        if wildcard not in exclude_modules:
+            exclude_modules.append(wildcard)
+    # Runtimes fuse sibling projections into one layer whose name is in no checkpoint key,
+    # so excluding only the parts would leave the fused layer quantized.
+    for fused, parts in (
+        ("qkv_proj", ("q_proj", "k_proj", "v_proj")),
+        ("gate_up_proj", ("gate_proj", "up_proj")),
+    ):
+        if all(any(p in name for name in exclude_modules) for p in parts):
+            alias = f"*{fused}"
+            if alias not in exclude_modules:
+                exclude_modules.append(alias)
+    hf_quant_config["quantization"]["exclude_modules"] = exclude_modules
+    config["quantization_config"] = dict(hf_quant_config["quantization"])
+    # ModelOpt names the format ``quant_algo``; vLLM reads ``quant_method`` and treats its
+    # absence as unquantized, splitting NVFP4 off into its own backend. Emit both.
+    quant_algo = str(hf_quant_config["quantization"].get("quant_algo") or "")
+    config["quantization_config"].setdefault(
+        "quant_method", "modelopt_fp4" if "NVFP4" in quant_algo.upper() else "modelopt"
+    )
+    # Same list, second key: the flat ``quantization_config`` in config.json is read for
+    # ``ignore``, not ``exclude_modules``.
+    config["quantization_config"]["ignore"] = list(exclude_modules)
+    config["torch_dtype"] = args.dtype
+    (export_dir / "config.json").write_text(json.dumps(config, indent=2))
+    (export_dir / "hf_quant_config.json").write_text(json.dumps(hf_quant_config, indent=2))
+
+    for extra in SIDECAR_FILES:
+        if (source_dir / extra).is_file():
+            shutil.copy2(source_dir / extra, export_dir / extra)
+
+    # A drafter that ships custom modeling code points at it from auto_map; the export
+    # carries that config verbatim, so the .py files have to come along or the reference
+    # dangles. (The DFlash/DSpark exports have no auto_map -- this is for the ones that do.)
+    for relative in auto_map_modules(config, source_dir):
+        source_py = source_dir / relative
+        if source_py.is_file():
+            target = export_dir / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_py, target)
+
+    before = sum(v.numel() * v.element_size() for v in state_dict.values())
+    after = sum(v.numel() * v.element_size() for v in export_sd.values())
+    print(f"\n{args.qformat}: {before / 2**30:.2f} GiB -> {after / 2**30:.2f} GiB")
+    print(f"Exported to {export_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -15,29 +15,18 @@
 
 """Calibration-free PTQ for a speculative-decoding drafter.
 
-Every scale is derived from the weights, so this needs no dataset and no forward pass --
-only the drafter's safetensors file. That also means the drafter's modeling code is never
-imported: each 2-D weight is wrapped in a throwaway ``nn.Linear`` under its checkpoint
-name, and ModelOpt's usual ``quantizer_name`` patterns select over those names. Works for
-any drafter layout (DSpark / DFlash / EAGLE3 / Medusa).
+Every scale is derived from the weights, so this needs no dataset and no forward pass, and
+never imports the drafter's modeling code: each 2-D weight is wrapped in a throwaway
+``nn.Linear`` under its checkpoint name, and ModelOpt's usual ``quantizer_name`` patterns
+select over those names. Works for any drafter layout (DSpark / DFlash / EAGLE3 / Medusa),
+including exported ones that ship no importable model class.
 
-Avoiding the modeling code is what makes this work for DFlash-family drafters at all: an
-exported drafter declares ``architectures: ["DFlashDraftModel"]`` but ships no importable
-class, so ``AutoModelForCausalLM`` silently loads it as a plain Qwen3 and drops the draft
-tensors, and the real draft ``forward`` takes hidden states rather than ``input_ids``, so
-the stock ``hf_ptq.py`` calibration loop cannot drive it either.
-
-``fp8`` and ``nvfp4`` quantize activations against a static amax that is normally measured
-on calibration data; a fixed ``input_scale`` of 1.0 is applied instead. That holds up
-because acceptance length is governed by clipping rather than resolution: on Qwen3-8B +
-a DSpark drafter (MT-Bench), AL falls off a cliff below input_scale ~0.03 but sits on a
-flat plateau from ~0.3 to 4.0 with no drop-off at the top, so the scale only has to be big
-enough. 1.0 is the middle of that plateau, and measures +0.1% AL for FP8 and -3.9% for
-NVFP4 (that gap is the 4-bit resolution cost; no scale recovers it). Deriving the amax
-from the weights instead clips badly and measures -31% to -46%.
-
-AWQ formats are deliberately not offered: ``awq_lite`` silently degrades to plain RTN when
-no ``forward_loop`` is supplied.
+``fp8`` and ``nvfp4`` need a static activation amax, normally measured on calibration data;
+a fixed ``input_scale`` of 1.0 is applied instead. Acceptance length is governed by
+clipping rather than resolution, and AL sits on a flat plateau from input_scale ~0.3 to 4.0
+(Qwen3-8B + DSpark, MT-Bench: +0.1% for FP8, -3.9% for NVFP4), so the scale only has to be
+big enough. AWQ is not offered: ``awq_lite`` silently degrades to RTN without a
+``forward_loop``.
 
 Example:
     python quantize_drafter.py \
@@ -70,9 +59,8 @@ from modelopt.torch.export.quant_utils import (
 from modelopt.torch.quantization.config import need_calibration
 from modelopt.torch.quantization.utils import is_quantized_linear
 
-# INT8/INT4 weight-only formats are deliberately absent: vLLM's ModelOpt backend accepts
-# only FP8, FP8_PER_CHANNEL_PER_TOKEN, FP8_PB_WO, NVFP4, W4A16_NVFP4, MXFP8 and
-# MIXED_PRECISION, so an INT checkpoint quantizes cleanly but cannot be served.
+# INT8/INT4 are absent on purpose: they quantize cleanly but vLLM's ModelOpt backend
+# cannot serve them.
 SUPPORTED_QFORMATS = [
     "w4a16_nvfp4",
     "nvfp4",
@@ -81,19 +69,14 @@ SUPPORTED_QFORMATS = [
     "fp8_pb_wo",
 ]
 
-# These are 2-D, so the flat-linear view treats them as GEMMs, but none of them is one:
-# markov_w1 and embed_tokens are embeddings (row lookups), which ModelOpt's presets
-# normally skip via `parent_class: nn.Embedding` -- a class the flat view cannot see, so
-# the exclusion is restated by name. Quantizing embed_tokens also breaks deployment, since
-# a drafter inherits it from the target (vLLM: KeyError: 'embed_tokens.weight_scale').
-# confidence_head projects to a single output, whose per-channel scale collapses to a
-# 0-dim tensor. All are tiny; nothing is lost by leaving them alone.
-# Not excluded: `fc` (the presets decide; use --exclude '*fc*' to compare) and `lm_head`
-# (the preset already excludes it -- see --quantize_lm_head).
+# All 2-D, so the flat view treats them as GEMMs, but none is one: markov_w1/embed_tokens
+# are embeddings (ModelOpt's presets skip these via `parent_class`, which the flat view
+# cannot see), and confidence_head has a single output whose per-channel scale is 0-dim.
+# All tiny. `fc` is left to the presets; `lm_head` is excluded by the preset itself.
 DEFAULT_EXCLUDE = ["*markov_head*", "*confidence_head*", "*embed_tokens*"]
 
-# The amax that yields input_scale 1.0 for FP8. NVFP4 divides by 6*448 instead, so the same
-# amax records as input_scale 0.1667 there; both mean the same activation range.
+# The amax that yields input_scale 1.0 for FP8. NVFP4 divides by 6*448, so the same amax
+# records as 0.1667 there; both mean the same activation range.
 FP8_E4M3_MAX = 448.0
 STATIC_ACT_AMAX = FP8_E4M3_MAX
 
@@ -108,10 +91,8 @@ def parse_args():
         "--qformat",
         default="w4a16_nvfp4",
         choices=SUPPORTED_QFORMATS,
-        help="Quantization format. All are calibration-free: weight-only and "
-        "dynamic-activation formats derive every scale from the weights or per token at "
-        "runtime, and the static-activation formats (fp8, nvfp4) use a fixed input_scale "
-        "of 1.0.",
+        help="Quantization format. All are calibration-free; fp8 and nvfp4 additionally "
+        "quantize activations, using a fixed input_scale of 1.0.",
     )
     parser.add_argument(
         "--dtype",
@@ -130,8 +111,8 @@ def parse_args():
     parser.add_argument(
         "--quantize_lm_head",
         action="store_true",
-        help="Also quantize lm_head. It is the single largest drafter tensor, but it feeds "
-        "the acceptance test directly -- measure AL before shipping this.",
+        help="Also quantize lm_head -- the largest drafter tensor, but it feeds the "
+        "acceptance test directly, so measure AL first.",
     )
     return parser.parse_args()
 
@@ -155,9 +136,8 @@ def load_drafter(drafter_path: str) -> tuple[Path, dict[str, torch.Tensor]]:
 def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -> nn.Module:
     """Expose every 2-D weight as an nn.Linear whose module name is its checkpoint key.
 
-    Nested ModuleDicts are used so that ``named_modules()`` reproduces the dotted keys
-    (``layers.0.self_attn.q_proj``), which is what the preset's ``quantizer_name``
-    patterns match against.
+    Nested ModuleDicts so ``named_modules()`` reproduces the dotted checkpoint keys, which
+    is what ``quantizer_name`` patterns match against.
     """
     root = nn.ModuleDict()
     for key, weight in state_dict.items():
@@ -179,8 +159,8 @@ def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -
 def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -> int:
     """Give every static ``input_quantizer`` the same fixed amax. Returns how many were set.
 
-    Skips quantizers that are dynamic (scale computed per token at runtime) or that already
-    have an amax, so this composes as a fallback rather than an overwrite.
+    Skips dynamic quantizers and any that already have an amax, so it composes as a
+    fallback rather than an overwrite.
     """
     count = 0
     for _, module in root.named_modules():
@@ -189,7 +169,6 @@ def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -
         input_quantizer = getattr(module, "input_quantizer", None)
         if input_quantizer is None or not input_quantizer.is_enabled:
             continue
-        # A dynamic quantizer derives its scale at runtime; leave it untouched.
         if getattr(input_quantizer, "_dynamic", False):
             continue
         if getattr(input_quantizer, "amax", None) is not None:
@@ -202,12 +181,8 @@ def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -
 def resolve_activation_scales(root: nn.Module, quant_cfg: dict) -> None:
     """Establish activation scales for a format that quantizes activations statically.
 
-    The single place deciding where a static amax comes from. Real calibration would slot
-    in here ahead of the fixed fallback, leaving the CLI and call site unchanged::
-
-        if calib_forward_loop is not None:
-            mtq.calibrate(root, quant_cfg["algorithm"], forward_loop=calib_forward_loop)
-        set_static_activation_amax(root)  # fills in what calibration did not reach
+    The single place deciding where a static amax comes from: real calibration would call
+    ``mtq.calibrate`` here, ahead of the fixed fallback.
     """
     if not need_calibration(quant_cfg):
         return
@@ -232,8 +207,7 @@ def export_quantized_state_dict(
 ) -> dict[str, torch.Tensor]:
     """Pack each quantized weight and emit it alongside its scales.
 
-    Follows the unified-HF naming convention: ``w.weight`` / ``w.weight_scale`` /
-    ``w.weight_scale_2``. Untouched tensors are carried through in ``dtype``.
+    Unified-HF naming (``w.weight_scale`` etc). Untouched tensors carry through in ``dtype``.
     """
     export_sd = {k: v.to(dtype) for k, v in state_dict.items()}
     for name, module in root.named_modules():
@@ -243,9 +217,8 @@ def export_quantized_state_dict(
         assert quantization is not None, f"{name}: enabled quantizer resolved to no format"
         weight_scale = get_weight_scaling_factor(module)
         weight_scale_2 = get_weight_scaling_factor_2(module)
-        # A per-channel scale over a single-output projection collapses to a 0-dim tensor
-        # that the packing helpers index as ``scale[:, None]``. Skip rather than crash --
-        # it is one row of weights and stays in ``dtype``.
+        # The packing helpers index the scale as ``scale[:, None]``, which a 0-dim scale
+        # cannot satisfy. One row of weights, so leave it in ``dtype``.
         if weight_scale is not None and weight_scale.dim() == 0 and module.weight.shape[0] == 1:
             print(f"Skipping {name}: single-output projection, per-channel scale is scalar")
             continue
@@ -259,8 +232,7 @@ def export_quantized_state_dict(
         export_sd[f"{name}.weight_scale"] = weight_scale
         if weight_scale_2 is not None:
             export_sd[f"{name}.weight_scale_2"] = weight_scale_2
-        # Static-activation formats need the input scale in the checkpoint too; without it
-        # the runtime has no activation scale to apply and the format silently degrades.
+        # Without this the runtime has no activation scale and the format silently degrades.
         activation_scale = get_activation_scaling_factor(module)
         if activation_scale is not None:
             export_sd[f"{name}.input_scale"] = activation_scale
@@ -289,9 +261,8 @@ def main():
 
     config = json.loads((source_dir / "config.json").read_text())
     hf_quant_config = get_quant_config(root)
-    # ``get_quant_config`` only knows the modules in the linear view, so anything it never
-    # saw (norms, 1-D weights) is missing from ``exclude_modules`` and a loader walking the
-    # checkpoint expects a ``weight_scale`` for it. List every unquantized weight instead.
+    # ``get_quant_config`` only knows the linear view, so tensors it never saw (norms, 1-D
+    # weights) are missing and a loader walking the checkpoint expects a scale for them.
     quantized = {
         name
         for name, module in root.named_modules()
@@ -308,15 +279,13 @@ def main():
     for name in unquantized:
         if name not in exclude_modules:
             exclude_modules.append(name)
-        # A runtime matches this against its own module prefix, which is nested relative to
-        # the checkpoint key (vLLM builds the draft's ``fc`` at ``model.fc``). Add a suffix
-        # wildcard so the exclusion matches at any depth.
+        # Runtimes match against their own module prefix, which is nested relative to the
+        # checkpoint key (vLLM builds the draft's ``fc`` at ``model.fc``).
         wildcard = f"*{name}"
         if wildcard not in exclude_modules:
             exclude_modules.append(wildcard)
-    # Runtimes fuse sibling projections into one layer whose name appears in no checkpoint
-    # key (q/k/v -> ``qkv_proj``, gate/up -> ``gate_up_proj``), so excluding only the parts
-    # leaves the fused layer quantized. Emit the alias once every component is excluded.
+    # Runtimes fuse sibling projections into one layer whose name is in no checkpoint key,
+    # so excluding only the parts would leave the fused layer quantized.
     for fused, parts in (
         ("qkv_proj", ("q_proj", "k_proj", "v_proj")),
         ("gate_up_proj", ("gate_proj", "up_proj")),
@@ -328,15 +297,13 @@ def main():
     hf_quant_config["quantization"]["exclude_modules"] = exclude_modules
     config["quantization_config"] = dict(hf_quant_config["quantization"])
     # ModelOpt names the format ``quant_algo``; vLLM reads ``quant_method`` and treats its
-    # absence as unquantized. Emit both. vLLM splits ModelOpt checkpoints across two
-    # backends: ``modelopt_fp4`` for block-scaled NVFP4, ``modelopt`` for the rest.
+    # absence as unquantized, splitting NVFP4 off into its own backend. Emit both.
     quant_algo = str(hf_quant_config["quantization"].get("quant_algo") or "")
     config["quantization_config"].setdefault(
         "quant_method", "modelopt_fp4" if "NVFP4" in quant_algo.upper() else "modelopt"
     )
-    # The exclusion list is read under two different keys: ModelOpt nests it under
-    # ``quantization.exclude_modules``, but a runtime parsing the flat
-    # ``quantization_config`` in config.json looks for ``ignore``. Emit both.
+    # Same list, second key: the flat ``quantization_config`` in config.json is read for
+    # ``ignore``, not ``exclude_modules``.
     config["quantization_config"]["ignore"] = list(exclude_modules)
     config["torch_dtype"] = args.dtype
     (export_dir / "config.json").write_text(json.dumps(config, indent=2))

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -74,6 +74,10 @@ SUPPORTED_QFORMATS = [
 # All tiny. `fc` is left to the presets; `lm_head` is excluded by the preset itself.
 DEFAULT_EXCLUDE = ["*markov_head*", "*confidence_head*", "*embed_tokens*"]
 
+# Sidecars carried over to the export, and -- with the weights and config.json -- the only
+# files fetched when --drafter_path is a repo id rather than a local directory.
+SIDECAR_FILES = ("tokenizer.json", "tokenizer_config.json", "generation_config.json")
+
 # The amax that yields input_scale 1.0 for FP8. NVFP4 divides by 6*448, so the same amax
 # records as 0.1667 there; both mean the same activation range.
 FP8_E4M3_MAX = 448.0
@@ -122,7 +126,11 @@ def load_drafter(drafter_path: str) -> tuple[Path, dict[str, torch.Tensor]]:
     if not local_dir.is_dir():
         from huggingface_hub import snapshot_download
 
-        local_dir = Path(snapshot_download(drafter_path))
+        local_dir = Path(
+            snapshot_download(
+                drafter_path, allow_patterns=["*.safetensors", "config.json", *SIDECAR_FILES]
+            )
+        )
 
     shards = sorted(local_dir.glob("*.safetensors"))
     assert shards, f"No .safetensors found under {local_dir}"
@@ -314,9 +322,18 @@ def main():
     (export_dir / "config.json").write_text(json.dumps(config, indent=2))
     (export_dir / "hf_quant_config.json").write_text(json.dumps(hf_quant_config, indent=2))
 
-    for extra in ("tokenizer.json", "tokenizer_config.json", "generation_config.json"):
+    for extra in SIDECAR_FILES:
         if (source_dir / extra).is_file():
             shutil.copy2(source_dir / extra, export_dir / extra)
+
+    # A drafter that ships custom modeling code points at it from auto_map; the export
+    # carries that config verbatim, so the .py files have to come along or the reference
+    # dangles. (The DFlash/DSpark exports have no auto_map -- this is for the ones that do.)
+    if config.get("auto_map"):
+        for module in {ref.split("--")[-1].split(".")[0] for ref in config["auto_map"].values()}:
+            source_py = source_dir / f"{module}.py"
+            if source_py.is_file():
+                shutil.copy2(source_py, export_dir / source_py.name)
 
     before = sum(v.numel() * v.element_size() for v in state_dict.values())
     after = sum(v.numel() * v.element_size() for v in export_sd.values())

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -66,7 +66,6 @@ SUPPORTED_QFORMATS = [
     "nvfp4",
     "fp8",
     "fp8_pc_pt",
-    "fp8_pb_wo",
 ]
 
 # All 2-D, so the flat view treats them as GEMMs, but none is one: markov_w1/embed_tokens
@@ -173,7 +172,9 @@ def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -
             continue
         if getattr(input_quantizer, "amax", None) is not None:
             continue
-        input_quantizer.amax = torch.tensor(amax, dtype=torch.float32).to(module.weight.dtype)
+        # Keep amax in fp32, as ModelOpt does everywhere else -- casting to the weight
+        # dtype would round a measured amax through bf16's 8-bit mantissa.
+        input_quantizer.amax = torch.tensor(amax, dtype=torch.float32)
         count += 1
     return count
 
@@ -194,9 +195,13 @@ def build_quant_cfg(qformat: str, exclude: list[str], quantize_lm_head: bool) ->
     """Take the shipped preset and layer the drafter-specific exclusions on top."""
     quant_cfg = copy.deepcopy(QUANT_CFG_CHOICES[qformat])
     if quantize_lm_head:
-        quant_cfg["quant_cfg"].append(
-            {"quantizer_name": "*lm_head*weight_quantizer", "enable": True}
-        )
+        # The preset disables *all* of lm_head's quantizers. Re-enabling only the weight
+        # one would leave a W+A format exporting lm_head with no input_scale while the
+        # config still advertises it as fully quantized, which a runtime fails to load.
+        for quantizer in ("weight_quantizer", "input_quantizer"):
+            quant_cfg["quant_cfg"].append(
+                {"quantizer_name": f"*lm_head*{quantizer}", "enable": True}
+            )
     for pattern in DEFAULT_EXCLUDE + exclude:
         quant_cfg["quant_cfg"].append({"quantizer_name": pattern, "enable": False})
     return quant_cfg

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -34,8 +34,8 @@ Two families of format are supported:
 * **Weight-only / dynamic-activation** (``w4a16_nvfp4``, ``fp8_pc_pt``, ``fp8_pb_wo``) --
   every scale is either derived from the weight or computed at runtime per token.
 * **Static-activation** (``fp8``, ``nvfp4``) -- these need an ``input_quantizer`` amax,
-  normally measured with calibration data. Instead one fixed amax is applied to every
-  layer (``--act_scale_amax``, default 448 = input_scale 1.0 for FP8).
+  normally measured with calibration data. Instead a fixed ``input_scale`` of 1.0 is
+  applied to every layer.
 
 A fixed activation scale sounds crude but measures well, because acceptance length is
 governed almost entirely by *clipping* rather than by resolution. Sweeping input_scale over
@@ -54,12 +54,13 @@ input_scale  FP8 AL          NVFP4 AL
 (bf16 baseline 3.142.) Both formats fall off a cliff below ~0.03, where the declared range
 is far under the activations' true magnitude and most of the tensor is clipped, and both
 sit on a flat plateau from ~0.3 to 4.0 with no drop-off at the top -- so the scale needs to
-be big enough, and little else. NVFP4 trails FP8 by a roughly constant 3.5% across the
+be big enough, and little else. 1.0 sits in the middle of that plateau, which is why it is
+fixed rather than exposed as a knob. NVFP4 trails FP8 by a roughly constant 3.5% across the
 plateau: that gap is the 4-bit resolution cost itself and no choice of scale recovers it.
 
-Two weight-derived estimators (``weight_amax``, ``weight_rms``) are kept for reference.
-They land 1-2 orders of magnitude below the activation range and measure -31% to -46% AL;
-they are not recommended.
+Estimating the amax from the weights instead was tried and does not work: max|W| averages
+0.79 while a RMSNorm'd activation is O(1) with outlier channels in the tens, so the range
+lands 1-2 orders of magnitude low and clips. That measured -31% to -46% AL.
 
 AWQ formats are deliberately not offered: ``awq_lite`` silently degrades to plain RTN when
 no ``forward_loop`` is supplied.
@@ -136,10 +137,14 @@ SUPPORTED_QFORMATS = [
 # target, and vLLM's loader then fails with ``KeyError: 'embed_tokens.weight_scale'``.
 DEFAULT_EXCLUDE = ["*markov_head*", "*confidence_head*", "*embed_tokens*"]
 
-# Largest value FP8 E4M3 can represent, and the default static activation amax. The
-# exported input_scale is amax/448 for FP8 but amax/(6*448) for NVFP4 -- the amax is what
-# both formats share, which is why the CLI takes it rather than an input_scale.
+# Static activation amax applied to every layer of a static-activation format, expressed as
+# the amax that yields input_scale 1.0. The exported input_scale is amax/448 for FP8 but
+# amax/(6*448) for NVFP4, so this is the FP8 convention; an NVFP4 checkpoint built from the
+# same amax records input_scale 0.1667. See the module docstring for why 1.0 and why this is
+# not a CLI knob: the usable plateau spans ~0.3 to 4.0, so the value only has to be big
+# enough, and 1.0 sits in the middle of it.
 FP8_E4M3_MAX = 448.0
+STATIC_ACT_AMAX = FP8_E4M3_MAX
 
 
 def parse_args():
@@ -152,38 +157,10 @@ def parse_args():
         "--qformat",
         default="w4a16_nvfp4",
         choices=SUPPORTED_QFORMATS,
-        help="Quantization format. Weight-only and dynamic-activation formats are fully "
-        "calibration-free; static-activation formats (fp8, nvfp4) additionally need "
-        "--act_scale_heuristic.",
-    )
-    parser.add_argument(
-        "--act_scale_heuristic",
-        default="fixed",
-        choices=["fixed", "none", "weight_amax", "weight_rms"],
-        help="How to set the static activation amax for formats that need one, without "
-        "calibration data. 'fixed' (default) applies --act_scale_amax to every "
-        "layer. 'none' refuses to guess and errors out. The two weight-derived estimators "
-        "are kept for reference only -- they were measured at -31%% to -46%% acceptance "
-        "length; see estimate_activation_amax.",
-    )
-    parser.add_argument(
-        "--act_scale_amax",
-        type=float,
-        default=FP8_E4M3_MAX,
-        help="Static activation amax applied to every layer with --act_scale_heuristic "
-        "fixed, i.e. the largest activation the quantizer will represent without clipping. "
-        "Default 448 corresponds to input_scale 1.0 for FP8; it is lossless for FP8 and "
-        "within 4%% for NVFP4 on Qwen3-8B, and anything from ~134 (scale 0.3) upward sits "
-        "on the same plateau. Below ~13 the activations get clipped and acceptance length "
-        "falls off a cliff. Note the exported input_scale is amax/448 for FP8 but "
-        "amax/(6*448) for NVFP4, so the same amax yields different input_scale values.",
-    )
-    parser.add_argument(
-        "--act_scale_multiplier",
-        type=float,
-        default=1.0,
-        help="Extra factor on the estimated activation amax. >1 clips less and quantizes "
-        "coarser; <1 the reverse. Only used with --act_scale_heuristic.",
+        help="Quantization format. All are calibration-free: weight-only and "
+        "dynamic-activation formats derive every scale from the weights or per token at "
+        "runtime, and the static-activation formats (fp8, nvfp4) use a fixed input_scale "
+        "of 1.0.",
     )
     parser.add_argument(
         "--dtype",
@@ -248,60 +225,19 @@ def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -
     return root
 
 
-def estimate_activation_amax(
-    module: nn.Linear, method: str, multiplier: float, fixed_value: float = 1.0
-) -> torch.Tensor | None:
-    """Estimate a static activation amax for ``module`` from its weight alone.
+def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -> int:
+    """Give every static ``input_quantizer`` the same fixed amax. Returns how many were set.
 
     Static-activation formats (fp8, nvfp4) need an ``input_quantizer`` amax, which is
-    normally measured by pushing calibration data through the model. A drafter cannot be
-    driven that way here (no importable modeling code, and its real forward takes hidden
-    states rather than token ids), so these estimators stand in for the measurement.
+    normally *measured* by pushing calibration data through the model. A drafter cannot be
+    driven that way here: it has no importable modeling code, and its real forward takes
+    hidden states rather than token ids. See the module docstring for why one fixed value
+    stands in for that measurement, and why 1.0.
 
-    Both assume the layer's input is roughly unit-scale -- true for a transformer's linear
-    inputs, which are RMSNorm outputs -- and use the weight only to set the dynamic range:
-
-    ``weight_amax``
-        amax = max |W|. An upper-ish bound: activations feeding a layer with large weights
-        are assumed to span a comparable range. Errs toward clipping less, quantizing
-        coarser.
-    ``weight_rms``
-        amax = 4 * rms(W), i.e. a 4-sigma range for a roughly Gaussian weight. Tighter than
-        weight_amax on layers with a few outlier weights, so it usually preserves more
-        resolution -- at the cost of clipping genuine activation outliers.
-
-    ``fixed``
-        amax = ``--act_scale_amax``, the same value for every layer,
-        ignoring the weight
-        entirely. Measured on Qwen3-8B the weight-derived estimators land 1-2 orders of
-        magnitude below the activations they are meant to bound (max|W| averages 0.79 while
-        a RMSNorm'd activation is O(1) with outlier channels in the tens), so most values
-        are clipped. A fixed amax lets the range be set directly on the scale the
-        activations actually live on.
-
-    None is a substitute for calibration. All are deliberately crude, and which one wins is
-    model-dependent; measure acceptance length rather than trusting any of them.
-    """
-    weight = module.weight.detach().float()
-    if method == "weight_amax":
-        amax = weight.abs().max()
-    elif method == "weight_rms":
-        amax = 4.0 * weight.pow(2).mean().sqrt()
-    elif method == "fixed":
-        amax = torch.tensor(fixed_value, dtype=torch.float32)
-    else:
-        return None
-    return (amax * multiplier).to(module.weight.dtype)
-
-
-def apply_activation_scale_heuristic(
-    root: nn.Module, method: str, multiplier: float, fixed_value: float = 1.0
-) -> int:
-    """Set every enabled ``input_quantizer``'s amax from the weight heuristic.
-
-    Returns the number of quantizers that were given a scale. Only quantizers that are
-    both enabled and still missing an amax are touched, so dynamic-activation formats
-    (whose scales are computed per token at runtime) are left alone.
+    Only quantizers that are enabled and still missing an amax are touched, so
+    dynamic-activation formats -- whose scales are computed per token at runtime -- are left
+    alone, and any amax already established (by a future calibration pass, see
+    ``resolve_activation_scales``) wins over the fixed default.
     """
     count = 0
     for _, module in root.named_modules():
@@ -315,12 +251,32 @@ def apply_activation_scale_heuristic(
             continue
         if getattr(input_quantizer, "amax", None) is not None:
             continue
-        amax = estimate_activation_amax(module, method, multiplier, fixed_value)
-        if amax is None:
-            continue
-        input_quantizer.amax = amax
+        input_quantizer.amax = torch.tensor(amax, dtype=torch.float32).to(module.weight.dtype)
         count += 1
     return count
+
+
+def resolve_activation_scales(root: nn.Module, quant_cfg: dict) -> None:
+    """Establish activation scales for a format that quantizes activations statically.
+
+    The single place that decides *where* a static activation amax comes from. Today there
+    is one source -- a fixed value applied uniformly -- because the drafter cannot be run
+    forward without its modeling code. Real calibration would slot in here as a second
+    source ahead of the fixed fallback::
+
+        if calib_forward_loop is not None:
+            mtq.calibrate(root, quant_cfg["algorithm"], forward_loop=calib_forward_loop)
+        set_static_activation_amax(root)  # fills in whatever calibration did not reach
+
+    ``set_static_activation_amax`` deliberately skips quantizers that already have an amax,
+    so it composes as a fallback rather than overwriting measured values, and the callers
+    below do not change when that day comes.
+    """
+    if not need_calibration(quant_cfg):
+        # Weight-only, or activations scaled per token at runtime -- nothing to establish.
+        return
+    n = set_static_activation_amax(root)
+    print(f"Set {n} static activation amax values (fixed, input_scale 1.0) -- not calibrated.")
 
 
 def build_quant_cfg(qformat: str, exclude: list[str], quantize_lm_head: bool) -> dict:
@@ -384,34 +340,9 @@ def main():
     root = build_linear_view(state_dict, dtype)
 
     quant_cfg = build_quant_cfg(args.qformat, args.exclude, args.quantize_lm_head)
-    needs_static_act = need_calibration(quant_cfg)
-    if needs_static_act and args.act_scale_heuristic == "none":
-        raise SystemExit(
-            f"--qformat {args.qformat} quantizes activations with a static scale, which is "
-            "normally measured with calibration data. This script has none, so pass "
-            "--act_scale_heuristic {weight_amax,weight_rms} to estimate it from the weights "
-            "(approximate -- verify acceptance length), or pick a calibration-free format "
-            "such as w4a16_nvfp4 (weight-only) or fp8_pc_pt (dynamic per-token activations)."
-        )
 
     mtq.quantize(root, quant_cfg)  # no forward_loop: scales come from the weights
-
-    if needs_static_act:
-        n = apply_activation_scale_heuristic(
-            root,
-            args.act_scale_heuristic,
-            args.act_scale_multiplier,
-            args.act_scale_amax,
-        )
-        detail = (
-            f"amax={args.act_scale_amax:g}"
-            if args.act_scale_heuristic == "fixed"
-            else f"derived from weights (x{args.act_scale_multiplier:g})"
-        )
-        print(
-            f"Set {n} static activation amax values via '{args.act_scale_heuristic}' "
-            f"({detail}) -- not calibrated."
-        )
+    resolve_activation_scales(root, quant_cfg)
 
     mtq.print_quant_summary(root)
 

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -15,52 +15,26 @@
 
 """Calibration-free PTQ for a speculative-decoding drafter.
 
-Block-wise ``max`` quantization derives every scale from the weight tensor itself, so
-this needs neither a dataset nor a forward pass -- only the drafter's safetensors file.
-That in turn means we never have to import the drafter's modeling code: each 2-D weight
-is wrapped in a throwaway ``nn.Linear`` under its checkpoint name, and ModelOpt's normal
-``quantizer_name`` patterns select over those names exactly as they would on the real
-module tree. Works for any drafter layout (DSpark / DFlash / EAGLE3 / Medusa).
+Every scale is derived from the weights, so this needs no dataset and no forward pass --
+only the drafter's safetensors file. That also means the drafter's modeling code is never
+imported: each 2-D weight is wrapped in a throwaway ``nn.Linear`` under its checkpoint
+name, and ModelOpt's usual ``quantizer_name`` patterns select over those names. Works for
+any drafter layout (DSpark / DFlash / EAGLE3 / Medusa).
 
-Avoiding the modeling code is what makes this work at all for DFlash-family drafters. An
+Avoiding the modeling code is what makes this work for DFlash-family drafters at all: an
 exported drafter declares ``architectures: ["DFlashDraftModel"]`` but ships no importable
-class, so ``AutoModelForCausalLM`` silently loads it as a plain Qwen3 and drops ``fc`` /
-``hidden_norm`` / the DSpark heads; and the real draft module's ``forward`` takes
-``(noise_embedding, target_hidden, ...)``, not ``input_ids``, so the stock ``hf_ptq.py``
-calibration loop cannot drive it either. The flat-linear view sidesteps both problems.
+class, so ``AutoModelForCausalLM`` silently loads it as a plain Qwen3 and drops the draft
+tensors, and the real draft ``forward`` takes hidden states rather than ``input_ids``, so
+the stock ``hf_ptq.py`` calibration loop cannot drive it either.
 
-Two families of format are supported:
-
-* **Weight-only / dynamic-activation** (``w4a16_nvfp4``, ``fp8_pc_pt``, ``fp8_pb_wo``) --
-  every scale is either derived from the weight or computed at runtime per token.
-* **Static-activation** (``fp8``, ``nvfp4``) -- these need an ``input_quantizer`` amax,
-  normally measured with calibration data. Instead a fixed ``input_scale`` of 1.0 is
-  applied to every layer.
-
-A fixed activation scale sounds crude but measures well, because acceptance length is
-governed almost entirely by *clipping* rather than by resolution. Sweeping input_scale over
-three decades on Qwen3-8B + a DSpark drafter (MT-Bench, 80 questions):
-
-===========  ==============  ==============
-input_scale  FP8 AL          NVFP4 AL
-===========  ==============  ==============
-0.003        2.220 (-29.3%)  2.208 (-29.8%)
-0.03         2.975  (-5.3%)  2.926  (-6.9%)
-0.3          3.137  (-0.2%)  3.022  (-3.8%)
-1.0          3.146  (+0.1%)  3.019  (-3.9%)
-4.0          3.125  (-0.6%)  3.003  (-4.4%)
-===========  ==============  ==============
-
-(bf16 baseline 3.142.) Both formats fall off a cliff below ~0.03, where the declared range
-is far under the activations' true magnitude and most of the tensor is clipped, and both
-sit on a flat plateau from ~0.3 to 4.0 with no drop-off at the top -- so the scale needs to
-be big enough, and little else. 1.0 sits in the middle of that plateau, which is why it is
-fixed rather than exposed as a knob. NVFP4 trails FP8 by a roughly constant 3.5% across the
-plateau: that gap is the 4-bit resolution cost itself and no choice of scale recovers it.
-
-Estimating the amax from the weights instead was tried and does not work: max|W| averages
-0.79 while a RMSNorm'd activation is O(1) with outlier channels in the tens, so the range
-lands 1-2 orders of magnitude low and clips. That measured -31% to -46% AL.
+``fp8`` and ``nvfp4`` quantize activations against a static amax that is normally measured
+on calibration data; a fixed ``input_scale`` of 1.0 is applied instead. That holds up
+because acceptance length is governed by clipping rather than resolution: on Qwen3-8B +
+a DSpark drafter (MT-Bench), AL falls off a cliff below input_scale ~0.03 but sits on a
+flat plateau from ~0.3 to 4.0 with no drop-off at the top, so the scale only has to be big
+enough. 1.0 is the middle of that plateau, and measures +0.1% AL for FP8 and -3.9% for
+NVFP4 (that gap is the 4-bit resolution cost; no scale recovers it). Deriving the amax
+from the weights instead clips badly and measures -31% to -46%.
 
 AWQ formats are deliberately not offered: ``awq_lite`` silently degrades to plain RTN when
 no ``forward_loop`` is supplied.
@@ -96,13 +70,6 @@ from modelopt.torch.export.quant_utils import (
 from modelopt.torch.quantization.config import need_calibration
 from modelopt.torch.quantization.utils import is_quantized_linear
 
-# Formats this script offers, in the order they are most likely to be wanted.
-#   w4a16_nvfp4 -- block-16 E2M1 weights, dynamic FP8 E4M3 scales. Smallest, weight-only.
-#   nvfp4       -- same weights plus NVFP4 activations (static amax -> needs a scale).
-#   fp8         -- E4M3 weights and activations, per-tensor (static amax -> needs a scale).
-#   fp8_pc_pt   -- E4M3 per-channel weights, DYNAMIC per-token activations. The
-#                  calibration-free way to get FP8 activations.
-#   fp8_pb_wo   -- E4M3 per-block weight-only fallback.
 # INT8/INT4 weight-only formats are deliberately absent: vLLM's ModelOpt backend accepts
 # only FP8, FP8_PER_CHANNEL_PER_TOKEN, FP8_PB_WO, NVFP4, W4A16_NVFP4, MXFP8 and
 # MIXED_PRECISION, so an INT checkpoint quantizes cleanly but cannot be served.
@@ -114,35 +81,19 @@ SUPPORTED_QFORMATS = [
     "fp8_pb_wo",
 ]
 
-# The Markov head writes straight into the draft logits and is only a few percent of the
-# drafter, so the bits it would save are not worth the acceptance-rate risk. It is also not
-# a plain GEMM in the real module tree -- markov_w1 is an nn.Embedding, which ModelOpt's
-# stock presets already exclude via `parent_class: nn.Embedding`; the flat-linear view here
-# has lost the original module classes, so the exclusion has to be restated by name.
-#
-# The confidence head is excluded for the same reason plus a mechanical one: it projects to
-# a single output (``[1, hidden]``), so a per-channel scale collapses to a 0-dim tensor and
-# the per-channel export path (fp8_pc_pt) indexes it as ``scale[:, None]`` and raises. It is
-# one row of weights, so there is nothing to gain by quantizing it.
-#
-# ``fc`` is deliberately NOT excluded here: it is the single largest non-lm_head tensor and
-# the formats' own presets decide its fate. Exclude it explicitly with --exclude '*fc*' when
-# comparing acceptance length.
-# lm_head is excluded by the preset itself (see --quantize_lm_head).
-#
-# ``embed_tokens`` must be excluded too. It is 2-D, so the flat-linear view happily treats
-# it as a GEMM, but it is an ``nn.Embedding``: a row lookup, not a matmul. ModelOpt's stock
-# presets skip embeddings via ``parent_class: nn.Embedding``, which the flat view cannot
-# see. Quantizing it also breaks deployment -- a drafter inherits ``embed_tokens`` from the
-# target, and vLLM's loader then fails with ``KeyError: 'embed_tokens.weight_scale'``.
+# These are 2-D, so the flat-linear view treats them as GEMMs, but none of them is one:
+# markov_w1 and embed_tokens are embeddings (row lookups), which ModelOpt's presets
+# normally skip via `parent_class: nn.Embedding` -- a class the flat view cannot see, so
+# the exclusion is restated by name. Quantizing embed_tokens also breaks deployment, since
+# a drafter inherits it from the target (vLLM: KeyError: 'embed_tokens.weight_scale').
+# confidence_head projects to a single output, whose per-channel scale collapses to a
+# 0-dim tensor. All are tiny; nothing is lost by leaving them alone.
+# Not excluded: `fc` (the presets decide; use --exclude '*fc*' to compare) and `lm_head`
+# (the preset already excludes it -- see --quantize_lm_head).
 DEFAULT_EXCLUDE = ["*markov_head*", "*confidence_head*", "*embed_tokens*"]
 
-# Static activation amax applied to every layer of a static-activation format, expressed as
-# the amax that yields input_scale 1.0. The exported input_scale is amax/448 for FP8 but
-# amax/(6*448) for NVFP4, so this is the FP8 convention; an NVFP4 checkpoint built from the
-# same amax records input_scale 0.1667. See the module docstring for why 1.0 and why this is
-# not a CLI knob: the usable plateau spans ~0.3 to 4.0, so the value only has to be big
-# enough, and 1.0 sits in the middle of it.
+# The amax that yields input_scale 1.0 for FP8. NVFP4 divides by 6*448 instead, so the same
+# amax records as input_scale 0.1667 there; both mean the same activation range.
 FP8_E4M3_MAX = 448.0
 STATIC_ACT_AMAX = FP8_E4M3_MAX
 
@@ -228,16 +179,8 @@ def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -
 def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -> int:
     """Give every static ``input_quantizer`` the same fixed amax. Returns how many were set.
 
-    Static-activation formats (fp8, nvfp4) need an ``input_quantizer`` amax, which is
-    normally *measured* by pushing calibration data through the model. A drafter cannot be
-    driven that way here: it has no importable modeling code, and its real forward takes
-    hidden states rather than token ids. See the module docstring for why one fixed value
-    stands in for that measurement, and why 1.0.
-
-    Only quantizers that are enabled and still missing an amax are touched, so
-    dynamic-activation formats -- whose scales are computed per token at runtime -- are left
-    alone, and any amax already established (by a future calibration pass, see
-    ``resolve_activation_scales``) wins over the fixed default.
+    Skips quantizers that are dynamic (scale computed per token at runtime) or that already
+    have an amax, so this composes as a fallback rather than an overwrite.
     """
     count = 0
     for _, module in root.named_modules():
@@ -259,21 +202,14 @@ def set_static_activation_amax(root: nn.Module, amax: float = STATIC_ACT_AMAX) -
 def resolve_activation_scales(root: nn.Module, quant_cfg: dict) -> None:
     """Establish activation scales for a format that quantizes activations statically.
 
-    The single place that decides *where* a static activation amax comes from. Today there
-    is one source -- a fixed value applied uniformly -- because the drafter cannot be run
-    forward without its modeling code. Real calibration would slot in here as a second
-    source ahead of the fixed fallback::
+    The single place deciding where a static amax comes from. Real calibration would slot
+    in here ahead of the fixed fallback, leaving the CLI and call site unchanged::
 
         if calib_forward_loop is not None:
             mtq.calibrate(root, quant_cfg["algorithm"], forward_loop=calib_forward_loop)
-        set_static_activation_amax(root)  # fills in whatever calibration did not reach
-
-    ``set_static_activation_amax`` deliberately skips quantizers that already have an amax,
-    so it composes as a fallback rather than overwriting measured values, and the callers
-    below do not change when that day comes.
+        set_static_activation_amax(root)  # fills in what calibration did not reach
     """
     if not need_calibration(quant_cfg):
-        # Weight-only, or activations scaled per token at runtime -- nothing to establish.
         return
     n = set_static_activation_amax(root)
     print(f"Set {n} static activation amax values (fixed, input_scale 1.0) -- not calibrated.")
@@ -307,9 +243,9 @@ def export_quantized_state_dict(
         assert quantization is not None, f"{name}: enabled quantizer resolved to no format"
         weight_scale = get_weight_scaling_factor(module)
         weight_scale_2 = get_weight_scaling_factor_2(module)
-        # A per-channel scale over a single-output projection (``[1, hidden]``) collapses to
-        # a 0-dim tensor that the packing helpers index as ``scale[:, None]``. Such a layer
-        # is one row of weights, so skip it rather than crash -- it stays in ``dtype``.
+        # A per-channel scale over a single-output projection collapses to a 0-dim tensor
+        # that the packing helpers index as ``scale[:, None]``. Skip rather than crash --
+        # it is one row of weights and stays in ``dtype``.
         if weight_scale is not None and weight_scale.dim() == 0 and module.weight.shape[0] == 1:
             print(f"Skipping {name}: single-output projection, per-channel scale is scalar")
             continue
@@ -323,9 +259,8 @@ def export_quantized_state_dict(
         export_sd[f"{name}.weight_scale"] = weight_scale
         if weight_scale_2 is not None:
             export_sd[f"{name}.weight_scale_2"] = weight_scale_2
-        # Static-activation formats also need the input scale in the checkpoint. Without
-        # it the runtime has no activation scale to apply, so every heuristic produces a
-        # byte-identical export and the format silently degrades.
+        # Static-activation formats need the input scale in the checkpoint too; without it
+        # the runtime has no activation scale to apply and the format silently degrades.
         activation_scale = get_activation_scaling_factor(module)
         if activation_scale is not None:
             export_sd[f"{name}.input_scale"] = activation_scale
@@ -354,11 +289,9 @@ def main():
 
     config = json.loads((source_dir / "config.json").read_text())
     hf_quant_config = get_quant_config(root)
-    # ``get_quant_config`` only knows about the modules in the linear view, so anything the
-    # view never saw -- embeddings, norms, and any 1-D weight -- is absent from
-    # ``exclude_modules``. A loader that walks the checkpoint (vLLM does) then expects a
-    # ``weight_scale`` for those too and dies with e.g. KeyError: 'embed_tokens.weight_scale'.
-    # List every weight that was not quantized so the exclusion set is complete.
+    # ``get_quant_config`` only knows the modules in the linear view, so anything it never
+    # saw (norms, 1-D weights) is missing from ``exclude_modules`` and a loader walking the
+    # checkpoint expects a ``weight_scale`` for it. List every unquantized weight instead.
     quantized = {
         name
         for name, module in root.named_modules()
@@ -375,19 +308,15 @@ def main():
     for name in unquantized:
         if name not in exclude_modules:
             exclude_modules.append(name)
-        # A runtime matches this list against its own module prefix, which is usually
-        # nested relative to the checkpoint key (vLLM builds the draft's ``fc`` at
-        # ``model.fc`` via ``maybe_prefix``). A bare ``fc`` then fails to match, the layer
-        # is built quantized, and loading the bf16 weight into a packed parameter raises a
-        # size assertion. Add a suffix wildcard so the exclusion matches at any depth.
+        # A runtime matches this against its own module prefix, which is nested relative to
+        # the checkpoint key (vLLM builds the draft's ``fc`` at ``model.fc``). Add a suffix
+        # wildcard so the exclusion matches at any depth.
         wildcard = f"*{name}"
         if wildcard not in exclude_modules:
             exclude_modules.append(wildcard)
     # Runtimes fuse sibling projections into one layer whose name appears in no checkpoint
-    # key: q/k/v -> ``qkv_proj``, gate/up -> ``gate_up_proj``. Excluding only the individual
-    # names leaves the fused layer quantized, and its merged shard shapes then disagree with
-    # the unpacked weights being loaded into it. Emit the fused aliases whenever every
-    # component of a fusion group was excluded.
+    # key (q/k/v -> ``qkv_proj``, gate/up -> ``gate_up_proj``), so excluding only the parts
+    # leaves the fused layer quantized. Emit the alias once every component is excluded.
     for fused, parts in (
         ("qkv_proj", ("q_proj", "k_proj", "v_proj")),
         ("gate_up_proj", ("gate_proj", "up_proj")),
@@ -398,21 +327,16 @@ def main():
                 exclude_modules.append(alias)
     hf_quant_config["quantization"]["exclude_modules"] = exclude_modules
     config["quantization_config"] = dict(hf_quant_config["quantization"])
-    # ModelOpt names the format ``quant_algo``; vLLM's ModelConfig reads
-    # ``quant_cfg["quant_method"]`` and treats a config without that key as unquantized,
-    # then dies on the packed weight shapes. Emit both so either loader is satisfied.
-    # vLLM splits ModelOpt checkpoints into two backends: ``modelopt_fp4`` for the
-    # block-scaled NVFP4 layouts and ``modelopt`` for the per-tensor/per-channel ones.
+    # ModelOpt names the format ``quant_algo``; vLLM reads ``quant_method`` and treats its
+    # absence as unquantized. Emit both. vLLM splits ModelOpt checkpoints across two
+    # backends: ``modelopt_fp4`` for block-scaled NVFP4, ``modelopt`` for the rest.
     quant_algo = str(hf_quant_config["quantization"].get("quant_algo") or "")
     config["quantization_config"].setdefault(
         "quant_method", "modelopt_fp4" if "NVFP4" in quant_algo.upper() else "modelopt"
     )
-    # The exclusion list is read under two different keys. ModelOpt's own
-    # ``hf_quant_config.json`` nests it under ``quantization.exclude_modules``, but when a
-    # runtime parses the flat ``quantization_config`` block inside ``config.json`` it looks
-    # for ``ignore`` (vLLM's ModelOptQuantConfigBase.from_config). Emitting only
-    # ``exclude_modules`` there yields an empty exclusion set, every layer is built
-    # quantized, and loading an untouched bf16 weight into a packed parameter raises.
+    # The exclusion list is read under two different keys: ModelOpt nests it under
+    # ``quantization.exclude_modules``, but a runtime parsing the flat
+    # ``quantization_config`` in config.json looks for ``ignore``. Emit both.
     config["quantization_config"]["ignore"] = list(exclude_modules)
     config["torch_dtype"] = args.dtype
     (export_dir / "config.json").write_text(json.dumps(config, indent=2))

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Calibration-free W4A16 weight-only PTQ for a speculative-decoding drafter.
+"""Calibration-free PTQ for a speculative-decoding drafter.
 
 Block-wise ``max`` quantization derives every scale from the weight tensor itself, so
 this needs neither a dataset nor a forward pass -- only the drafter's safetensors file.
@@ -22,15 +22,53 @@ is wrapped in a throwaway ``nn.Linear`` under its checkpoint name, and ModelOpt'
 ``quantizer_name`` patterns select over those names exactly as they would on the real
 module tree. Works for any drafter layout (DSpark / DFlash / EAGLE3 / Medusa).
 
-The format is fixed to ModelOpt's ``w4a16_nvfp4`` preset (E2M1 values, block 16, FP8 E4M3
-scales). It is calibration-free because the block scales are dynamic; AWQ formats are
-deliberately not offered, since ``awq_lite`` silently degrades to plain RTN when no
-``forward_loop`` is supplied.
+Avoiding the modeling code is what makes this work at all for DFlash-family drafters. An
+exported drafter declares ``architectures: ["DFlashDraftModel"]`` but ships no importable
+class, so ``AutoModelForCausalLM`` silently loads it as a plain Qwen3 and drops ``fc`` /
+``hidden_norm`` / the DSpark heads; and the real draft module's ``forward`` takes
+``(noise_embedding, target_hidden, ...)``, not ``input_ids``, so the stock ``hf_ptq.py``
+calibration loop cannot drive it either. The flat-linear view sidesteps both problems.
+
+Two families of format are supported:
+
+* **Weight-only / dynamic-activation** (``w4a16_nvfp4``, ``fp8_pc_pt``, ``fp8_pb_wo``) --
+  every scale is either derived from the weight or computed at runtime per token.
+* **Static-activation** (``fp8``, ``nvfp4``) -- these need an ``input_quantizer`` amax,
+  normally measured with calibration data. Instead one fixed amax is applied to every
+  layer (``--act_scale_amax``, default 448 = input_scale 1.0 for FP8).
+
+A fixed activation scale sounds crude but measures well, because acceptance length is
+governed almost entirely by *clipping* rather than by resolution. Sweeping input_scale over
+three decades on Qwen3-8B + a DSpark drafter (MT-Bench, 80 questions):
+
+===========  ==============  ==============
+input_scale  FP8 AL          NVFP4 AL
+===========  ==============  ==============
+0.003        2.220 (-29.3%)  2.208 (-29.8%)
+0.03         2.975  (-5.3%)  2.926  (-6.9%)
+0.3          3.137  (-0.2%)  3.022  (-3.8%)
+1.0          3.146  (+0.1%)  3.019  (-3.9%)
+4.0          3.125  (-0.6%)  3.003  (-4.4%)
+===========  ==============  ==============
+
+(bf16 baseline 3.142.) Both formats fall off a cliff below ~0.03, where the declared range
+is far under the activations' true magnitude and most of the tensor is clipped, and both
+sit on a flat plateau from ~0.3 to 4.0 with no drop-off at the top -- so the scale needs to
+be big enough, and little else. NVFP4 trails FP8 by a roughly constant 3.5% across the
+plateau: that gap is the 4-bit resolution cost itself and no choice of scale recovers it.
+
+Two weight-derived estimators (``weight_amax``, ``weight_rms``) are kept for reference.
+They land 1-2 orders of magnitude below the activation range and measure -31% to -46% AL;
+they are not recommended.
+
+AWQ formats are deliberately not offered: ``awq_lite`` silently degrades to plain RTN when
+no ``forward_loop`` is supplied.
 
 Example:
-    python quantize_drafter_w4a16.py \
+    python quantize_drafter.py \
         --drafter_path nvidia/MiniMax-M3-DSpark \
-        --export_path ./MiniMax-M3-DSpark-W4A16
+        --qformat fp8 \
+        --export_path ./MiniMax-M3-DSpark-FP8
 """
 
 import argparse
@@ -46,6 +84,7 @@ from safetensors.torch import load_file, save_file
 import modelopt.torch.quantization as mtq
 from modelopt.recipe.presets import QUANT_CFG_CHOICES
 from modelopt.torch.export.quant_utils import (
+    get_activation_scaling_factor,
     get_quant_config,
     get_quantization_format,
     get_weight_block_size,
@@ -53,19 +92,54 @@ from modelopt.torch.export.quant_utils import (
     get_weight_scaling_factor_2,
     to_quantized_weight,
 )
+from modelopt.torch.quantization.config import need_calibration
 from modelopt.torch.quantization.utils import is_quantized_linear
 
-# NVFP4 weight-only: block-16 E2M1 values with dynamic FP8 E4M3 scales, so every scale is
-# derived from the weight block itself and no calibration data is involved.
-QFORMAT = "w4a16_nvfp4"
+# Formats this script offers, in the order they are most likely to be wanted.
+#   w4a16_nvfp4 -- block-16 E2M1 weights, dynamic FP8 E4M3 scales. Smallest, weight-only.
+#   nvfp4       -- same weights plus NVFP4 activations (static amax -> needs a scale).
+#   fp8         -- E4M3 weights and activations, per-tensor (static amax -> needs a scale).
+#   fp8_pc_pt   -- E4M3 per-channel weights, DYNAMIC per-token activations. The
+#                  calibration-free way to get FP8 activations.
+#   fp8_pb_wo   -- E4M3 per-block weight-only fallback.
+# INT8/INT4 weight-only formats are deliberately absent: vLLM's ModelOpt backend accepts
+# only FP8, FP8_PER_CHANNEL_PER_TOKEN, FP8_PB_WO, NVFP4, W4A16_NVFP4, MXFP8 and
+# MIXED_PRECISION, so an INT checkpoint quantizes cleanly but cannot be served.
+SUPPORTED_QFORMATS = [
+    "w4a16_nvfp4",
+    "nvfp4",
+    "fp8",
+    "fp8_pc_pt",
+    "fp8_pb_wo",
+]
 
 # The Markov head writes straight into the draft logits and is only a few percent of the
 # drafter, so the bits it would save are not worth the acceptance-rate risk. It is also not
 # a plain GEMM in the real module tree -- markov_w1 is an nn.Embedding, which ModelOpt's
 # stock presets already exclude via `parent_class: nn.Embedding`; the flat-linear view here
 # has lost the original module classes, so the exclusion has to be restated by name.
+#
+# The confidence head is excluded for the same reason plus a mechanical one: it projects to
+# a single output (``[1, hidden]``), so a per-channel scale collapses to a 0-dim tensor and
+# the per-channel export path (fp8_pc_pt) indexes it as ``scale[:, None]`` and raises. It is
+# one row of weights, so there is nothing to gain by quantizing it.
+#
+# ``fc`` is deliberately NOT excluded here: it is the single largest non-lm_head tensor and
+# the formats' own presets decide its fate. Exclude it explicitly with --exclude '*fc*' when
+# comparing acceptance length.
 # lm_head is excluded by the preset itself (see --quantize_lm_head).
-DEFAULT_EXCLUDE = ["*markov_head*"]
+#
+# ``embed_tokens`` must be excluded too. It is 2-D, so the flat-linear view happily treats
+# it as a GEMM, but it is an ``nn.Embedding``: a row lookup, not a matmul. ModelOpt's stock
+# presets skip embeddings via ``parent_class: nn.Embedding``, which the flat view cannot
+# see. Quantizing it also breaks deployment -- a drafter inherits ``embed_tokens`` from the
+# target, and vLLM's loader then fails with ``KeyError: 'embed_tokens.weight_scale'``.
+DEFAULT_EXCLUDE = ["*markov_head*", "*confidence_head*", "*embed_tokens*"]
+
+# Largest value FP8 E4M3 can represent, and the default static activation amax. The
+# exported input_scale is amax/448 for FP8 but amax/(6*448) for NVFP4 -- the amax is what
+# both formats share, which is why the CLI takes it rather than an input_scale.
+FP8_E4M3_MAX = 448.0
 
 
 def parse_args():
@@ -74,6 +148,43 @@ def parse_args():
         "--drafter_path", required=True, help="HF repo id or local dir of the drafter checkpoint."
     )
     parser.add_argument("--export_path", required=True, help="Output directory.")
+    parser.add_argument(
+        "--qformat",
+        default="w4a16_nvfp4",
+        choices=SUPPORTED_QFORMATS,
+        help="Quantization format. Weight-only and dynamic-activation formats are fully "
+        "calibration-free; static-activation formats (fp8, nvfp4) additionally need "
+        "--act_scale_heuristic.",
+    )
+    parser.add_argument(
+        "--act_scale_heuristic",
+        default="fixed",
+        choices=["fixed", "none", "weight_amax", "weight_rms"],
+        help="How to set the static activation amax for formats that need one, without "
+        "calibration data. 'fixed' (default) applies --act_scale_amax to every "
+        "layer. 'none' refuses to guess and errors out. The two weight-derived estimators "
+        "are kept for reference only -- they were measured at -31%% to -46%% acceptance "
+        "length; see estimate_activation_amax.",
+    )
+    parser.add_argument(
+        "--act_scale_amax",
+        type=float,
+        default=FP8_E4M3_MAX,
+        help="Static activation amax applied to every layer with --act_scale_heuristic "
+        "fixed, i.e. the largest activation the quantizer will represent without clipping. "
+        "Default 448 corresponds to input_scale 1.0 for FP8; it is lossless for FP8 and "
+        "within 4%% for NVFP4 on Qwen3-8B, and anything from ~134 (scale 0.3) upward sits "
+        "on the same plateau. Below ~13 the activations get clipped and acceptance length "
+        "falls off a cliff. Note the exported input_scale is amax/448 for FP8 but "
+        "amax/(6*448) for NVFP4, so the same amax yields different input_scale values.",
+    )
+    parser.add_argument(
+        "--act_scale_multiplier",
+        type=float,
+        default=1.0,
+        help="Extra factor on the estimated activation amax. >1 clips less and quantizes "
+        "coarser; <1 the reverse. Only used with --act_scale_heuristic.",
+    )
     parser.add_argument(
         "--dtype",
         default="bfloat16",
@@ -137,9 +248,84 @@ def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -
     return root
 
 
-def build_quant_cfg(exclude: list[str], quantize_lm_head: bool) -> dict:
+def estimate_activation_amax(
+    module: nn.Linear, method: str, multiplier: float, fixed_value: float = 1.0
+) -> torch.Tensor | None:
+    """Estimate a static activation amax for ``module`` from its weight alone.
+
+    Static-activation formats (fp8, nvfp4) need an ``input_quantizer`` amax, which is
+    normally measured by pushing calibration data through the model. A drafter cannot be
+    driven that way here (no importable modeling code, and its real forward takes hidden
+    states rather than token ids), so these estimators stand in for the measurement.
+
+    Both assume the layer's input is roughly unit-scale -- true for a transformer's linear
+    inputs, which are RMSNorm outputs -- and use the weight only to set the dynamic range:
+
+    ``weight_amax``
+        amax = max |W|. An upper-ish bound: activations feeding a layer with large weights
+        are assumed to span a comparable range. Errs toward clipping less, quantizing
+        coarser.
+    ``weight_rms``
+        amax = 4 * rms(W), i.e. a 4-sigma range for a roughly Gaussian weight. Tighter than
+        weight_amax on layers with a few outlier weights, so it usually preserves more
+        resolution -- at the cost of clipping genuine activation outliers.
+
+    ``fixed``
+        amax = ``--act_scale_amax``, the same value for every layer,
+        ignoring the weight
+        entirely. Measured on Qwen3-8B the weight-derived estimators land 1-2 orders of
+        magnitude below the activations they are meant to bound (max|W| averages 0.79 while
+        a RMSNorm'd activation is O(1) with outlier channels in the tens), so most values
+        are clipped. A fixed amax lets the range be set directly on the scale the
+        activations actually live on.
+
+    None is a substitute for calibration. All are deliberately crude, and which one wins is
+    model-dependent; measure acceptance length rather than trusting any of them.
+    """
+    weight = module.weight.detach().float()
+    if method == "weight_amax":
+        amax = weight.abs().max()
+    elif method == "weight_rms":
+        amax = 4.0 * weight.pow(2).mean().sqrt()
+    elif method == "fixed":
+        amax = torch.tensor(fixed_value, dtype=torch.float32)
+    else:
+        return None
+    return (amax * multiplier).to(module.weight.dtype)
+
+
+def apply_activation_scale_heuristic(
+    root: nn.Module, method: str, multiplier: float, fixed_value: float = 1.0
+) -> int:
+    """Set every enabled ``input_quantizer``'s amax from the weight heuristic.
+
+    Returns the number of quantizers that were given a scale. Only quantizers that are
+    both enabled and still missing an amax are touched, so dynamic-activation formats
+    (whose scales are computed per token at runtime) are left alone.
+    """
+    count = 0
+    for _, module in root.named_modules():
+        if not is_quantized_linear(module):
+            continue
+        input_quantizer = getattr(module, "input_quantizer", None)
+        if input_quantizer is None or not input_quantizer.is_enabled:
+            continue
+        # A dynamic quantizer derives its scale at runtime; leave it untouched.
+        if getattr(input_quantizer, "_dynamic", False):
+            continue
+        if getattr(input_quantizer, "amax", None) is not None:
+            continue
+        amax = estimate_activation_amax(module, method, multiplier, fixed_value)
+        if amax is None:
+            continue
+        input_quantizer.amax = amax
+        count += 1
+    return count
+
+
+def build_quant_cfg(qformat: str, exclude: list[str], quantize_lm_head: bool) -> dict:
     """Take the shipped preset and layer the drafter-specific exclusions on top."""
-    quant_cfg = copy.deepcopy(QUANT_CFG_CHOICES[QFORMAT])
+    quant_cfg = copy.deepcopy(QUANT_CFG_CHOICES[qformat])
     if quantize_lm_head:
         quant_cfg["quant_cfg"].append(
             {"quantizer_name": "*lm_head*weight_quantizer", "enable": True}
@@ -165,6 +351,12 @@ def export_quantized_state_dict(
         assert quantization is not None, f"{name}: enabled quantizer resolved to no format"
         weight_scale = get_weight_scaling_factor(module)
         weight_scale_2 = get_weight_scaling_factor_2(module)
+        # A per-channel scale over a single-output projection (``[1, hidden]``) collapses to
+        # a 0-dim tensor that the packing helpers index as ``scale[:, None]``. Such a layer
+        # is one row of weights, so skip it rather than crash -- it stays in ``dtype``.
+        if weight_scale is not None and weight_scale.dim() == 0 and module.weight.shape[0] == 1:
+            print(f"Skipping {name}: single-output projection, per-channel scale is scalar")
+            continue
         export_sd[f"{name}.weight"] = to_quantized_weight(
             module.weight,
             weight_scale,
@@ -175,6 +367,12 @@ def export_quantized_state_dict(
         export_sd[f"{name}.weight_scale"] = weight_scale
         if weight_scale_2 is not None:
             export_sd[f"{name}.weight_scale_2"] = weight_scale_2
+        # Static-activation formats also need the input scale in the checkpoint. Without
+        # it the runtime has no activation scale to apply, so every heuristic produces a
+        # byte-identical export and the format silently degrades.
+        activation_scale = get_activation_scaling_factor(module)
+        if activation_scale is not None:
+            export_sd[f"{name}.input_scale"] = activation_scale
     return export_sd
 
 
@@ -185,8 +383,36 @@ def main():
     source_dir, state_dict = load_drafter(args.drafter_path)
     root = build_linear_view(state_dict, dtype)
 
-    quant_cfg = build_quant_cfg(args.exclude, args.quantize_lm_head)
+    quant_cfg = build_quant_cfg(args.qformat, args.exclude, args.quantize_lm_head)
+    needs_static_act = need_calibration(quant_cfg)
+    if needs_static_act and args.act_scale_heuristic == "none":
+        raise SystemExit(
+            f"--qformat {args.qformat} quantizes activations with a static scale, which is "
+            "normally measured with calibration data. This script has none, so pass "
+            "--act_scale_heuristic {weight_amax,weight_rms} to estimate it from the weights "
+            "(approximate -- verify acceptance length), or pick a calibration-free format "
+            "such as w4a16_nvfp4 (weight-only) or fp8_pc_pt (dynamic per-token activations)."
+        )
+
     mtq.quantize(root, quant_cfg)  # no forward_loop: scales come from the weights
+
+    if needs_static_act:
+        n = apply_activation_scale_heuristic(
+            root,
+            args.act_scale_heuristic,
+            args.act_scale_multiplier,
+            args.act_scale_amax,
+        )
+        detail = (
+            f"amax={args.act_scale_amax:g}"
+            if args.act_scale_heuristic == "fixed"
+            else f"derived from weights (x{args.act_scale_multiplier:g})"
+        )
+        print(
+            f"Set {n} static activation amax values via '{args.act_scale_heuristic}' "
+            f"({detail}) -- not calibrated."
+        )
+
     mtq.print_quant_summary(root)
 
     export_sd = export_quantized_state_dict(root, state_dict, dtype)
@@ -197,7 +423,66 @@ def main():
 
     config = json.loads((source_dir / "config.json").read_text())
     hf_quant_config = get_quant_config(root)
-    config["quantization_config"] = hf_quant_config["quantization"]
+    # ``get_quant_config`` only knows about the modules in the linear view, so anything the
+    # view never saw -- embeddings, norms, and any 1-D weight -- is absent from
+    # ``exclude_modules``. A loader that walks the checkpoint (vLLM does) then expects a
+    # ``weight_scale`` for those too and dies with e.g. KeyError: 'embed_tokens.weight_scale'.
+    # List every weight that was not quantized so the exclusion set is complete.
+    quantized = {
+        name
+        for name, module in root.named_modules()
+        if is_quantized_linear(module)
+        and f"{name}.weight" in export_sd
+        and f"{name}.weight_scale" in export_sd
+    }
+    unquantized = sorted(
+        key[: -len(".weight")]
+        for key in state_dict
+        if key.endswith(".weight") and key[: -len(".weight")] not in quantized
+    )
+    exclude_modules = hf_quant_config["quantization"].get("exclude_modules", [])
+    for name in unquantized:
+        if name not in exclude_modules:
+            exclude_modules.append(name)
+        # A runtime matches this list against its own module prefix, which is usually
+        # nested relative to the checkpoint key (vLLM builds the draft's ``fc`` at
+        # ``model.fc`` via ``maybe_prefix``). A bare ``fc`` then fails to match, the layer
+        # is built quantized, and loading the bf16 weight into a packed parameter raises a
+        # size assertion. Add a suffix wildcard so the exclusion matches at any depth.
+        wildcard = f"*{name}"
+        if wildcard not in exclude_modules:
+            exclude_modules.append(wildcard)
+    # Runtimes fuse sibling projections into one layer whose name appears in no checkpoint
+    # key: q/k/v -> ``qkv_proj``, gate/up -> ``gate_up_proj``. Excluding only the individual
+    # names leaves the fused layer quantized, and its merged shard shapes then disagree with
+    # the unpacked weights being loaded into it. Emit the fused aliases whenever every
+    # component of a fusion group was excluded.
+    for fused, parts in (
+        ("qkv_proj", ("q_proj", "k_proj", "v_proj")),
+        ("gate_up_proj", ("gate_proj", "up_proj")),
+    ):
+        if all(any(p in name for name in exclude_modules) for p in parts):
+            alias = f"*{fused}"
+            if alias not in exclude_modules:
+                exclude_modules.append(alias)
+    hf_quant_config["quantization"]["exclude_modules"] = exclude_modules
+    config["quantization_config"] = dict(hf_quant_config["quantization"])
+    # ModelOpt names the format ``quant_algo``; vLLM's ModelConfig reads
+    # ``quant_cfg["quant_method"]`` and treats a config without that key as unquantized,
+    # then dies on the packed weight shapes. Emit both so either loader is satisfied.
+    # vLLM splits ModelOpt checkpoints into two backends: ``modelopt_fp4`` for the
+    # block-scaled NVFP4 layouts and ``modelopt`` for the per-tensor/per-channel ones.
+    quant_algo = str(hf_quant_config["quantization"].get("quant_algo") or "")
+    config["quantization_config"].setdefault(
+        "quant_method", "modelopt_fp4" if "NVFP4" in quant_algo.upper() else "modelopt"
+    )
+    # The exclusion list is read under two different keys. ModelOpt's own
+    # ``hf_quant_config.json`` nests it under ``quantization.exclude_modules``, but when a
+    # runtime parses the flat ``quantization_config`` block inside ``config.json`` it looks
+    # for ``ignore`` (vLLM's ModelOptQuantConfigBase.from_config). Emitting only
+    # ``exclude_modules`` there yields an empty exclusion set, every layer is built
+    # quantized, and loading an untouched bf16 weight into a packed parameter raises.
+    config["quantization_config"]["ignore"] = list(exclude_modules)
     config["torch_dtype"] = args.dtype
     (export_dir / "config.json").write_text(json.dumps(config, indent=2))
     (export_dir / "hf_quant_config.json").write_text(json.dumps(hf_quant_config, indent=2))
@@ -208,7 +493,7 @@ def main():
 
     before = sum(v.numel() * v.element_size() for v in state_dict.values())
     after = sum(v.numel() * v.element_size() for v in export_sd.values())
-    print(f"\n{QFORMAT}: {before / 2**30:.2f} GiB -> {after / 2**30:.2f} GiB")
+    print(f"\n{args.qformat}: {before / 2**30:.2f} GiB -> {after / 2**30:.2f} GiB")
     print(f"Exported to {export_dir}")
 
 

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calibration-free W4A16 weight-only PTQ for a speculative-decoding drafter.
+
+Block-wise ``max`` quantization derives every scale from the weight tensor itself, so
+this needs neither a dataset nor a forward pass -- only the drafter's safetensors file.
+That in turn means we never have to import the drafter's modeling code: each 2-D weight
+is wrapped in a throwaway ``nn.Linear`` under its checkpoint name, and ModelOpt's normal
+``quantizer_name`` patterns select over those names exactly as they would on the real
+module tree. Works for any drafter layout (DSpark / DFlash / EAGLE3 / Medusa).
+
+The format is fixed to ModelOpt's ``w4a16_nvfp4`` preset (E2M1 values, block 16, FP8 E4M3
+scales). It is calibration-free because the block scales are dynamic; AWQ formats are
+deliberately not offered, since ``awq_lite`` silently degrades to plain RTN when no
+``forward_loop`` is supplied.
+
+Example:
+    python quantize_drafter_w4a16.py \
+        --drafter_path nvidia/MiniMax-M3-DSpark \
+        --export_path ./MiniMax-M3-DSpark-W4A16
+"""
+
+import argparse
+import copy
+import json
+import shutil
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from safetensors.torch import load_file, save_file
+
+import modelopt.torch.quantization as mtq
+from modelopt.recipe.presets import QUANT_CFG_CHOICES
+from modelopt.torch.export.quant_utils import (
+    get_quant_config,
+    get_quantization_format,
+    get_weight_block_size,
+    get_weight_scaling_factor,
+    get_weight_scaling_factor_2,
+    to_quantized_weight,
+)
+from modelopt.torch.quantization.utils import is_quantized_linear
+
+# NVFP4 weight-only: block-16 E2M1 values with dynamic FP8 E4M3 scales, so every scale is
+# derived from the weight block itself and no calibration data is involved.
+QFORMAT = "w4a16_nvfp4"
+
+# The Markov head writes straight into the draft logits and is only a few percent of the
+# drafter, so the bits it would save are not worth the acceptance-rate risk. It is also not
+# a plain GEMM in the real module tree -- markov_w1 is an nn.Embedding, which ModelOpt's
+# stock presets already exclude via `parent_class: nn.Embedding`; the flat-linear view here
+# has lost the original module classes, so the exclusion has to be restated by name.
+# lm_head is excluded by the preset itself (see --quantize_lm_head).
+DEFAULT_EXCLUDE = ["*markov_head*"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--drafter_path", required=True, help="HF repo id or local dir of the drafter checkpoint."
+    )
+    parser.add_argument("--export_path", required=True, help="Output directory.")
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=["bfloat16", "float16", "float32"],
+        help="Compute dtype the weights are cast to before quantizing.",
+    )
+    parser.add_argument(
+        "--exclude",
+        nargs="*",
+        default=[],
+        metavar="PATTERN",
+        help="Extra fnmatch patterns to leave unquantized, in `quantizer_name` form. "
+        f"Appended to the defaults ({' '.join(DEFAULT_EXCLUDE)}), which always apply.",
+    )
+    parser.add_argument(
+        "--quantize_lm_head",
+        action="store_true",
+        help="Also quantize lm_head. It is the single largest drafter tensor, but it feeds "
+        "the acceptance test directly -- measure AL before shipping this.",
+    )
+    return parser.parse_args()
+
+
+def load_drafter(drafter_path: str) -> tuple[Path, dict[str, torch.Tensor]]:
+    """Resolve a local dir or HF repo id to (dir, state_dict)."""
+    local_dir = Path(drafter_path)
+    if not local_dir.is_dir():
+        from huggingface_hub import snapshot_download
+
+        local_dir = Path(snapshot_download(drafter_path))
+
+    shards = sorted(local_dir.glob("*.safetensors"))
+    assert shards, f"No .safetensors found under {local_dir}"
+    state_dict: dict[str, torch.Tensor] = {}
+    for shard in shards:
+        state_dict.update(load_file(shard))
+    return local_dir, state_dict
+
+
+def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -> nn.Module:
+    """Expose every 2-D weight as an nn.Linear whose module name is its checkpoint key.
+
+    Nested ModuleDicts are used so that ``named_modules()`` reproduces the dotted keys
+    (``layers.0.self_attn.q_proj``), which is what the preset's ``quantizer_name``
+    patterns match against.
+    """
+    root = nn.ModuleDict()
+    for key, weight in state_dict.items():
+        if weight.dim() != 2 or not key.endswith(".weight"):
+            continue
+        *parents, leaf = key[: -len(".weight")].split(".")
+        node = root
+        for part in parents:
+            if part not in node:
+                node[part] = nn.ModuleDict()
+            node = node[part]
+        out_features, in_features = weight.shape
+        linear = nn.Linear(in_features, out_features, bias=False, dtype=dtype)
+        linear.weight.data = weight.to(dtype)
+        node[leaf] = linear
+    return root
+
+
+def build_quant_cfg(exclude: list[str], quantize_lm_head: bool) -> dict:
+    """Take the shipped preset and layer the drafter-specific exclusions on top."""
+    quant_cfg = copy.deepcopy(QUANT_CFG_CHOICES[QFORMAT])
+    if quantize_lm_head:
+        quant_cfg["quant_cfg"].append(
+            {"quantizer_name": "*lm_head*weight_quantizer", "enable": True}
+        )
+    for pattern in DEFAULT_EXCLUDE + exclude:
+        quant_cfg["quant_cfg"].append({"quantizer_name": pattern, "enable": False})
+    return quant_cfg
+
+
+def export_quantized_state_dict(
+    root: nn.Module, state_dict: dict[str, torch.Tensor], dtype: torch.dtype
+) -> dict[str, torch.Tensor]:
+    """Pack each quantized weight and emit it alongside its scales.
+
+    Follows the unified-HF naming convention: ``w.weight`` / ``w.weight_scale`` /
+    ``w.weight_scale_2``. Untouched tensors are carried through in ``dtype``.
+    """
+    export_sd = {k: v.to(dtype) for k, v in state_dict.items()}
+    for name, module in root.named_modules():
+        if not is_quantized_linear(module) or not module.weight_quantizer.is_enabled:
+            continue
+        quantization = get_quantization_format(module)
+        assert quantization is not None, f"{name}: enabled quantizer resolved to no format"
+        weight_scale = get_weight_scaling_factor(module)
+        weight_scale_2 = get_weight_scaling_factor_2(module)
+        export_sd[f"{name}.weight"] = to_quantized_weight(
+            module.weight,
+            weight_scale,
+            quantization,
+            weight_scale_2,
+            get_weight_block_size(module),
+        )
+        export_sd[f"{name}.weight_scale"] = weight_scale
+        if weight_scale_2 is not None:
+            export_sd[f"{name}.weight_scale_2"] = weight_scale_2
+    return export_sd
+
+
+def main():
+    args = parse_args()
+    dtype = getattr(torch, args.dtype)
+
+    source_dir, state_dict = load_drafter(args.drafter_path)
+    root = build_linear_view(state_dict, dtype)
+
+    quant_cfg = build_quant_cfg(args.exclude, args.quantize_lm_head)
+    mtq.quantize(root, quant_cfg)  # no forward_loop: scales come from the weights
+    mtq.print_quant_summary(root)
+
+    export_sd = export_quantized_state_dict(root, state_dict, dtype)
+
+    export_dir = Path(args.export_path)
+    export_dir.mkdir(parents=True, exist_ok=True)
+    save_file(export_sd, export_dir / "model.safetensors", metadata={"format": "pt"})
+
+    config = json.loads((source_dir / "config.json").read_text())
+    hf_quant_config = get_quant_config(root)
+    config["quantization_config"] = hf_quant_config["quantization"]
+    config["torch_dtype"] = args.dtype
+    (export_dir / "config.json").write_text(json.dumps(config, indent=2))
+    (export_dir / "hf_quant_config.json").write_text(json.dumps(hf_quant_config, indent=2))
+
+    for extra in ("tokenizer.json", "tokenizer_config.json", "generation_config.json"):
+        if (source_dir / extra).is_file():
+            shutil.copy2(source_dir / extra, export_dir / extra)
+
+    before = sum(v.numel() * v.element_size() for v in state_dict.values())
+    after = sum(v.numel() * v.element_size() for v in export_sd.values())
+    print(f"\n{QFORMAT}: {before / 2**30:.2f} GiB -> {after / 2**30:.2f} GiB")
+    print(f"Exported to {export_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -157,8 +157,11 @@ def build_linear_view(state_dict: dict[str, torch.Tensor], dtype: torch.dtype) -
                 node[part] = nn.ModuleDict()
             node = node[part]
         out_features, in_features = weight.shape
-        linear = nn.Linear(in_features, out_features, bias=False, dtype=dtype)
-        linear.weight.data = weight.to(dtype)
+        # On meta, so nn.Linear skips allocating and randomly initializing a weight that
+        # the next line replaces anyway.
+        with torch.device("meta"):
+            linear = nn.Linear(in_features, out_features, bias=False, dtype=dtype)
+        linear.weight = nn.Parameter(weight.to(dtype), requires_grad=False)
         node[leaf] = linear
     return root
 

--- a/examples/speculative_decoding/scripts/quantize_drafter.py
+++ b/examples/speculative_decoding/scripts/quantize_drafter.py
@@ -120,15 +120,34 @@ def parse_args():
     return parser.parse_args()
 
 
+def auto_map_modules(config: dict) -> set[str]:
+    """Module basenames referenced by a config's ``auto_map``, e.g. {"modeling_x"}.
+
+    Values are either ``"modeling_x.XModel"`` or, for tokenizers, a list whose entries may
+    be null (``[null, "tokenization_x.XTokenizerFast"]``); a ``repo--`` prefix points at
+    another repository and is not a local file.
+    """
+    modules = set()
+    for value in (config.get("auto_map") or {}).values():
+        for ref in value if isinstance(value, list) else [value]:
+            if isinstance(ref, str) and "." in ref:
+                modules.add(ref.split("--")[-1].rsplit(".", 1)[0])
+    return modules
+
+
 def load_drafter(drafter_path: str) -> tuple[Path, dict[str, torch.Tensor]]:
     """Resolve a local dir or HF repo id to (dir, state_dict)."""
     local_dir = Path(drafter_path)
     if not local_dir.is_dir():
         from huggingface_hub import snapshot_download
 
+        # A drafter that ships custom modeling code references it from auto_map, and the
+        # export carries that config verbatim -- so those .py files have to be fetched too
+        # or the exported references dangle.
         local_dir = Path(
             snapshot_download(
-                drafter_path, allow_patterns=["*.safetensors", "config.json", *SIDECAR_FILES]
+                drafter_path,
+                allow_patterns=["*.safetensors", "config.json", "*.py", *SIDECAR_FILES],
             )
         )
 
@@ -332,11 +351,10 @@ def main():
     # A drafter that ships custom modeling code points at it from auto_map; the export
     # carries that config verbatim, so the .py files have to come along or the reference
     # dangles. (The DFlash/DSpark exports have no auto_map -- this is for the ones that do.)
-    if config.get("auto_map"):
-        for module in {ref.split("--")[-1].split(".")[0] for ref in config["auto_map"].values()}:
-            source_py = source_dir / f"{module}.py"
-            if source_py.is_file():
-                shutil.copy2(source_py, export_dir / source_py.name)
+    for module in auto_map_modules(config):
+        source_py = source_dir / f"{module}.py"
+        if source_py.is_file():
+            shutil.copy2(source_py, export_dir / source_py.name)
 
     before = sum(v.numel() * v.element_size() for v in state_dict.values())
     after = sum(v.numel() * v.element_size() for v in export_sd.values())

--- a/tools/launcher/common/specdec/quantize_drafter.sh
+++ b/tools/launcher/common/specdec/quantize_drafter.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Calibration-free PTQ for an exported speculative-decoding drafter.
+#
+# Required env vars:
+#   DRAFTER_CKPT — exported drafter path, or a training output_dir to auto-detect under
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source ${SCRIPT_DIR}/../service_utils.sh
+
+trap 'error_handler $0 $LINENO' ERR
+
+###################################################################################################
+
+DRAFTER="${DRAFTER_CKPT}"
+# Training writes exported-checkpoint-<step>/ under output_dir; take the newest. Only for a
+# local directory -- anything else (an HF repo id) is passed through for the script to
+# resolve. -V sorts numerically, so checkpoint-1000 beats checkpoint-900.
+if [ -d "${DRAFTER}" ] && [ ! -f "${DRAFTER}/config.json" ]; then
+    latest=$(find "${DRAFTER}" -maxdepth 1 -mindepth 1 -type d \
+        -name 'exported-checkpoint-*' -printf '%f\n' 2>/dev/null | sort -V | tail -1)
+    if [ -z "${latest}" ]; then
+        echo "ERROR: ${DRAFTER} is not a checkpoint and holds no exported-checkpoint-* directory."
+        exit 1
+    fi
+    DRAFTER="${DRAFTER}/${latest}"
+    echo "Auto-detected drafter: ${DRAFTER}"
+fi
+
+python modules/Model-Optimizer/examples/speculative_decoding/scripts/quantize_drafter.py \
+    --drafter_path "${DRAFTER}" \
+    "$@"

--- a/tools/launcher/common/specdec/quantize_drafter.sh
+++ b/tools/launcher/common/specdec/quantize_drafter.sh
@@ -27,17 +27,21 @@ trap 'error_handler $0 $LINENO' ERR
 
 ###################################################################################################
 
-DRAFTER=${DRAFTER_CKPT}
-# Training writes exported-checkpoint-<step>/ under output_dir; take the newest.
-if [ ! -f "${DRAFTER}/config.json" ]; then
-    DRAFTER=$(ls -d ${DRAFTER_CKPT}/exported-checkpoint-* 2>/dev/null | sort -t- -k3 -n | tail -1)
-    if [ -z "${DRAFTER}" ]; then
-        echo "ERROR: no drafter checkpoint at ${DRAFTER_CKPT}"
+DRAFTER="${DRAFTER_CKPT}"
+# Training writes exported-checkpoint-<step>/ under output_dir; take the newest. Only for a
+# local directory -- anything else (an HF repo id) is passed through for the script to
+# resolve. -V sorts numerically, so checkpoint-1000 beats checkpoint-900.
+if [ -d "${DRAFTER}" ] && [ ! -f "${DRAFTER}/config.json" ]; then
+    latest=$(find "${DRAFTER}" -maxdepth 1 -mindepth 1 -type d \
+        -name 'exported-checkpoint-*' -printf '%f\n' 2>/dev/null | sort -V | tail -1)
+    if [ -z "${latest}" ]; then
+        echo "ERROR: ${DRAFTER} is not a checkpoint and holds no exported-checkpoint-* directory."
         exit 1
     fi
+    DRAFTER="${DRAFTER}/${latest}"
     echo "Auto-detected drafter: ${DRAFTER}"
 fi
 
 python modules/Model-Optimizer/examples/speculative_decoding/scripts/quantize_drafter.py \
-    --drafter_path ${DRAFTER} \
-    ${@}
+    --drafter_path "${DRAFTER}" \
+    "$@"

--- a/tools/launcher/common/specdec/quantize_drafter.sh
+++ b/tools/launcher/common/specdec/quantize_drafter.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Calibration-free PTQ for an exported speculative-decoding drafter.
+#
+# Required env vars:
+#   DRAFTER_CKPT — exported drafter path, or a training output_dir to auto-detect under
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source ${SCRIPT_DIR}/../service_utils.sh
+
+trap 'error_handler $0 $LINENO' ERR
+
+###################################################################################################
+
+DRAFTER=${DRAFTER_CKPT}
+# Training writes exported-checkpoint-<step>/ under output_dir; take the newest.
+if [ ! -f "${DRAFTER}/config.json" ]; then
+    DRAFTER=$(ls -d ${DRAFTER_CKPT}/exported-checkpoint-* 2>/dev/null | sort -t- -k3 -n | tail -1)
+    if [ -z "${DRAFTER}" ]; then
+        echo "ERROR: no drafter checkpoint at ${DRAFTER_CKPT}"
+        exit 1
+    fi
+    echo "Auto-detected drafter: ${DRAFTER}"
+fi
+
+python modules/Model-Optimizer/examples/speculative_decoding/scripts/quantize_drafter.py \
+    --drafter_path ${DRAFTER} \
+    ${@}

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
@@ -1,0 +1,73 @@
+# Calibration-free NVFP4 PTQ of a DSpark drafter for Qwen3-8B.
+#
+# Takes an exported drafter (train one with hf_streaming_dspark.yaml, or point
+# drafter at a published checkpoint) and quantizes it weight-only to NVFP4, then
+# measures acceptance length so the cost is visible. No calibration data needed:
+# every scale comes from the weights.
+#
+# 2-step pipeline:
+#   task_0: Quantize the drafter (CPU-only, ~1 min for an 8B-class draft)
+#   task_1: Benchmark acceptance length on MT-Bench via vLLM
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml --yes
+
+job_name: Qwen3-8B_DSpark_PTQ_nvfp4
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+    # Exported drafter to quantize. /scratchspace/export is where the streaming
+    # examples leave theirs; a plain checkpoint dir or HF repo id also works.
+    draft_model: /scratchspace/export
+
+  # Step 1: Quantize. w4a16_nvfp4 keeps activations in bf16; use --qformat nvfp4
+  # for weight+activation (fixed input_scale 1.0, ~3.9% AL on Qwen3-8B).
+  #
+  # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
+  # drafters build their fused context-KV projection by reading qkv_proj.weight
+  # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
+  # `fc` is optional -- quantizing it saves ~3% more size for ~0.7% AL on
+  # Qwen3-8B (3.0186 vs 3.0392); add '*fc*' to keep it in bf16.
+  task_0:
+    script: common/specdec/quantize_drafter.sh
+    args:
+      - --qformat w4a16_nvfp4
+      - --export_path /scratchspace/export_quantized
+      - --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*'
+    environment:
+      - DRAFTER_CKPT: <<global_vars.draft_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
+
+  # Step 2: Acceptance length on MT-Bench. Compare against the same run with
+  # --draft_model_dir <<global_vars.draft_model>> to see what quantization cost.
+  task_1:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export_quantized
+      # DSPARK/DFLASH read --block_size, not --draft_length; must match the
+      # drafter's block_size (7 for dspark_qwen3_8b_block7).
+      - --block_size 7
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm DSPARK
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 32
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:nightly

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
@@ -30,7 +30,7 @@ pipeline:
   # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
   # drafters build their fused context-KV projection by reading qkv_proj.weight
   # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
-  # `fc` is optional -- quantizing it saves ~12% more size for ~0.7% AL on
+  # `fc` is optional -- quantizing it saves ~3% more size for ~0.7% AL on
   # Qwen3-8B (3.0186 vs 3.0392); add '*fc*' to keep it in bf16.
   task_0:
     script: common/specdec/quantize_drafter.sh

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
@@ -50,16 +50,14 @@ pipeline:
     script: common/specdec_bench/quick_check.sh
     args:
       - --draft_model_dir /scratchspace/export_quantized
-      # DFLASH reads --block_size, not --draft_length; must match the drafter's
-      # dflash_block_size.
+      # DSPARK/DFLASH read --block_size, not --draft_length; must match the
+      # drafter's dflash_block_size.
       - --block_size 16
       - --output_length 4096
       - --engine VLLM
       - --tp_size 1
       - --ep_size 1
-      # DSpark runs through the DFLASH path; the drafter's own config carries the
-      # DSpark heads.
-      - --speculative_algorithm DFLASH
+      - --speculative_algorithm DSPARK
       - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
       - --concurrency 32
     environment:

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
@@ -26,15 +26,18 @@ pipeline:
 
   # Step 1: Quantize. w4a16_nvfp4 keeps activations in bf16; use --qformat nvfp4
   # for weight+activation (fixed input_scale 1.0, ~3.9% AL on Qwen3-8B).
-  # DFlash-family drafters read qkv_proj.weight raw for their fused context-KV
-  # projection, so those layers must stay unquantized; o_proj and the MLP still
-  # quantize.
+  #
+  # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
+  # drafters build their fused context-KV projection by reading qkv_proj.weight
+  # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
+  # `fc` is optional -- quantizing it saves ~12% more size for ~0.7% AL on
+  # Qwen3-8B (3.0186 vs 3.0392); add '*fc*' to keep it in bf16.
   task_0:
     script: common/specdec/quantize_drafter.sh
     args:
       - --qformat w4a16_nvfp4
       - --export_path /scratchspace/export_quantized
-      - --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*' '*fc*'
+      - --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*'
     environment:
       - DRAFTER_CKPT: <<global_vars.draft_model>>
     slurm_config:

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml
@@ -1,0 +1,72 @@
+# Calibration-free NVFP4 PTQ of a DSpark drafter for Qwen3-8B.
+#
+# Takes an exported drafter (train one with hf_streaming_dspark.yaml, or point
+# drafter at a published checkpoint) and quantizes it weight-only to NVFP4, then
+# measures acceptance length so the cost is visible. No calibration data needed:
+# every scale comes from the weights.
+#
+# 2-step pipeline:
+#   task_0: Quantize the drafter (CPU-only, ~1 min for an 8B-class draft)
+#   task_1: Benchmark acceptance length on MT-Bench via vLLM
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml --yes
+
+job_name: Qwen3-8B_DSpark_PTQ_nvfp4
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+    # Exported drafter to quantize. /scratchspace/export is where the streaming
+    # examples leave theirs; a plain checkpoint dir or HF repo id also works.
+    draft_model: /scratchspace/export
+
+  # Step 1: Quantize. w4a16_nvfp4 keeps activations in bf16; use --qformat nvfp4
+  # for weight+activation (fixed input_scale 1.0, ~3.9% AL on Qwen3-8B).
+  # DFlash-family drafters read qkv_proj.weight raw for their fused context-KV
+  # projection, so those layers must stay unquantized; o_proj and the MLP still
+  # quantize.
+  task_0:
+    script: common/specdec/quantize_drafter.sh
+    args:
+      - --qformat w4a16_nvfp4
+      - --export_path /scratchspace/export_quantized
+      - --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*' '*fc*'
+    environment:
+      - DRAFTER_CKPT: <<global_vars.draft_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
+
+  # Step 2: Acceptance length on MT-Bench. Compare against the same run with
+  # --draft_model_dir <<global_vars.draft_model>> to see what quantization cost.
+  task_1:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export_quantized
+      # DFLASH reads --block_size, not --draft_length; must match the drafter's
+      # dflash_block_size.
+      - --block_size 16
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      # DSpark runs through the DFLASH path; the drafter's own config carries the
+      # DSpark heads.
+      - --speculative_algorithm DFLASH
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 32
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:nightly

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/specdec_bench.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/specdec_bench.yaml
@@ -32,13 +32,13 @@ pipeline:
 
   global_vars:
     hf_model: /hf-local/nvidia/Kimi-K2.5-NVFP4
-    # Trained+exported DFLASH draft; override: pipeline.global_vars.draft_model_dir=<path>
-    draft_model_dir: /hf-local/nvidia/Kimi-K2.5-DFlash
+    # Trained+exported DFLASH draft; override: pipeline.global_vars.draft_model=<path>
+    draft_model: /hf-local/nvidia/Kimi-K2.5-DFlash
 
   task_0:
     script: common/specdec_bench/run.sh
     args:
-      - --draft_model_dir <<global_vars.draft_model_dir>>
+      - --draft_model_dir <<global_vars.draft_model>>
       - --speculative_algorithm DFLASH
       - --engine VLLM
       - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/engine_args.json
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/engine_args.json
@@ -1,0 +1,8 @@
+{
+  "engine_args": {
+    "mamba_backend": "flashinfer",
+    "mamba_ssm_cache_dtype": "float16",
+    "enable_mamba_cache_stochastic_rounding": true,
+    "mamba_cache_philox_rounds": 5
+  }
+}

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_fp8.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_fp8.yaml
@@ -1,0 +1,90 @@
+# Calibration-free FP8 PTQ of the DSpark drafter for Nemotron-3.5-Lightning-30B-A3B.
+#
+# Same pipeline as hf_dspark_ptq_nvfp4.yaml in this directory, quantizing both
+# weights and activations to FP8 instead of weight-only NVFP4. Activations use a
+# fixed input_scale of 1.0, so no calibration data is needed. This is the
+# lossless recipe: AL 4.3289 vs 4.3296 for bf16 (-0.02%, inside run-to-run
+# noise), against -2.92% for nvfp4.
+#
+# 2-step pipeline:
+#   task_0: Quantize the drafter (CPU-only, well under a minute for this 0.97B draft)
+#   task_1: Benchmark acceptance length on MT-Bench via vLLM
+#
+# Usage:
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_fp8.yaml --yes
+
+job_name: Nemotron-3.5-Lightning-30B-A3B_DSpark_PTQ_fp8
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+    draft_model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
+
+  # Step 1: Quantize. fp8 quantizes weights and activations; use --qformat
+  # fp8_pc_pt for per-channel weights with dynamic per-token activations, which
+  # needs no activation scale at all (4.3411 here, also within noise).
+  #
+  # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
+  # drafters build their fused context-KV projection by reading qkv_proj.weight
+  # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
+  # Unlike the nvfp4 recipe, `fc` is left quantized: FP8 is lossless here, so
+  # there is no accuracy reason to keep it in bf16.
+  #
+  # This drafter has has_lm_head=false (it shares the target's), so
+  # --quantize_lm_head does not apply. embed_tokens is 36% of the checkpoint but
+  # is excluded by default: it is an nn.Embedding the drafter inherits.
+  task_0:
+    script: common/specdec/quantize_drafter.sh
+    args:
+      - --qformat fp8
+      - --export_path /scratchspace/export_quantized
+      - --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*'
+    environment:
+      - DRAFTER_CKPT: <<global_vars.draft_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
+
+  # Step 2: Acceptance length on MT-Bench. Compare against the same run with
+  # --draft_model_dir <<global_vars.draft_model>> to see what quantization cost.
+  #
+  # This target is a hybrid Mamba-MoE model, so it differs from the Qwen3 example
+  # in three ways. It needs TP8. Startup is dominated by Mamba2 kernel warmup
+  # (~6 min before the engine is ready), not weight loading. And it needs the
+  # mamba engine settings from the model card (runtime_params below): without
+  # them the first draft token is rejected ~88% of the time and acceptance length
+  # collapses from ~4.3 to ~1.5, while every later position stays normal -- so it
+  # looks like a bad drafter rather than a serving misconfiguration.
+  task_1:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export_quantized
+      # DSPARK reads --block_size, not --draft_length; must match the drafter's
+      # block_size, which is 8 for this checkpoint.
+      - --block_size 8
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 8
+      - --ep_size 1
+      - --speculative_algorithm DSPARK
+      - --trust_remote_code
+      - --temperature 0
+      - --runtime_params modules/Model-Optimizer/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/engine_args.json
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 8
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # The model card sets this on every Nemotron-3.5 serve command.
+      - VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:nightly

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
@@ -1,0 +1,88 @@
+# Calibration-free NVFP4 PTQ of the DSpark drafter for Nemotron-3.5-Lightning-30B-A3B.
+#
+# Same pipeline as examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml, against a hybrid
+# Mamba-MoE target and the published DSpark drafter. Quantizes weight-only to NVFP4,
+# then measures acceptance length so the cost is visible. No calibration data needed:
+# every scale comes from the weights.
+#
+# 2-step pipeline:
+#   task_0: Quantize the drafter (CPU-only, well under a minute for this 0.97B draft)
+#   task_1: Benchmark acceptance length on MT-Bench via vLLM
+#
+# Usage:
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml --yes
+
+job_name: Nemotron-3.5-Lightning-30B-A3B_DSpark_PTQ_nvfp4
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+    draft_model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
+
+  # Step 1: Quantize. w4a16_nvfp4 keeps activations in bf16; use --qformat nvfp4
+  # for weight+activation (fixed input_scale 1.0).
+  #
+  # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
+  # drafters build their fused context-KV projection by reading qkv_proj.weight
+  # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
+  # `fc` is optional -- quantizing it saves ~4% more size for ~1.3% AL on this
+  # model (4.2334 vs 4.2899); add '*fc*' to keep it in bf16.
+  #
+  # This drafter has has_lm_head=false (it shares the target's), so
+  # --quantize_lm_head does not apply. embed_tokens is 37% of the checkpoint but
+  # is excluded by default: it is an nn.Embedding the drafter inherits.
+  task_0:
+    script: common/specdec/quantize_drafter.sh
+    args:
+      - --qformat w4a16_nvfp4
+      - --export_path /scratchspace/export_quantized
+      - --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*'
+    environment:
+      - DRAFTER_CKPT: <<global_vars.draft_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
+
+  # Step 2: Acceptance length on MT-Bench. Compare against the same run with
+  # --draft_model_dir <<global_vars.draft_model>> to see what quantization cost.
+  #
+  # This target is a hybrid Mamba-MoE model, so it differs from the Qwen3 example
+  # in three ways. It needs TP8. Startup is dominated by Mamba2 kernel warmup
+  # (~6 min before the engine is ready), not weight loading. And it needs the
+  # mamba engine settings from the model card (runtime_params below): without
+  # them the first draft token is rejected ~88% of the time and acceptance length
+  # collapses from ~4.3 to ~1.5, while every later position stays normal -- so it
+  # looks like a bad drafter rather than a serving misconfiguration.
+  task_1:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export_quantized
+      # DSPARK reads --block_size, not --draft_length; must match the drafter's
+      # block_size, which is 8 for this checkpoint.
+      - --block_size 8
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 8
+      - --ep_size 1
+      - --speculative_algorithm DSPARK
+      - --trust_remote_code
+      - --temperature 0
+      - --runtime_params modules/Model-Optimizer/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/engine_args.json
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 8
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # The model card sets this on every Nemotron-3.5 serve command.
+      - VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:nightly

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
@@ -1,37 +1,38 @@
-# Calibration-free NVFP4 PTQ of a DSpark drafter for Qwen3-8B.
+# Calibration-free NVFP4 PTQ of the DSpark drafter for Nemotron-3.5-Lightning-30B-A3B.
 #
-# Takes an exported drafter (train one with hf_streaming_dspark.yaml, or point
-# drafter at a published checkpoint) and quantizes it weight-only to NVFP4, then
-# measures acceptance length so the cost is visible. No calibration data needed:
+# Same pipeline as examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml, against a hybrid
+# Mamba-MoE target and the published DSpark drafter. Quantizes weight-only to NVFP4,
+# then measures acceptance length so the cost is visible. No calibration data needed:
 # every scale comes from the weights.
 #
 # 2-step pipeline:
-#   task_0: Quantize the drafter (CPU-only, ~1 min for an 8B-class draft)
+#   task_0: Quantize the drafter (CPU-only, well under a minute for this 0.97B draft)
 #   task_1: Benchmark acceptance length on MT-Bench via vLLM
 #
 # Usage:
-#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml --yes
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml --yes
 
-job_name: Qwen3-8B_DSpark_PTQ_nvfp4
+job_name: Nemotron-3.5-Lightning-30B-A3B_DSpark_PTQ_nvfp4
 pipeline:
   allow_to_fail: false
   skip: false
   note:
 
   global_vars:
-    hf_model: /hf-local/Qwen/Qwen3-8B
-    # Exported drafter to quantize. /scratchspace/export is where the streaming
-    # examples leave theirs; a plain checkpoint dir or HF repo id also works.
-    draft_model: /scratchspace/export
+    hf_model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+    draft_model: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
 
   # Step 1: Quantize. w4a16_nvfp4 keeps activations in bf16; use --qformat nvfp4
-  # for weight+activation (fixed input_scale 1.0, ~3.9% AL on Qwen3-8B).
+  # for weight+activation (fixed input_scale 1.0).
   #
   # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
   # drafters build their fused context-KV projection by reading qkv_proj.weight
   # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
-  # `fc` is optional -- quantizing it saves ~12% more size for ~0.7% AL on
-  # Qwen3-8B (3.0186 vs 3.0392); add '*fc*' to keep it in bf16.
+  # `fc` is optional -- add '*fc*' to keep it in bf16 at the cost of size.
+  #
+  # This drafter has has_lm_head=false (it shares the target's), so
+  # --quantize_lm_head does not apply. embed_tokens is 37% of the checkpoint but
+  # is excluded by default: it is an nn.Embedding the drafter inherits.
   task_0:
     script: common/specdec/quantize_drafter.sh
     args:
@@ -49,16 +50,20 @@ pipeline:
 
   # Step 2: Acceptance length on MT-Bench. Compare against the same run with
   # --draft_model_dir <<global_vars.draft_model>> to see what quantization cost.
+  #
+  # The target is a hybrid Mamba-MoE model, which changes two things versus the
+  # Qwen3 example: it needs TP8, and startup is dominated by Mamba2 kernel warmup
+  # (~6 min before the engine is ready) rather than weight loading.
   task_1:
     script: common/specdec_bench/quick_check.sh
     args:
       - --draft_model_dir /scratchspace/export_quantized
-      # DSPARK/DFLASH read --block_size, not --draft_length; must match the
-      # drafter's block_size (7 for dspark_qwen3_8b_block7).
-      - --block_size 7
+      # DSPARK reads --block_size, not --draft_length; must match the drafter's
+      # block_size, which is 8 for this checkpoint.
+      - --block_size 8
       - --output_length 4096
       - --engine VLLM
-      - --tp_size 1
+      - --tp_size 8
       - --ep_size 1
       - --speculative_algorithm DSPARK
       - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
@@ -68,6 +73,6 @@ pipeline:
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 1
-      ntasks_per_node: 1
-      gpus_per_node: 1
+      ntasks_per_node: 8
+      gpus_per_node: 8
       container: vllm/vllm-openai:nightly

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
@@ -28,7 +28,8 @@ pipeline:
   # The q/k/v exclusions are mandatory, not a tuning choice: DFlash-family
   # drafters build their fused context-KV projection by reading qkv_proj.weight
   # raw, which cannot be a packed tensor. o_proj and the MLP still quantize.
-  # `fc` is optional -- add '*fc*' to keep it in bf16 at the cost of size.
+  # `fc` is optional -- quantizing it saves ~4% more size for ~1.3% AL on this
+  # model (4.2334 vs 4.2899); add '*fc*' to keep it in bf16.
   #
   # This drafter has has_lm_head=false (it shares the target's), so
   # --quantize_lm_head does not apply. embed_tokens is 37% of the checkpoint but

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml
@@ -52,9 +52,13 @@ pipeline:
   # Step 2: Acceptance length on MT-Bench. Compare against the same run with
   # --draft_model_dir <<global_vars.draft_model>> to see what quantization cost.
   #
-  # The target is a hybrid Mamba-MoE model, which changes two things versus the
-  # Qwen3 example: it needs TP8, and startup is dominated by Mamba2 kernel warmup
-  # (~6 min before the engine is ready) rather than weight loading.
+  # This target is a hybrid Mamba-MoE model, so it differs from the Qwen3 example
+  # in three ways. It needs TP8. Startup is dominated by Mamba2 kernel warmup
+  # (~6 min before the engine is ready), not weight loading. And it needs the
+  # mamba engine settings from the model card (runtime_params below): without
+  # them the first draft token is rejected ~88% of the time and acceptance length
+  # collapses from ~4.3 to ~1.5, while every later position stays normal -- so it
+  # looks like a bad drafter rather than a serving misconfiguration.
   task_1:
     script: common/specdec_bench/quick_check.sh
     args:
@@ -67,13 +71,18 @@ pipeline:
       - --tp_size 8
       - --ep_size 1
       - --speculative_algorithm DSPARK
+      - --trust_remote_code
+      - --temperature 0
+      - --runtime_params modules/Model-Optimizer/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/engine_args.json
       - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
-      - --concurrency 32
+      - --concurrency 8
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # The model card sets this on every Nemotron-3.5 serve command.
+      - VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 1
-      ntasks_per_node: 8
+      ntasks_per_node: 1
       gpus_per_node: 8
       container: vllm/vllm-openai:nightly

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_streaming_dspark_warmstart.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_streaming_dspark_warmstart.yaml
@@ -56,7 +56,7 @@ pipeline:
     # config.json layer-type vocabulary already patched for tf5 (see header).
     hf_model: /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
     # The published drafter the warm start continues from.
-    drafter: /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
+    draft_model: /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
 
   # Build /scratchspace/data/train.jsonl. Point data.data_path at the full
   # Spec-Decoding-Dataset-v2 corpus to reproduce; eagle_utils also accepts a
@@ -80,7 +80,7 @@ pipeline:
       # causal attention and attention sink all come from this recipe — see header.
       - --config modules/Model-Optimizer/modelopt_recipes/huggingface/models/nvidia/Nemotron-3.5-Lightning-30B-A3B-BF16/speculative_decoding/dspark_warmstart.yaml
       - model.model_name_or_path=<<global_vars.hf_model>>
-      - dflash.dflash_init_checkpoint=<<global_vars.drafter>>
+      - dflash.dflash_init_checkpoint=<<global_vars.draft_model>>
       - data.data_path=/scratchspace/data/train.jsonl
       # The stock Nemotron template has no {% generation %} tags; without a tagged copy
       # answer_only_loss trains on an all-zero mask (see header).


### PR DESCRIPTION
### What does this PR do?

Type of change: new example

Adds `examples/speculative_decoding/scripts/quantize_drafter.py`, a CLI that quantizes an exported speculative-decoding drafter to FP8 or NVFP4 — weight-only or weight+activation — with no calibration data.

It needs no modeling code either. Exported drafters such as [`nvidia/MiniMax-M3-DSpark`](https://huggingface.co/nvidia/MiniMax-M3-DSpark) have no importable model class, so each 2-D weight is wrapped in a throwaway `nn.Linear` under its checkpoint key and ModelOpt's usual `quantizer_name` patterns select over those names. Works for any drafter layout (DSpark / DFlash / EAGLE3 / Medusa).

**Formats:** `w4a16_nvfp4`, `nvfp4`, `fp8`, `fp8_pc_pt` — the ModelOpt formats vLLM's backend can actually serve. AWQ is deliberately not offered, since `awq_lite` silently degrades to plain RTN without a `forward_loop`.

**Static activation scales without calibration.** `fp8` and `nvfp4` normally need an activation amax *measured* on calibration data; a fixed `input_scale` of 1.0 is applied instead. That works because acceptance length is governed almost entirely by **clipping**, not resolution:

Sweeping the fixed scale over three decades (same setup as the Testing section below; bf16 baseline 3.1423):

| `input_scale` | amax | FP8 AL | vs bf16 | NVFP4 AL | vs bf16 |
|---|---|---|---|---|---|
| 0.003 | 1.3 | 2.2204 | -29.34% | 2.2076 | -29.75% |
| 0.01 | 4.5 | 2.6719 | -14.97% | 2.6641 | -15.22% |
| 0.03 | 13.4 | 2.9751 | -5.32% | 2.9259 | -6.89% |
| 0.1 | 44.8 | 3.1013 | -1.31% | 3.0206 | -3.88% |
| 0.2 | 89.6 | 3.1178 | -0.78% | 3.0015 | -4.48% |
| 0.3 | 134.4 | 3.1370 | -0.17% | 3.0222 | -3.82% |
| 0.5 | 224.0 | 3.1268 | -0.50% | 3.0360 | -3.38% |
| **1.0 (default)** | **448.0** | **3.1457** | **+0.11%** | **3.0193** | **-3.91%** |
| 2.0 | 896.0 | 3.1354 | -0.22% | 3.0172 | -3.98% |
| 4.0 | 1792.0 | 3.1245 | -0.57% | 3.0034 | -4.42% |

Both formats fall off a cliff below ~0.03, where the declared range sits far under the activations' true magnitude and most of the tensor is clipped. Both then sit on a flat plateau from ~0.3 to 4.0 **with no drop-off at the top**, so the scale only has to be big enough. 1.0 is the middle of that plateau, which is why it is hardcoded rather than exposed. NVFP4 trails FP8 by a roughly constant 3.5% across the plateau — that gap is the 4-bit resolution cost, and no choice of scale recovers it.

Deriving the amax from the weights instead was tried and does not work: `max|W|` averages 0.79 while a RMSNorm'd activation is O(1) with outlier channels in the tens, so the range lands 1–2 orders of magnitude low and clips, measuring -31% to -46% AL.

**Where calibration would go.** All of this sits behind `resolve_activation_scales()`, the single place deciding where a static amax comes from. Real calibration slots in ahead of the fixed fallback with no change to the CLI or the call site, and composes because `set_static_activation_amax()` skips quantizers that already have an amax:

```python
if calib_forward_loop is not None:
    mtq.calibrate(root, quant_cfg["algorithm"], forward_loop=calib_forward_loop)
set_static_activation_amax(root)   # fills in what calibration did not reach
```

**Serving a quantized drafter.** Four things had to be written into the exported checkpoint before vLLM would load one:

- emit `quant_method` (`modelopt_fp4` / `modelopt`) — vLLM reads that key, ModelOpt writes only `quant_algo`
- emit the exclusion list under `ignore` too — that is the key read from the flat `quantization_config`; `exclude_modules` alone yields an empty exclusion set
- add `*<name>` wildcards so exclusions match a runtime's nested module prefix (`model.fc`) rather than the checkpoint key (`fc`)
- add `*qkv_proj` / `*gate_up_proj` aliases for layers a runtime fuses, whose names appear in no checkpoint key

Nothing is then needed on the caller side. **This closes the open question left in the previous revision of this PR: vLLM does read `quantization_config` off the draft checkpoint.** `ModelConfig._verify_quantization` fills `quantization` in from `quant_method` when it is unset, so once the export declares that key — the first fix above — detection works on its own. Verified on Nemotron-3.5-Lightning passing nothing: `Detected ModelOpt NVFP4 checkpoint (quant_algo=NVFP4)` → `FlashInferCuteDslNvFp4LinearKernel`, AL 4.278 against 4.203 measured earlier.

`specdec_bench` also gains a `DSPARK` algorithm, which it did not have: an exported `Qwen3DSparkModel` would otherwise have to go through `DFLASH` and be built with vLLM `method="dflash"`. The branch sets `method="dspark"` and leaves `draft_sample_method` on vLLM's own default of `greedy`. A target whose fused-collective workspace (sized at CUDA-graph capture) overflows at large speculative batches can disable graphs with `--runtime_params '{"engine_args": {"enforce_eager": true}}'`.

For DFlash-family drafters, `qwen3_dflash.py` builds its fused context-KV projection by reading `qkv_proj.weight` raw and calling `F.linear`, which cannot consume a packed weight. Keep those layers in bf16 with `--exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*'`; `o_proj` and the MLP — the bulk of the drafter — still quantize. That exclusion is mandatory, not a tuning choice.

`fc` (the projection from the target's captured layers into the draft) is the one real knob, and it is a genuine trade rather than a free win — see the Testing section for both models' numbers. The examples quantize it; add `'*fc*'` to the exclude list to keep it in bf16.

`embed_tokens`, `markov_head` and `confidence_head` are excluded by default: they are 2-D so the flat view treats them as GEMMs, but they are embeddings or a single-output projection. `lm_head` is excluded by the preset itself — unlike on a base model it is 37% of this drafter's parameters, so `--quantize_lm_head` is a real lever (~1.9 GiB), but measure AL first. The flag re-enables both of `lm_head`'s quantizers; re-enabling only the weight one would ship a W+A checkpoint whose `lm_head` has no `input_scale` while the config still advertises it as quantized.

### Usage

```bash
# weight+activation FP8, calibration-free, lossless on both models measured below
python scripts/quantize_drafter.py \
    --drafter_path deepseek-ai/dspark_qwen3_8b_block7 \
    --qformat fp8 \
    --export_path ./dspark-qwen3-8b-fp8 \
    --exclude '*q_proj*' '*k_proj*' '*v_proj*' '*qkv_proj*'

# smallest: weight-only NVFP4
python scripts/quantize_drafter.py \
    --drafter_path nvidia/MiniMax-M3-DSpark \
    --qformat w4a16_nvfp4 \
    --export_path ./MiniMax-M3-DSpark-W4A16
```

Or end to end on Slurm — quantize, then measure AL — via the launcher examples added here, one per target:

```bash
uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_dspark_ptq_nvfp4.yaml --yes
uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_dspark_ptq_nvfp4.yaml --yes
```

Serving one, if you are not going through `specdec_bench`:

```python
speculative_config = {
    "method": "dspark",
    "model": "./dspark-qwen3-8b-fp8",   # quantization is read from its config.json
    "num_speculative_tokens": 7,
}
```

### Testing

Two targets with different architectures, so the conclusions are not one model's quirk:

* **Qwen3-8B** (dense transformer) + [`deepseek-ai/dspark_qwen3_8b_block7`](https://huggingface.co/deepseek-ai/dspark_qwen3_8b_block7), `block_size` 7, TP1.
* **Nemotron-3.5-Lightning-30B-A3B** (hybrid Mamba-MoE) + [`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark), `block_size` 8, TP8, with the mamba engine settings the model card pins (`mamba_backend=flashinfer`, `mamba_ssm_cache_dtype=float16`, stochastic SSM-cache rounding).

Both: MT-Bench 80 questions, greedy, one vLLM instance per point.

| recipe | activations | Qwen3-8B AL | vs bf16 | Nemotron-3.5 AL | vs bf16 |
|---|---|---|---|---|---|
| bf16 baseline | — | 3.1423 | — | 4.3296 | — |
| **`fp8`** | static, `input_scale` 1.0 | **3.1457** | **+0.11%** | **4.3289** | **-0.02%** |
| `fp8_pc_pt` | dynamic per-token | 3.1228 | -0.62% | 4.3411 | +0.26% |
| `w4a16_nvfp4`, `fc` in bf16 | bf16 (weight-only) | 3.0392 | -3.28% | 4.2899 | -0.92% |
| `w4a16_nvfp4`, `fc` quantized | bf16 (weight-only) | 3.0186 | -3.94% | 4.2334 | -2.22% |
| **`nvfp4`** | static, `input_scale` 1.0 | **3.0193** | **-3.91%** | **4.2030** | **-2.92%** |

**FP8 weight+activation at the fixed `input_scale` of 1.0 is lossless on both.** +0.11% and -0.02% are both inside run-to-run noise — the Nemotron baseline was measured twice under identical settings and the two runs differ by 0.94% (4.3093 / 4.3499), which sets the resolution of that column. On the same reading, `fp8` and `fp8_pc_pt` are indistinguishable on Nemotron; the dynamic variant only pulls ahead on Qwen3. NVFP4 costs 3-4% on Qwen3 and 2-3% on Nemotron, i.e. the 4-bit weight resolution is the real price and it is model-dependent but bounded.

Whether to quantize `fc` is a per-model call rather than a general recommendation — it buys a few percent of size for an AL cost that differs by ~2x between these two drafters:

| `fc` bf16 → quantized | Qwen3-8B | Nemotron-3.5 |
|---|---|---|
| checkpoint size | 3.293 → 3.181 GiB (-3.4%) | 1.316 → 1.258 GiB (-4.4%) |
| AL | 3.0392 → 3.0186 (-0.68%) | 4.2899 → 4.2334 (-1.32%) |

`fc` itself is only 3.5% (Qwen3) / 4.5% (Nemotron) of drafter parameters; `embed_tokens` is the bulk (26% / 36%) and is excluded by default.

The Qwen3 `w4a16_nvfp4` rows were measured in a later session than the rest of that column; the `fc`-in-bf16 run reproduced the original number to four decimals (3.0392), so the column is internally comparable.

Also validated on `nvidia/MiniMax-M3-DSpark`: `w4a16_nvfp4` runs in 67 s on CPU, 9.98 GiB (fp32) -> 3.51 GiB; all 43 quantized tensors round-trip within 0.0952 relative error; the 29 untouched tensors are bit-identical to `bf16(source)`.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (example-only)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ❌ — validated manually as above. Can add a `tests/examples/speculative_decoding/` test over a small synthetic drafter if wanted before merge.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (example-only)
- Did you get Claude approval on this PR?: ❌ (not yet run)

### Additional Information

The measurements above are one drafter on one target with one benchmark; the plateau's location and the ~3.5% NVFP4 gap should be re-measured before assuming they carry to a different drafter.

Note when reading an exported checkpoint: `input_scale` is `amax/448` for FP8 but `amax/(6*448)` for NVFP4, so the one fixed amax records as 1.0 in an FP8 checkpoint and 0.1667 in an NVFP4 one. Both mean the same activation range.
