### PR TITLE
Propagate candidate-library import failures

### DIFF
--- a/modelopt/torch/puzzletron/stages/pipeline.py
+++ b/modelopt/torch/puzzletron/stages/pipeline.py
@@ -1000,32 +1000,29 @@ def build_library_stage(config: dict[str, Any], manifest: StageManifest):
 
             launch_build_replacement_library(hydra_cfg)
             _calculate_static_workload_stats(config, hydra_cfg)
-            try:
-                from ..candidates import build_candidate_library_from_checkpoint
+            from ..candidates import build_candidate_library_from_checkpoint
 
-                library_cfg = config.get("build_replacement_library") or {}
-                configured_parent = library_cfg.get("source_checkpoint_dir")
-                parent_dir = (
-                    Path(configured_parent).resolve() if configured_parent else scoring_parent.path
+            library_cfg = config.get("build_replacement_library") or {}
+            configured_parent = library_cfg.get("source_checkpoint_dir")
+            parent_dir = (
+                Path(configured_parent).resolve() if configured_parent else scoring_parent.path
+            )
+            if parent_dir.resolve() != scoring_parent.path.resolve():
+                raise RuntimeError(
+                    "build-library source does not match the resolved scoring parent: "
+                    f"{parent_dir} != {scoring_parent.path}"
                 )
-                if parent_dir.resolve() != scoring_parent.path.resolve():
-                    raise RuntimeError(
-                        "build-library source does not match the resolved scoring parent: "
-                        f"{parent_dir} != {scoring_parent.path}"
-                    )
-                build_candidate_library_from_checkpoint(
-                    parent_dir,
-                    search_space=config.get("search_space") or {},
-                    output_path=candidate_library_path,
-                    puzzle_dir=puzzle_dir,
-                    include_noops=bool(library_cfg.get("include_noops", True)),
-                    include_bypass=bool(library_cfg.get("include_bypass", True)),
-                    stats_paths=(stats_path,) if stats_path.is_file() else (),
-                    metadata={"library_settings": config.get("library") or {}},
-                    hidden_width=library_cfg.get("hidden_width"),
-                )
-            except ImportError:
-                pass
+            build_candidate_library_from_checkpoint(
+                parent_dir,
+                search_space=config.get("search_space") or {},
+                output_path=candidate_library_path,
+                puzzle_dir=puzzle_dir,
+                include_noops=bool(library_cfg.get("include_noops", True)),
+                include_bypass=bool(library_cfg.get("include_bypass", True)),
+                stats_paths=(stats_path,) if stats_path.is_file() else (),
+                metadata={"library_settings": config.get("library") or {}},
+                hidden_width=library_cfg.get("hidden_width"),
+            )
         dist.barrier()
     return complete_stage(
         config,

--- a/modelopt/torch/puzzletron/stages/pipeline.py
+++ b/modelopt/torch/puzzletron/stages/pipeline.py
@@ -1000,6 +1000,8 @@ def build_library_stage(config: dict[str, Any], manifest: StageManifest):
 
             launch_build_replacement_library(hydra_cfg)
             _calculate_static_workload_stats(config, hydra_cfg)
+            # Keep this stage-local so handler registration and config preflight do not
+            # load build-library implementation dependencies before the stage executes.
             from ..candidates import build_candidate_library_from_checkpoint
 
             library_cfg = config.get("build_replacement_library") or {}

--- a/tests/unit/torch/puzzletron/test_sparse_runtime_stats.py
+++ b/tests/unit/torch/puzzletron/test_sparse_runtime_stats.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import sys
 from contextlib import nullcontext
@@ -1062,6 +1077,51 @@ def test_build_library_refreshes_static_stats_for_each_vllm_mode(
     build_library_stage(config, StageManifest(stage="build_library", config=config))
 
     assert calls == ["library", "static", "candidates"]
+
+
+def test_build_library_propagates_candidate_module_import_error(tmp_path, monkeypatch):
+    teacher_dir = tmp_path / "teacher"
+    teacher_dir.mkdir()
+    config = {
+        "experiment": {"dir": str(tmp_path)},
+        "build_replacement_library": {},
+        "search_space": {},
+    }
+    hydra_cfg = OmegaConf.create(
+        {
+            "puzzle_dir": str(tmp_path),
+            "build_replacement_library": {},
+            "calc_subblock_stats": {"subblock_stats_filename": "subblock_stats.json"},
+        }
+    )
+
+    class ScoringParent:
+        path = teacher_dir
+
+        @staticmethod
+        def to_dict():
+            return {"path": str(teacher_dir)}
+
+    monkeypatch.setattr(pipeline_stages, "load_runtime_hydra_config", lambda _: hydra_cfg)
+    monkeypatch.setattr(
+        pipeline_stages,
+        "ensure_scoring_parent",
+        lambda *_args, **_kwargs: ScoringParent(),
+    )
+    monkeypatch.setattr(pipeline_stages, "_distributed", lambda _: nullcontext())
+    monkeypatch.setattr(pipeline_stages.dist, "is_master", lambda: True)
+    monkeypatch.setattr(pipeline_stages.dist, "barrier", lambda: None)
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.replacement_library.build_replacement_library.launch_build_replacement_library",
+        lambda _: None,
+    )
+    monkeypatch.setattr(pipeline_stages, "_calculate_static_workload_stats", lambda *_args: None)
+    monkeypatch.setitem(sys.modules, "modelopt.torch.puzzletron.candidates", None)
+
+    with pytest.raises(ImportError, match="candidates"):
+        build_library_stage(config, StageManifest(stage="build_library", config=config))
+
+    assert not (tmp_path / "manifests" / "build_library.json").exists()
 
 
 def test_sparse_runtime_selection_is_unique_and_layer_independent():

--- a/tests/unit/torch/puzzletron/test_sparse_runtime_stats.py
+++ b/tests/unit/torch/puzzletron/test_sparse_runtime_stats.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tests for Puzzletron sparse runtime statistics and library-building stages."""
+
 import json
 import sys
 from contextlib import nullcontext
@@ -1079,7 +1081,14 @@ def test_build_library_refreshes_static_stats_for_each_vllm_mode(
     assert calls == ["library", "static", "candidates"]
 
 
-def test_build_library_propagates_candidate_module_import_error(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "failure_source",
+    ["candidate_module_import", "candidate_library_build"],
+    ids=("candidate-module-import", "candidate-library-build"),
+)
+def test_build_library_propagates_candidate_import_errors_without_success_manifest(
+    tmp_path, monkeypatch, failure_source
+):
     teacher_dir = tmp_path / "teacher"
     teacher_dir.mkdir()
     config = {
@@ -1116,9 +1125,21 @@ def test_build_library_propagates_candidate_module_import_error(tmp_path, monkey
         lambda _: None,
     )
     monkeypatch.setattr(pipeline_stages, "_calculate_static_workload_stats", lambda *_args: None)
-    monkeypatch.setitem(sys.modules, "modelopt.torch.puzzletron.candidates", None)
+    if failure_source == "candidate_module_import":
+        monkeypatch.setitem(sys.modules, "modelopt.torch.puzzletron.candidates", None)
+        error_match = "candidates"
+    else:
+        error_match = "candidate library build failed"
 
-    with pytest.raises(ImportError, match="candidates"):
+        def raise_candidate_library_import_error(*_args, **_kwargs):
+            raise ImportError(error_match)
+
+        monkeypatch.setattr(
+            "modelopt.torch.puzzletron.candidates.build_candidate_library_from_checkpoint",
+            raise_candidate_library_import_error,
+        )
+
+    with pytest.raises(ImportError, match=error_match):
         build_library_stage(config, StageManifest(stage="build_library", config=config))
 
     assert not (tmp_path / "manifests" / "build_library.json").exists()


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

**Problem:** The build-library stage wraps both the candidate-builder import and candidate-library construction in a broad `ImportError` handler. A missing dependency or nested import failure is therefore discarded, and the stage continues until a later output check reports only that the candidate library is missing.

**Why this change:** The original import failure identifies the actionable cause. Preserving it is more useful than converting it into a delayed missing-artifact failure, and it prevents the stage from appearing to progress after a required producer failed.

**What changed:** The broad `ImportError` suppression is removed. Candidate-builder import and construction failures now propagate from the build-library stage.

**Outcome:** A campaign fails at the actual dependency boundary with the original error, and no successful build-library manifest is written for that failed execution.

### Testing

Puzzletron unit coverage verifies that candidate-module import failures and builder-raised `ImportError` failures propagate without creating a build-library success manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Candidate-library generation errors are now surfaced instead of being silently skipped.
  * Build failures no longer produce a misleading successful build manifest.

* **Tests**
  * Added coverage confirming that import and build errors propagate correctly.
  * Added licensing metadata and documentation to the relevant test module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->