### PR TITLE
Skip weight quantizers with no stored weight in fold_weight

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changelog
 
 **Bug Fixes**
 
+- Fix ``mtq.fold_weight`` crashing with ``AttributeError: 'NoneType' object has no attribute 'data'`` on Megatron-Core models with tied word embeddings: the tied ``output_layer`` (built with ``skip_weight_param_allocation``) stores ``weight = None`` and borrows the embedding weight at forward time, yet still carries a ``weight_quantizer``. Weight-quantizer pairs whose weight is not a stored tensor are now skipped and left untouched.
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
 
 0.46 (2026-08-17)

--- a/modelopt/torch/quantization/nn/modules/quant_module.py
+++ b/modelopt/torch/quantization/nn/modules/quant_module.py
@@ -157,6 +157,14 @@ class QuantModule(DynamicModule):
         transform is baked into the stored weight and then disabled, so subsequent forwards use
         the stored weight directly. Calibration buffers (``_pre_quant_scale``, ``_amax``) are
         dropped unless ``keep_attrs``.
+
+        Quantizers whose weight attribute is not a tensor are skipped and left untouched:
+        modules such as Megatron tied-embedding output layers (built with
+        ``skip_weight_param_allocation``) store ``weight = None`` and receive the shared
+        weight as a forward-time argument, so there is nothing stored to fold. Such quantizers
+        stay enabled after folding, so callers that assert all weight quantizers are disabled
+        once folding completes (e.g. ``_check_all_weight_quantizers_disabled`` in the vLLM
+        fakequant export plugin) must account for them.
         """
         # Handle all attributes that end with _weight_quantizer
         for name in dir(self):
@@ -173,6 +181,10 @@ class QuantModule(DynamicModule):
                     f"{name} doesn't have a corresponding {weight_name} in {self.__class__.__name__}"
                 )
                 weight = getattr(self, weight_name)
+                if not isinstance(weight, torch.Tensor):
+                    # e.g. Megatron tied-embedding output_layer: weight is None and
+                    # borrowed at forward time, so there is nothing stored to fold.
+                    continue
                 self._fold_weight_quantizer(attr, (weight,), keep_attrs)
 
 

--- a/tests/unit/torch/quantization/test_tensor_quant_cpu.py
+++ b/tests/unit/torch/quantization/test_tensor_quant_cpu.py
@@ -332,6 +332,25 @@ def test_fold_weight_keep_attrs_keeps_amax(monkeypatch):
         unregister_quant_backend(backend_name)
 
 
+def test_fold_weight_skips_none_weight():
+    """A weight quantizer with no stored weight is skipped instead of crashing.
+
+    Megatron-Core tied-embedding output layers are built with
+    ``skip_weight_param_allocation``: the module stores ``weight = None`` and borrows the
+    embedding weight at forward time, while still carrying a ``weight_quantizer``.
+    ``fold_weight`` must skip the pair, leaving the quantizer intact for forward-time use.
+    """
+    qlinear = QuantModuleRegistry.convert(torch.nn.Linear(4, 3))
+    qlinear.weight_quantizer.amax = torch.tensor(1.0)
+    expected_amax = qlinear.weight_quantizer.amax.detach().clone()
+    qlinear.register_parameter("weight", None)
+
+    qlinear.fold_weight()  # must not raise
+
+    assert qlinear.weight_quantizer.is_enabled
+    assert torch.equal(qlinear.weight_quantizer.amax, expected_amax)
+
+
 WINT4INT8_CFG = {
     "quant_cfg": [
         {"quantizer_name": "*", "enable": False},


### PR DESCRIPTION
# Skip weight quantizers with no stored weight in `fold_weight`

### What does this PR do?

Type of change: Bug fix

Fixes #2131.

On Megatron-Core models with tied word embeddings
(`share_embeddings_and_output_weights=True`), the `output_layer` is built with
`skip_weight_param_allocation`: it stores `weight = None` and borrows the embedding
weight at forward time, while ModelOpt still attaches a `weight_quantizer` to it.
`QuantModule.fold_weight` matches the pair on the `*_weight_quantizer` attribute name
and `fake_quant` alone, then dereferences `weight.data`, so `mtq.fold_weight` crashes:

```
modelopt/torch/quantization/nn/modules/quant_module.py:145, in _fold_weight_quantizer
    weight.data.copy_(quantizer(weight.float().contiguous()).to(weight.dtype))
AttributeError: 'NoneType' object has no attribute 'data'
```

This PR skips pairs whose weight attribute is not a tensor and leaves their quantizer
untouched: there is nothing stored to fold, and the shared weight keeps being
quantized at forward time through the still-enabled quantizer (the embedding module
folds its own stored weight as before). HF models are unaffected — they express tying
as a shared tensor rather than `None`, which is why the crash only surfaced on
Megatron.

### Usage

```python
import modelopt.torch.quantization as mtq
from megatron.core.models.gpt import GPTModel

# Any GPTModel with tied embeddings, e.g. Qwen3-0.6B:
# output_layer.weight is None (borrowed from the embedding at forward time).
model = GPTModel(..., share_embeddings_and_output_weights=True)
model = mtq.quantize(model, mtq.NVFP4_DEFAULT_CFG, forward_loop)

mtq.fold_weight(model)  # previously: AttributeError; now folds all stored weights
```

### Testing

- New unit test `test_fold_weight_skips_none_weight` in
  `tests/unit/torch/quantization/test_tensor_quant_cpu.py` builds the tied-layer shape
  (a converted `QuantLinear` with `weight = None`) — it reproduces the exact
  `AttributeError` at `quant_module.py:145` without the fix and passes with it,
  asserting the skipped quantizer stays enabled with its `_amax` intact.


### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (previously-crashing calls now succeed; folding behavior for stored weights is unchanged)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: ❌ (external contribution — cannot self-trigger `/claude review`)

### Additional Information

Related issue: #2131. Downstream workaround that this fix would let us drop:
NVIDIA-NeMo/RL#3441 (`nemo_rl/modelopt/models/policy/workers/weight_folding.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weight folding crashes for quantized models with missing or non-tensor weights.
  * Such weights are now safely skipped without changing their associated quantizer settings.
  * Normal tensor weights continue to fold as expected.

* **Tests**
  * Added regression coverage to verify quantizers and calibration values remain unchanged when weights are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->