### PR TITLE
Persist immutable Puzzletron stage execution records

### DIFF
--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -361,6 +361,16 @@ python examples/puzzletron/main.py \
 stages with valid manifests and acceptance markers are skipped; use `--force`
 only when intentionally invalidating and rerunning the selected work.
 
+Each rank-zero stage result also writes an immutable execution record under
+`<puzzle-dir>/manifests/executions/<stage>/<execution-identity>/`. The
+`resolved_config.json` file contains the exact effective hierarchical config,
+its semantic identities, authoring provenance, and a replay command that loads
+the immutable resolved file rather than recomposing the authored YAML. The
+`artifact_manifest.json` file binds that config to the stage's declared outputs
+as an explicit artifact contract. The current `manifests/<stage>.json` points to
+both files, and new acceptance markers require them when they are present. The
+acceptance marker remains the validated inventory of required files.
+
 There is one current orchestration boundary to understand before using
 `--stage full`. The canonical `zero_shot_evaluation` handler evaluates realized
 checkpoints, while the Nano experiment uses `mode: online_solutions` to score

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -363,11 +363,11 @@ only when intentionally invalidating and rerunning the selected work.
 
 Each rank-zero stage result also writes an immutable execution record under
 `<puzzle-dir>/manifests/executions/<stage>/<execution-identity>/`. The
-`resolved_config.json` file contains the exact effective hierarchical config,
-its semantic identities, authoring provenance, and a replay command that loads
-the immutable resolved file rather than recomposing the authored YAML. The
-`artifact_manifest.json` file binds that config to the stage's declared outputs
-as an explicit artifact contract. The current `manifests/<stage>.json` points to
+`resolved_config.json` file contains stage-relevant resolved configuration,
+semantic identities, and authoring provenance. The `artifact_manifest.json`
+separates mutable canonical output pointers from fingerprints of files that
+existed when the record was published; it does not copy stage outputs or claim
+later mutations are immutable. The current `manifests/<stage>.json` points to
 both files, and new acceptance markers require them when they are present. The
 acceptance marker remains the validated inventory of required files.
 

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -256,6 +256,7 @@ def _completion_is_valid(config: dict, config_path: str | Path, stage: str) -> b
     if state is None:
         return False
     if state.status is StageStatus.SKIPPED:
+        _stage_execution_record_patterns(config, stage)
         return True
     if not artifacts_are_complete(config, stage):
         return False
@@ -268,6 +269,7 @@ def _mark_completion(config: dict, config_path: str | Path, stage: str) -> None:
     if state is None:
         raise RuntimeError(f"stage {stage!r} did not write an accepted terminal manifest")
     if state.status is StageStatus.SKIPPED:
+        _stage_execution_record_patterns(config, stage)
         return
     if not artifacts_are_complete(config, stage):
         raise RuntimeError(f"stage {stage!r} failed canonical artifact validation")

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -256,6 +256,7 @@ def _completion_is_valid(config: dict, config_path: str | Path, stage: str) -> b
     if state is None:
         return False
     if state.status is StageStatus.SKIPPED:
+        # Validation-only: raises if the referenced execution record was tampered with.
         _stage_execution_record_patterns(config, stage)
         return True
     if not artifacts_are_complete(config, stage):
@@ -269,6 +270,7 @@ def _mark_completion(config: dict, config_path: str | Path, stage: str) -> None:
     if state is None:
         raise RuntimeError(f"stage {stage!r} did not write an accepted terminal manifest")
     if state.status is StageStatus.SKIPPED:
+        # Validation-only: raises if the referenced execution record was tampered with.
         _stage_execution_record_patterns(config, stage)
         return
     if not artifacts_are_complete(config, stage):

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -40,10 +40,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 import modelopt.torch.puzzletron as mtpz
-from modelopt.torch.puzzletron.identity import stable_hash
 from modelopt.torch.puzzletron.manifest import (
     StageManifest,
     semantic_stage_config,
+    validate_stage_execution_record,
     write_stage_manifest,
 )
 from modelopt.torch.puzzletron.orchestration.adapters.stage_compat import (
@@ -65,7 +65,12 @@ from modelopt.torch.puzzletron.stages.graph import (
 )
 
 if __package__:
-    from .acceptance_resume import build_payload, check_marker, marker_path, write_marker
+    from .acceptance_resume import (
+        build_payload,
+        check_marker,
+        marker_path,
+        write_marker,
+    )
 else:
     from acceptance_resume import build_payload, check_marker, marker_path, write_marker
 
@@ -150,37 +155,6 @@ def build_worker_command(
     return tuple(command)
 
 
-def _pipeline_config_from_path(
-    config_path: str | Path,
-    *,
-    overrides: Sequence[str] = (),
-) -> dict:
-    """Load authored Hydra config or an immutable resolved execution config."""
-
-    path = Path(config_path)
-    if path.suffix == ".json":
-        try:
-            payload = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            payload = None
-        if isinstance(payload, dict) and payload.get("schema") == "puzzletron.stage-execution/v1":
-            if overrides:
-                raise ValueError("resolved execution configs do not accept overrides")
-            stage = payload.get("stage")
-            config = payload.get("effective_config")
-            expected_identity = payload.get("resolved_config_identity")
-            if not isinstance(stage, str) or not isinstance(config, dict):
-                raise ValueError(f"invalid resolved execution config: {path}")
-            actual_identity = stable_hash(config, prefix=f"{stage}_resolved_cfg")
-            if actual_identity != expected_identity:
-                raise ValueError(f"resolved execution config identity mismatch: {path}")
-            runtime = dict(config.get("_runtime") or {})
-            runtime["resolved_config_path"] = str(path.resolve())
-            config["_runtime"] = runtime
-            return config
-    return mtpz.pipeline_config.pipeline_config_from_path(path, overrides=overrides)
-
-
 def refresh_campaign_report(config: dict, running_stage: str | None = None) -> None:
     """Refresh the stable campaign report from rank zero.
 
@@ -246,36 +220,30 @@ def _manifest_terminal_state(config: dict, stage: str):
 
 
 def _stage_execution_record_patterns(config: dict, stage: str) -> tuple[str, ...]:
-    """Return immutable execution-record paths referenced by a stage manifest."""
+    """Validate and return immutable records referenced by a stage manifest."""
 
-    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
+    puzzle_dir = Path(
+        config.get("puzzle_dir") or (config.get("experiment") or {})["dir"]
+    )
     manifest_path = puzzle_dir / "manifests" / f"{stage}.json"
-    try:
-        payload = json.loads(manifest_path.read_text())
-    except (OSError, ValueError):
+    if not manifest_path.is_file():
         return ()
-    record = payload.get("execution_record") or {}
-    patterns = []
-    for key in ("resolved_config_path", "artifact_manifest_path"):
-        raw_path = record.get(key)
-        if not isinstance(raw_path, str) or not raw_path:
-            continue
-        relative = Path(raw_path)
-        if relative.is_absolute() or ".." in relative.parts:
-            raise ValueError(f"unsafe stage execution record path: {raw_path!r}")
-        patterns.append(relative.as_posix())
-    return tuple(patterns)
+    return validate_stage_execution_record(manifest_path, expected_stage=stage)
 
 
 def _resume_kwargs(config: dict, config_path: str | Path, stage: str) -> dict:
-    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
+    puzzle_dir = Path(
+        config.get("puzzle_dir") or (config.get("experiment") or {})["dir"]
+    )
     upstream = {
         parent: marker_path(puzzle_dir, parent, None, None)
         for parent in configured_parent_stage_ids(stage, config)
     }
     paths = config.get("paths") or {}
     repositories = tuple(
-        Path(paths[key]) for key in ("automodel_root", "vllm_root", "aiperf_root") if paths.get(key)
+        Path(paths[key])
+        for key in ("automodel_root", "vllm_root", "aiperf_root")
+        if paths.get(key)
     )
     return {
         "root": puzzle_dir,
@@ -376,7 +344,9 @@ def run_pipeline(
     is_complete: Callable[[str], bool],
     mark_complete: Callable[[str], None],
     refresh_report: Callable[[str | None], None],
-    command_runner: Callable[[Sequence[str]], subprocess.CompletedProcess] = subprocess.run,
+    command_runner: Callable[
+        [Sequence[str]], subprocess.CompletedProcess
+    ] = subprocess.run,
 ) -> None:
     """Run stage workers sequentially, stopping on the first failed worker."""
 
@@ -390,7 +360,9 @@ def run_pipeline(
             stage=stage,
             overrides=overrides,
             gpus_per_node=gpus_per_node,
-            force_single=bool((config.get("embedding_pruning") or {}).get("enabled", False))
+            force_single=bool(
+                (config.get("embedding_pruning") or {}).get("enabled", False)
+            )
             and stage == "replacement_scoring",
         )
         result = command_runner(command)
@@ -401,10 +373,14 @@ def run_pipeline(
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run the Puzzletron compression pipeline.")
+    parser = argparse.ArgumentParser(
+        description="Run the Puzzletron compression pipeline."
+    )
     parser.add_argument("--config", required=True, help="Hydra YAML entrypoint.")
     parser.add_argument("--stage", choices=("full", *STAGES))
-    parser.add_argument("--force", action="store_true", help="Rerun the selected stage(s).")
+    parser.add_argument(
+        "--force", action="store_true", help="Rerun the selected stage(s)."
+    )
     parser.add_argument("--gpus-per-node", type=int, default=None)
     parser.add_argument("--override", action="append", default=[], metavar="KEY=VALUE")
     parser.add_argument("--worker-stage", choices=STAGES, help=argparse.SUPPRESS)
@@ -423,14 +399,17 @@ def _embedding_followup_stage(stage: str) -> bool:
 
 
 def _run_worker(args: argparse.Namespace) -> None:
-    cfg = _pipeline_config_from_path(
+    cfg = mtpz.pipeline_config.pipeline_config_from_path(
         args.config,
         overrides=args.override,
     )
     embedding_root = (
-        bool((cfg.get("embedding_pruning") or {}).get("enabled", False)) and not args.scenario_child
+        bool((cfg.get("embedding_pruning") or {}).get("enabled", False))
+        and not args.scenario_child
     )
-    gpus_per_node = int(args.gpus_per_node or (cfg.get("execution") or {}).get("gpus_per_node", 8))
+    gpus_per_node = int(
+        args.gpus_per_node or (cfg.get("execution") or {}).get("gpus_per_node", 8)
+    )
     runtime = dict(cfg.get("_runtime") or {})
     runtime["gpus_per_node"] = gpus_per_node
     cfg["_runtime"] = runtime
@@ -485,7 +464,9 @@ def _run_worker(args: argparse.Namespace) -> None:
 
 
 def _complete_composite_stage(config: dict, stage: str, outputs: dict):
-    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
+    puzzle_dir = Path(
+        config.get("puzzle_dir") or (config.get("experiment") or {})["dir"]
+    )
     manifest_path = puzzle_dir / "manifests" / f"{stage}.json"
     manifest = StageManifest(stage=stage, inputs={"config": config}, config=config)
     manifest.complete(outputs=outputs)
@@ -504,7 +485,9 @@ def main() -> None:
         _run_worker(args)
         return
 
-    cfg = _pipeline_config_from_path(args.config, overrides=args.override)
+    cfg = mtpz.pipeline_config.pipeline_config_from_path(
+        args.config, overrides=args.override
+    )
     execution = cfg.get("execution") or {}
     gpus_per_node = int(args.gpus_per_node or execution.get("gpus_per_node", 8))
     stages = stage_sequence(args.stage, cfg)

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -65,12 +65,7 @@ from modelopt.torch.puzzletron.stages.graph import (
 )
 
 if __package__:
-    from .acceptance_resume import (
-        build_payload,
-        check_marker,
-        marker_path,
-        write_marker,
-    )
+    from .acceptance_resume import build_payload, check_marker, marker_path, write_marker
 else:
     from acceptance_resume import build_payload, check_marker, marker_path, write_marker
 
@@ -222,9 +217,7 @@ def _manifest_terminal_state(config: dict, stage: str):
 def _stage_execution_record_patterns(config: dict, stage: str) -> tuple[str, ...]:
     """Validate and return immutable records referenced by a stage manifest."""
 
-    puzzle_dir = Path(
-        config.get("puzzle_dir") or (config.get("experiment") or {})["dir"]
-    )
+    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
     manifest_path = puzzle_dir / "manifests" / f"{stage}.json"
     if not manifest_path.is_file():
         return ()
@@ -232,18 +225,14 @@ def _stage_execution_record_patterns(config: dict, stage: str) -> tuple[str, ...
 
 
 def _resume_kwargs(config: dict, config_path: str | Path, stage: str) -> dict:
-    puzzle_dir = Path(
-        config.get("puzzle_dir") or (config.get("experiment") or {})["dir"]
-    )
+    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
     upstream = {
         parent: marker_path(puzzle_dir, parent, None, None)
         for parent in configured_parent_stage_ids(stage, config)
     }
     paths = config.get("paths") or {}
     repositories = tuple(
-        Path(paths[key])
-        for key in ("automodel_root", "vllm_root", "aiperf_root")
-        if paths.get(key)
+        Path(paths[key]) for key in ("automodel_root", "vllm_root", "aiperf_root") if paths.get(key)
     )
     return {
         "root": puzzle_dir,
@@ -344,9 +333,7 @@ def run_pipeline(
     is_complete: Callable[[str], bool],
     mark_complete: Callable[[str], None],
     refresh_report: Callable[[str | None], None],
-    command_runner: Callable[
-        [Sequence[str]], subprocess.CompletedProcess
-    ] = subprocess.run,
+    command_runner: Callable[[Sequence[str]], subprocess.CompletedProcess] = subprocess.run,
 ) -> None:
     """Run stage workers sequentially, stopping on the first failed worker."""
 
@@ -360,9 +347,7 @@ def run_pipeline(
             stage=stage,
             overrides=overrides,
             gpus_per_node=gpus_per_node,
-            force_single=bool(
-                (config.get("embedding_pruning") or {}).get("enabled", False)
-            )
+            force_single=bool((config.get("embedding_pruning") or {}).get("enabled", False))
             and stage == "replacement_scoring",
         )
         result = command_runner(command)
@@ -373,14 +358,10 @@ def run_pipeline(
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Run the Puzzletron compression pipeline."
-    )
+    parser = argparse.ArgumentParser(description="Run the Puzzletron compression pipeline.")
     parser.add_argument("--config", required=True, help="Hydra YAML entrypoint.")
     parser.add_argument("--stage", choices=("full", *STAGES))
-    parser.add_argument(
-        "--force", action="store_true", help="Rerun the selected stage(s)."
-    )
+    parser.add_argument("--force", action="store_true", help="Rerun the selected stage(s).")
     parser.add_argument("--gpus-per-node", type=int, default=None)
     parser.add_argument("--override", action="append", default=[], metavar="KEY=VALUE")
     parser.add_argument("--worker-stage", choices=STAGES, help=argparse.SUPPRESS)
@@ -404,12 +385,9 @@ def _run_worker(args: argparse.Namespace) -> None:
         overrides=args.override,
     )
     embedding_root = (
-        bool((cfg.get("embedding_pruning") or {}).get("enabled", False))
-        and not args.scenario_child
+        bool((cfg.get("embedding_pruning") or {}).get("enabled", False)) and not args.scenario_child
     )
-    gpus_per_node = int(
-        args.gpus_per_node or (cfg.get("execution") or {}).get("gpus_per_node", 8)
-    )
+    gpus_per_node = int(args.gpus_per_node or (cfg.get("execution") or {}).get("gpus_per_node", 8))
     runtime = dict(cfg.get("_runtime") or {})
     runtime["gpus_per_node"] = gpus_per_node
     cfg["_runtime"] = runtime
@@ -464,9 +442,7 @@ def _run_worker(args: argparse.Namespace) -> None:
 
 
 def _complete_composite_stage(config: dict, stage: str, outputs: dict):
-    puzzle_dir = Path(
-        config.get("puzzle_dir") or (config.get("experiment") or {})["dir"]
-    )
+    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
     manifest_path = puzzle_dir / "manifests" / f"{stage}.json"
     manifest = StageManifest(stage=stage, inputs={"config": config}, config=config)
     manifest.complete(outputs=outputs)
@@ -485,9 +461,7 @@ def main() -> None:
         _run_worker(args)
         return
 
-    cfg = mtpz.pipeline_config.pipeline_config_from_path(
-        args.config, overrides=args.override
-    )
+    cfg = mtpz.pipeline_config.pipeline_config_from_path(args.config, overrides=args.override)
     execution = cfg.get("execution") or {}
     gpus_per_node = int(args.gpus_per_node or execution.get("gpus_per_node", 8))
     stages = stage_sequence(args.stage, cfg)

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 import modelopt.torch.puzzletron as mtpz
+from modelopt.torch.puzzletron.identity import stable_hash
 from modelopt.torch.puzzletron.manifest import (
     StageManifest,
     semantic_stage_config,
@@ -149,6 +150,37 @@ def build_worker_command(
     return tuple(command)
 
 
+def _pipeline_config_from_path(
+    config_path: str | Path,
+    *,
+    overrides: Sequence[str] = (),
+) -> dict:
+    """Load authored Hydra config or an immutable resolved execution config."""
+
+    path = Path(config_path)
+    if path.suffix == ".json":
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            payload = None
+        if isinstance(payload, dict) and payload.get("schema") == "puzzletron.stage-execution/v1":
+            if overrides:
+                raise ValueError("resolved execution configs do not accept overrides")
+            stage = payload.get("stage")
+            config = payload.get("effective_config")
+            expected_identity = payload.get("resolved_config_identity")
+            if not isinstance(stage, str) or not isinstance(config, dict):
+                raise ValueError(f"invalid resolved execution config: {path}")
+            actual_identity = stable_hash(config, prefix=f"{stage}_resolved_cfg")
+            if actual_identity != expected_identity:
+                raise ValueError(f"resolved execution config identity mismatch: {path}")
+            runtime = dict(config.get("_runtime") or {})
+            runtime["resolved_config_path"] = str(path.resolve())
+            config["_runtime"] = runtime
+            return config
+    return mtpz.pipeline_config.pipeline_config_from_path(path, overrides=overrides)
+
+
 def refresh_campaign_report(config: dict, running_stage: str | None = None) -> None:
     """Refresh the stable campaign report from rank zero.
 
@@ -213,6 +245,28 @@ def _manifest_terminal_state(config: dict, stage: str):
     return state
 
 
+def _stage_execution_record_patterns(config: dict, stage: str) -> tuple[str, ...]:
+    """Return immutable execution-record paths referenced by a stage manifest."""
+
+    puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
+    manifest_path = puzzle_dir / "manifests" / f"{stage}.json"
+    try:
+        payload = json.loads(manifest_path.read_text())
+    except (OSError, ValueError):
+        return ()
+    record = payload.get("execution_record") or {}
+    patterns = []
+    for key in ("resolved_config_path", "artifact_manifest_path"):
+        raw_path = record.get(key)
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        relative = Path(raw_path)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"unsafe stage execution record path: {raw_path!r}")
+        patterns.append(relative.as_posix())
+    return tuple(patterns)
+
+
 def _resume_kwargs(config: dict, config_path: str | Path, stage: str) -> dict:
     puzzle_dir = Path(config.get("puzzle_dir") or (config.get("experiment") or {})["dir"])
     upstream = {
@@ -231,6 +285,7 @@ def _resume_kwargs(config: dict, config_path: str | Path, stage: str) -> dict:
         "depth": None,
         "required_patterns": (
             f"manifests/{stage}.json",
+            *_stage_execution_record_patterns(config, stage),
             *canonical_stage_output_patterns(config, stage),
         ),
         "upstream_markers": upstream,
@@ -368,7 +423,7 @@ def _embedding_followup_stage(stage: str) -> bool:
 
 
 def _run_worker(args: argparse.Namespace) -> None:
-    cfg = mtpz.pipeline_config.pipeline_config_from_path(
+    cfg = _pipeline_config_from_path(
         args.config,
         overrides=args.override,
     )
@@ -376,6 +431,9 @@ def _run_worker(args: argparse.Namespace) -> None:
         bool((cfg.get("embedding_pruning") or {}).get("enabled", False)) and not args.scenario_child
     )
     gpus_per_node = int(args.gpus_per_node or (cfg.get("execution") or {}).get("gpus_per_node", 8))
+    runtime = dict(cfg.get("_runtime") or {})
+    runtime["gpus_per_node"] = gpus_per_node
+    cfg["_runtime"] = runtime
     composite_only = {"replacement_scoring", "mip"}
     if not _stage_enabled(cfg, args.worker_stage):
         result = mtpz.stage_runner.run_stage(cfg, args.worker_stage, handlers={})
@@ -446,7 +504,7 @@ def main() -> None:
         _run_worker(args)
         return
 
-    cfg = mtpz.pipeline_config.pipeline_config_from_path(args.config, overrides=args.override)
+    cfg = _pipeline_config_from_path(args.config, overrides=args.override)
     execution = cfg.get("execution") or {}
     gpus_per_node = int(args.gpus_per_node or execution.get("gpus_per_node", 8))
     stages = stage_sequence(args.stage, cfg)

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -181,8 +181,8 @@ def write_stage_execution_record(
     record_dir = root / "manifests" / "executions" / stage / execution_identity
     resolved_path = record_dir / "resolved_config.json"
     artifact_path = record_dir / "artifact_manifest.json"
-    resolved_relative = str(resolved_path.relative_to(root))
-    artifact_relative = str(artifact_path.relative_to(root))
+    resolved_relative = resolved_path.relative_to(root).as_posix()
+    artifact_relative = artifact_path.relative_to(root).as_posix()
 
     inputs = manifest_payload.get("inputs") or {}
     runtime = effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
@@ -242,7 +242,7 @@ def write_stage_execution_record(
             "sha256": resolved_sha256,
         },
         "stage_manifest": {
-            "path": str(manifest_path.relative_to(root)),
+            "path": manifest_path.relative_to(root).as_posix(),
             "semantic_identity": manifest_payload.get("semantic_identity"),
         },
         "artifact_contract": "stage-manifest-output-pointers/v1",
@@ -557,7 +557,12 @@ class StageManifest:
 
 
 def write_stage_manifest(path: str | Path, manifest: StageManifest) -> None:
-    """Atomically write a stage manifest from rank zero."""
+    """Atomically write a stage manifest from rank zero.
+
+    Rank zero publishes the immutable execution record and assigns its reference
+    to ``manifest.execution_record`` before writing the manifest. Other ranks
+    return without writing and leave ``manifest.execution_record`` unchanged.
+    """
 
     if os.environ.get("RANK") not in (None, "", "0"):
         return

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -382,6 +382,12 @@ def validate_stage_execution_record(
     artifact, artifact_bytes = _read_mapping(
         artifact_path, description="stage artifact record"
     )
+    resolved_sha256 = _sha256_bytes(resolved_bytes)
+    if record.get("resolved_config_sha256") != resolved_sha256:
+        raise ValueError("resolved stage configuration SHA256 mismatch")
+    if record.get("artifact_manifest_sha256") != _sha256_bytes(artifact_bytes):
+        raise ValueError("stage artifact record SHA256 mismatch")
+
     for label, payload in (("resolved", resolved), ("artifact", artifact)):
         if (
             payload.get("schema") != _EXECUTION_RECORD_SCHEMA
@@ -397,9 +403,6 @@ def validate_stage_execution_record(
             if payload.get(key) != pointer.get(key):
                 raise ValueError(f"{label} stage execution {key} mismatch")
 
-    resolved_sha256 = _sha256_bytes(resolved_bytes)
-    if record.get("resolved_config_sha256") != resolved_sha256:
-        raise ValueError("resolved stage configuration SHA256 mismatch")
     resolved_identity = stable_hash(
         resolved.get("resolved_stage_config"), prefix=f"{stage}_resolved_cfg"
     )
@@ -457,8 +460,6 @@ def validate_stage_execution_record(
     if expected_execution_identity != execution_identity:
         raise ValueError("stage execution identity does not match record content")
 
-    if record.get("artifact_manifest_sha256") != _sha256_bytes(artifact_bytes):
-        raise ValueError("stage artifact record SHA256 mismatch")
     artifact_identity_payload = dict(artifact)
     artifact_identity = artifact_identity_payload.pop(
         "artifact_manifest_identity", None

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -108,6 +108,18 @@ def _sha256_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+def _file_evidence(path: Path) -> dict[str, int | str]:
+    """Return bounded-memory size and digest evidence for one file."""
+
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            size += len(chunk)
+            digest.update(chunk)
+    return {"size": size, "sha256": digest.hexdigest()}
+
+
 def _resolved_config_content(config: object) -> Any:
     """Remove path/launch-only runtime facts from resolved semantic identity."""
 
@@ -211,11 +223,9 @@ def write_stage_execution_record(
             if not output_path.is_absolute():
                 output_path = root / output_path
             if output_path.is_file():
-                output_bytes = output_path.read_bytes()
                 immutable_evidence[str(key)] = {
                     "path": value,
-                    "size": len(output_bytes),
-                    "sha256": _sha256_bytes(output_bytes),
+                    **_file_evidence(output_path),
                 }
     artifact_payload = {
         "schema": _EXECUTION_RECORD_SCHEMA,

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -22,8 +22,8 @@ import hashlib
 import json
 import os
 import shutil
-import sys
 import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +35,7 @@ __all__ = [
     "StageManifest",
     "read_stage_manifest",
     "semantic_stage_config",
+    "validate_stage_execution_record",
     "write_stage_execution_record",
     "write_stage_manifest",
 ]
@@ -51,38 +52,21 @@ def _json_bytes(payload: dict[str, Any]) -> bytes:
     return (json.dumps(canonicalize(payload), indent=2, sort_keys=True) + "\n").encode()
 
 
-def _replay_contract(
-    config: dict[str, Any],
-    stage: str,
-    resolved_config_path: Path,
-) -> dict[str, Any]:
-    runtime = config.get("_runtime") or {}
-    repository_root = Path(__file__).resolve().parents[3]
-    command = [
-        sys.executable,
-        str(repository_root / "examples" / "puzzletron" / "main.py"),
-        "--config",
-        str(resolved_config_path),
-        "--stage",
-        stage,
-    ]
-    gpus_per_node = runtime.get("gpus_per_node")
-    if gpus_per_node is not None:
-        command.extend(("--gpus-per-node", str(gpus_per_node)))
-    command.append("--force")
-    return {
-        "available": True,
-        "argv": command,
-        "working_directory": str(repository_root),
-    }
-
-
 def _publish_immutable_record(
     record_dir: Path,
     files: dict[str, bytes],
 ) -> None:
+    record_dir = _path_without_symlinks(
+        record_dir, description="stage execution record path"
+    )
+    for name in files:
+        _path_without_symlinks(
+            record_dir / name, description="stage execution record path"
+        )
     record_dir.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(tempfile.mkdtemp(prefix=f".{record_dir.name}.", dir=record_dir.parent))
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{record_dir.name}.", dir=record_dir.parent)
+    )
     try:
         for name, content in files.items():
             (temporary / name).write_bytes(content)
@@ -95,7 +79,8 @@ def _publish_immutable_record(
         mismatches = [
             name
             for name, content in files.items()
-            if not (record_dir / name).is_file() or (record_dir / name).read_bytes() != content
+            if not (record_dir / name).is_file()
+            or (record_dir / name).read_bytes() != content
         ]
         if mismatches:
             raise FileExistsError(
@@ -107,13 +92,48 @@ def _publish_immutable_record(
             shutil.rmtree(temporary)
 
 
+def _safe_relative_path(raw_path: object, *, description: str) -> Path:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError(f"invalid {description}: {raw_path!r}")
+    path = Path(raw_path)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"unsafe {description}: {raw_path!r}")
+    return path
+
+
+def _path_without_symlinks(path: Path, *, description: str) -> Path:
+    absolute = path.expanduser().absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"{description} is symlinked: {current}")
+    return absolute
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _resolved_config_content(config: object) -> Any:
+    """Remove path/launch-only runtime facts from resolved semantic identity."""
+
+    if not isinstance(config, Mapping):
+        return canonicalize(config)
+    return canonicalize(
+        {key: value for key, value in config.items() if key != "_runtime"}
+    )
+
+
 def write_stage_execution_record(
     manifest_path: str | Path,
     manifest_payload: dict[str, Any],
 ) -> dict[str, Any]:
     """Persist immutable resolved config and artifact metadata for one execution."""
 
-    manifest_path = Path(manifest_path).absolute()
+    manifest_path = _path_without_symlinks(
+        Path(manifest_path), description="stage manifest path"
+    )
     if manifest_path.parent.name != "manifests":
         raise ValueError(
             f"stage manifest must use the campaign manifests directory: {manifest_path}"
@@ -132,18 +152,32 @@ def write_stage_execution_record(
         manifest_payload.get("config_identity")
         or stable_hash(authored_config, prefix=f"{stage}_cfg")
     )
-    resolved_config_identity = stable_hash(effective_config, prefix=f"{stage}_resolved_cfg")
+    resolved_config_content = _resolved_config_content(
+        semantic_stage_config(dict(effective_config), stage)
+        if isinstance(effective_config, Mapping)
+        else effective_config
+    )
+    resolved_config_identity = stable_hash(
+        resolved_config_content, prefix=f"{stage}_resolved_cfg"
+    )
+    implementation_provenance = canonicalize(
+        manifest_payload.get("implementation_provenance") or {}
+    )
     execution_identity = stable_hash(
         {
             "stage": stage,
             "status": manifest_payload.get("status"),
+            "skip_reason": manifest_payload.get("skip_reason"),
             "started_at": manifest_payload.get("started_at"),
             "ended_at": manifest_payload.get("ended_at"),
             "authored_config_identity": authored_config_identity,
             "resolved_config_identity": resolved_config_identity,
-            "semantic_config_identity": manifest_payload.get("semantic_config_identity"),
+            "semantic_config_identity": manifest_payload.get(
+                "semantic_config_identity"
+            ),
             "semantic_identity": manifest_payload.get("semantic_identity"),
             "capability_snapshot": manifest_payload.get("capability_snapshot"),
+            "implementation_provenance": implementation_provenance,
         },
         prefix=f"{stage}_execution",
     )
@@ -154,13 +188,16 @@ def write_stage_execution_record(
     artifact_relative = str(artifact_path.relative_to(root))
 
     inputs = manifest_payload.get("inputs") or {}
-    runtime = effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
+    runtime = (
+        effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
+    )
     runtime = runtime if isinstance(runtime, dict) else {}
     resolved_payload = {
         "schema": _EXECUTION_RECORD_SCHEMA,
         "schema_version": 1,
         "stage": stage,
         "status": manifest_payload.get("status"),
+        "skip_reason": manifest_payload.get("skip_reason"),
         "started_at": manifest_payload.get("started_at"),
         "ended_at": manifest_payload.get("ended_at"),
         "execution_identity": execution_identity,
@@ -169,25 +206,40 @@ def write_stage_execution_record(
         "semantic_config": manifest_payload.get("semantic_config") or {},
         "semantic_config_identity": manifest_payload.get("semantic_config_identity"),
         "semantic_identity": manifest_payload.get("semantic_identity"),
-        "effective_config": effective_config,
         "provenance": {
             "authored_config_path": runtime.get("config_path"),
             "overrides": list(runtime.get("overrides") or ()),
-            "implementation": manifest_payload.get("implementation_provenance") or {},
+            "implementation": implementation_provenance,
             "descriptor_resolution": inputs.get("descriptor_resolution"),
             "capability_snapshot": manifest_payload.get("capability_snapshot"),
         },
-        "replay": _replay_contract(effective_config, stage, resolved_path),
+        "resolved_stage_config": resolved_config_content,
     }
     resolved_bytes = _json_bytes(resolved_payload)
-    resolved_sha256 = hashlib.sha256(resolved_bytes).hexdigest()
+    resolved_sha256 = _sha256_bytes(resolved_bytes)
 
-    declared_outputs = manifest_payload.get("outputs") or {}
+    declared_outputs = canonicalize(manifest_payload.get("outputs") or {})
+    immutable_evidence = {}
+    if isinstance(declared_outputs, Mapping):
+        for key, value in declared_outputs.items():
+            if not isinstance(value, str):
+                continue
+            output_path = Path(value)
+            if not output_path.is_absolute():
+                output_path = root / output_path
+            if output_path.is_file():
+                output_bytes = output_path.read_bytes()
+                immutable_evidence[str(key)] = {
+                    "path": value,
+                    "size": len(output_bytes),
+                    "sha256": _sha256_bytes(output_bytes),
+                }
     artifact_payload = {
         "schema": _EXECUTION_RECORD_SCHEMA,
         "schema_version": 1,
         "stage": stage,
         "status": manifest_payload.get("status"),
+        "skip_reason": manifest_payload.get("skip_reason"),
         "started_at": manifest_payload.get("started_at"),
         "ended_at": manifest_payload.get("ended_at"),
         "execution_identity": execution_identity,
@@ -200,12 +252,14 @@ def write_stage_execution_record(
             "path": str(manifest_path.relative_to(root)),
             "semantic_identity": manifest_payload.get("semantic_identity"),
         },
-        "artifact_contract": "stage-manifest-outputs",
-        "declared_outputs": declared_outputs,
+        "artifact_contract": "stage-manifest-output-pointers/v1",
+        "canonical_output_pointers": declared_outputs,
+        "immutable_evidence": immutable_evidence,
     }
     artifact_identity = stable_hash(artifact_payload, prefix=f"{stage}_artifacts")
     artifact_payload["artifact_manifest_identity"] = artifact_identity
     artifact_bytes = _json_bytes(artifact_payload)
+    artifact_sha256 = _sha256_bytes(artifact_bytes)
     _publish_immutable_record(
         record_dir,
         {
@@ -218,9 +272,223 @@ def write_stage_execution_record(
         "execution_identity": execution_identity,
         "resolved_config_path": resolved_relative,
         "resolved_config_identity": resolved_config_identity,
+        "resolved_config_sha256": resolved_sha256,
         "artifact_manifest_path": artifact_relative,
         "artifact_manifest_identity": artifact_identity,
+        "artifact_manifest_sha256": artifact_sha256,
     }
+
+
+def _read_mapping(path: Path, *, description: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        content = path.read_bytes()
+        payload = json.loads(content)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"invalid {description}: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"invalid {description}: {path}")
+    return payload, content
+
+
+def validate_stage_execution_record(
+    manifest_path: str | Path,
+    *,
+    expected_stage: str | None = None,
+) -> tuple[str, ...]:
+    """Validate the canonical pointer and every immutable record it references.
+
+    Historical stage manifests without ``execution_record`` remain readable. Any
+    manifest that opts into the execution-record schema is checked fail closed.
+    """
+
+    path = _path_without_symlinks(
+        Path(manifest_path), description="stage manifest path"
+    )
+    if path.parent.name != "manifests":
+        raise ValueError(f"stage manifest is outside the expected layout: {path}")
+    root = path.parent.parent
+    pointer, _ = _read_mapping(path, description="stage manifest")
+    stage = pointer.get("stage")
+    if not isinstance(stage, str) or Path(stage).name != stage or stage in {".", ".."}:
+        raise ValueError(f"invalid stage identifier in stage manifest: {stage!r}")
+    if expected_stage is not None and stage != expected_stage:
+        raise ValueError(
+            f"stage manifest identity mismatch: expected {expected_stage!r}, found {stage!r}"
+        )
+
+    pointer_config = pointer.get("config")
+    if not isinstance(pointer_config, Mapping):
+        raise ValueError("stage manifest config must be a mapping")
+    expected_config_identity = stable_hash(pointer_config, prefix=f"{stage}_cfg")
+    if pointer.get("config_identity") != expected_config_identity:
+        raise ValueError("stage manifest config identity mismatch")
+
+    pointer_semantic_config = pointer.get("semantic_config")
+    if not isinstance(pointer_semantic_config, Mapping):
+        raise ValueError("stage manifest semantic config must be a mapping")
+    expected_semantic_config_identity = stable_hash(
+        pointer_semantic_config, prefix=f"{stage}_semantic_cfg"
+    )
+    if pointer.get("semantic_config_identity") != expected_semantic_config_identity:
+        raise ValueError("stage manifest semantic config identity mismatch")
+    expected_semantic_identity = stable_hash(
+        {
+            "stage": stage,
+            "semantic_config_identity": expected_semantic_config_identity,
+            "capability_snapshot": pointer.get("capability_snapshot"),
+        },
+        prefix=f"{stage}_semantic",
+    )
+    if pointer.get("semantic_identity") != expected_semantic_identity:
+        raise ValueError("stage manifest semantic identity mismatch")
+
+    if "execution_record" not in pointer:
+        return ()
+    record = pointer.get("execution_record")
+    if (
+        not isinstance(record, Mapping)
+        or record.get("schema") != _EXECUTION_RECORD_SCHEMA
+    ):
+        raise ValueError(f"invalid stage execution record: {record!r}")
+    execution_identity = record.get("execution_identity")
+    if not isinstance(execution_identity, str) or not execution_identity:
+        raise ValueError("invalid stage execution identity")
+
+    resolved_relative = _safe_relative_path(
+        record.get("resolved_config_path"), description="stage execution record path"
+    )
+    artifact_relative = _safe_relative_path(
+        record.get("artifact_manifest_path"), description="stage execution record path"
+    )
+    expected_parent = Path("manifests") / "executions" / stage / execution_identity
+    for relative, filename in (
+        (resolved_relative, "resolved_config.json"),
+        (artifact_relative, "artifact_manifest.json"),
+    ):
+        if relative.parent != expected_parent or relative.name != filename:
+            raise ValueError(
+                f"stage execution record path does not match identity: {relative}"
+            )
+
+    resolved_path = _path_without_symlinks(
+        root / resolved_relative, description="stage execution record path"
+    )
+    artifact_path = _path_without_symlinks(
+        root / artifact_relative, description="stage execution record path"
+    )
+    resolved, resolved_bytes = _read_mapping(
+        resolved_path, description="resolved stage configuration record"
+    )
+    artifact, artifact_bytes = _read_mapping(
+        artifact_path, description="stage artifact record"
+    )
+    for label, payload in (("resolved", resolved), ("artifact", artifact)):
+        if (
+            payload.get("schema") != _EXECUTION_RECORD_SCHEMA
+            or payload.get("schema_version") != 1
+        ):
+            raise ValueError(f"invalid {label} stage execution record schema")
+        if (
+            payload.get("stage") != stage
+            or payload.get("execution_identity") != execution_identity
+        ):
+            raise ValueError(f"{label} stage execution identity mismatch")
+        for key in ("status", "skip_reason", "started_at", "ended_at"):
+            if payload.get(key) != pointer.get(key):
+                raise ValueError(f"{label} stage execution {key} mismatch")
+
+    resolved_sha256 = _sha256_bytes(resolved_bytes)
+    if record.get("resolved_config_sha256") != resolved_sha256:
+        raise ValueError("resolved stage configuration SHA256 mismatch")
+    resolved_identity = stable_hash(
+        resolved.get("resolved_stage_config"), prefix=f"{stage}_resolved_cfg"
+    )
+    if (
+        resolved.get("resolved_config_identity") != resolved_identity
+        or record.get("resolved_config_identity") != resolved_identity
+    ):
+        raise ValueError("resolved stage configuration identity mismatch")
+    for key in (
+        "authored_config_identity",
+        "semantic_config_identity",
+        "semantic_identity",
+    ):
+        pointer_key = "config_identity" if key == "authored_config_identity" else key
+        if resolved.get(key) != pointer.get(pointer_key):
+            raise ValueError(f"resolved stage {key} mismatch")
+
+    resolved_provenance = resolved.get("provenance") or {}
+    if not isinstance(resolved_provenance, Mapping):
+        raise ValueError("resolved stage provenance must be a mapping")
+    implementation = resolved_provenance.get("implementation") or {}
+    pointer_implementation = pointer.get("implementation_provenance") or {}
+    if implementation != pointer_implementation:
+        raise ValueError("resolved implementation provenance mismatch")
+    pointer_inputs = pointer.get("inputs") or {}
+    if not isinstance(pointer_inputs, Mapping):
+        raise ValueError("stage manifest inputs must be a mapping")
+    if resolved.get("semantic_config") != pointer_semantic_config:
+        raise ValueError("resolved stage semantic config mismatch")
+    if resolved_provenance.get("descriptor_resolution") != pointer_inputs.get(
+        "descriptor_resolution"
+    ):
+        raise ValueError("resolved descriptor input provenance mismatch")
+    if resolved_provenance.get("capability_snapshot") != pointer.get(
+        "capability_snapshot"
+    ):
+        raise ValueError("resolved capability provenance mismatch")
+
+    expected_execution_identity = stable_hash(
+        {
+            "stage": stage,
+            "status": resolved.get("status"),
+            "skip_reason": resolved.get("skip_reason"),
+            "started_at": resolved.get("started_at"),
+            "ended_at": resolved.get("ended_at"),
+            "authored_config_identity": resolved.get("authored_config_identity"),
+            "resolved_config_identity": resolved_identity,
+            "semantic_config_identity": resolved.get("semantic_config_identity"),
+            "semantic_identity": resolved.get("semantic_identity"),
+            "capability_snapshot": resolved_provenance.get("capability_snapshot"),
+            "implementation_provenance": implementation,
+        },
+        prefix=f"{stage}_execution",
+    )
+    if expected_execution_identity != execution_identity:
+        raise ValueError("stage execution identity does not match record content")
+
+    if record.get("artifact_manifest_sha256") != _sha256_bytes(artifact_bytes):
+        raise ValueError("stage artifact record SHA256 mismatch")
+    artifact_identity_payload = dict(artifact)
+    artifact_identity = artifact_identity_payload.pop(
+        "artifact_manifest_identity", None
+    )
+    expected_artifact_identity = stable_hash(
+        artifact_identity_payload, prefix=f"{stage}_artifacts"
+    )
+    if (
+        artifact_identity != expected_artifact_identity
+        or record.get("artifact_manifest_identity") != expected_artifact_identity
+    ):
+        raise ValueError("stage artifact record identity mismatch")
+    resolved_ref = artifact.get("resolved_config")
+    if not isinstance(resolved_ref, Mapping) or resolved_ref != {
+        "path": resolved_relative.as_posix(),
+        "identity": resolved_identity,
+        "sha256": resolved_sha256,
+    }:
+        raise ValueError("stage artifact resolved-configuration reference mismatch")
+    stage_ref = artifact.get("stage_manifest")
+    if (
+        not isinstance(stage_ref, Mapping)
+        or stage_ref.get("path") != path.relative_to(root).as_posix()
+    ):
+        raise ValueError("stage artifact canonical-manifest reference mismatch")
+    if stage_ref.get("semantic_identity") != pointer.get("semantic_identity"):
+        raise ValueError("stage artifact semantic identity mismatch")
+    if artifact.get("canonical_output_pointers") != pointer.get("outputs"):
+        raise ValueError("stage artifact canonical output pointers mismatch")
+    return resolved_relative.as_posix(), artifact_relative.as_posix()
 
 
 @dataclass
@@ -303,8 +571,6 @@ class StageManifest:
             "semantic_config_identity": self.semantic_config_identity,
             "semantic_identity": self.semantic_identity,
             "implementation_provenance": canonicalize(self.implementation_provenance),
-            "effective_config": canonicalize(self.effective_config),
-            "execution_record": canonicalize(self.execution_record),
             "capability_snapshot": canonicalize(self.capability_snapshot),
             "stale_reason": self.stale_reason,
             "started_at": self.started_at,
@@ -312,6 +578,8 @@ class StageManifest:
         }
         if self.skip_reason is not None:
             payload["skip_reason"] = self.skip_reason
+        if self.execution_record is not None:
+            payload["execution_record"] = canonicalize(self.execution_record)
         return payload
 
 
@@ -321,7 +589,9 @@ def write_stage_manifest(path: str | Path, manifest: StageManifest) -> None:
     if os.environ.get("RANK") not in (None, "", "0"):
         return
     path = Path(path)
-    manifest.execution_record = write_stage_execution_record(path, manifest.to_dict())
+    execution_payload = manifest.to_dict()
+    execution_payload["effective_config"] = canonicalize(manifest.effective_config)
+    manifest.execution_record = write_stage_execution_record(path, execution_payload)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n")

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -56,17 +56,11 @@ def _publish_immutable_record(
     record_dir: Path,
     files: dict[str, bytes],
 ) -> None:
-    record_dir = _path_without_symlinks(
-        record_dir, description="stage execution record path"
-    )
+    record_dir = _path_without_symlinks(record_dir, description="stage execution record path")
     for name in files:
-        _path_without_symlinks(
-            record_dir / name, description="stage execution record path"
-        )
+        _path_without_symlinks(record_dir / name, description="stage execution record path")
     record_dir.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(
-        tempfile.mkdtemp(prefix=f".{record_dir.name}.", dir=record_dir.parent)
-    )
+    temporary = Path(tempfile.mkdtemp(prefix=f".{record_dir.name}.", dir=record_dir.parent))
     try:
         for name, content in files.items():
             (temporary / name).write_bytes(content)
@@ -79,8 +73,7 @@ def _publish_immutable_record(
         mismatches = [
             name
             for name, content in files.items()
-            if not (record_dir / name).is_file()
-            or (record_dir / name).read_bytes() != content
+            if not (record_dir / name).is_file() or (record_dir / name).read_bytes() != content
         ]
         if mismatches:
             raise FileExistsError(
@@ -120,9 +113,7 @@ def _resolved_config_content(config: object) -> Any:
 
     if not isinstance(config, Mapping):
         return canonicalize(config)
-    return canonicalize(
-        {key: value for key, value in config.items() if key != "_runtime"}
-    )
+    return canonicalize({key: value for key, value in config.items() if key != "_runtime"})
 
 
 def write_stage_execution_record(
@@ -131,9 +122,7 @@ def write_stage_execution_record(
 ) -> dict[str, Any]:
     """Persist immutable resolved config and artifact metadata for one execution."""
 
-    manifest_path = _path_without_symlinks(
-        Path(manifest_path), description="stage manifest path"
-    )
+    manifest_path = _path_without_symlinks(Path(manifest_path), description="stage manifest path")
     if manifest_path.parent.name != "manifests":
         raise ValueError(
             f"stage manifest must use the campaign manifests directory: {manifest_path}"
@@ -157,9 +146,7 @@ def write_stage_execution_record(
         if isinstance(effective_config, Mapping)
         else effective_config
     )
-    resolved_config_identity = stable_hash(
-        resolved_config_content, prefix=f"{stage}_resolved_cfg"
-    )
+    resolved_config_identity = stable_hash(resolved_config_content, prefix=f"{stage}_resolved_cfg")
     implementation_provenance = canonicalize(
         manifest_payload.get("implementation_provenance") or {}
     )
@@ -172,9 +159,7 @@ def write_stage_execution_record(
             "ended_at": manifest_payload.get("ended_at"),
             "authored_config_identity": authored_config_identity,
             "resolved_config_identity": resolved_config_identity,
-            "semantic_config_identity": manifest_payload.get(
-                "semantic_config_identity"
-            ),
+            "semantic_config_identity": manifest_payload.get("semantic_config_identity"),
             "semantic_identity": manifest_payload.get("semantic_identity"),
             "capability_snapshot": manifest_payload.get("capability_snapshot"),
             "implementation_provenance": implementation_provenance,
@@ -188,9 +173,7 @@ def write_stage_execution_record(
     artifact_relative = str(artifact_path.relative_to(root))
 
     inputs = manifest_payload.get("inputs") or {}
-    runtime = (
-        effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
-    )
+    runtime = effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
     runtime = runtime if isinstance(runtime, dict) else {}
     resolved_payload = {
         "schema": _EXECUTION_RECORD_SCHEMA,
@@ -301,9 +284,7 @@ def validate_stage_execution_record(
     manifest that opts into the execution-record schema is checked fail closed.
     """
 
-    path = _path_without_symlinks(
-        Path(manifest_path), description="stage manifest path"
-    )
+    path = _path_without_symlinks(Path(manifest_path), description="stage manifest path")
     if path.parent.name != "manifests":
         raise ValueError(f"stage manifest is outside the expected layout: {path}")
     root = path.parent.parent
@@ -345,10 +326,7 @@ def validate_stage_execution_record(
     if "execution_record" not in pointer:
         return ()
     record = pointer.get("execution_record")
-    if (
-        not isinstance(record, Mapping)
-        or record.get("schema") != _EXECUTION_RECORD_SCHEMA
-    ):
+    if not isinstance(record, Mapping) or record.get("schema") != _EXECUTION_RECORD_SCHEMA:
         raise ValueError(f"invalid stage execution record: {record!r}")
     execution_identity = record.get("execution_identity")
     if not isinstance(execution_identity, str) or not execution_identity:
@@ -366,9 +344,7 @@ def validate_stage_execution_record(
         (artifact_relative, "artifact_manifest.json"),
     ):
         if relative.parent != expected_parent or relative.name != filename:
-            raise ValueError(
-                f"stage execution record path does not match identity: {relative}"
-            )
+            raise ValueError(f"stage execution record path does not match identity: {relative}")
 
     resolved_path = _path_without_symlinks(
         root / resolved_relative, description="stage execution record path"
@@ -379,9 +355,7 @@ def validate_stage_execution_record(
     resolved, resolved_bytes = _read_mapping(
         resolved_path, description="resolved stage configuration record"
     )
-    artifact, artifact_bytes = _read_mapping(
-        artifact_path, description="stage artifact record"
-    )
+    artifact, artifact_bytes = _read_mapping(artifact_path, description="stage artifact record")
     resolved_sha256 = _sha256_bytes(resolved_bytes)
     if record.get("resolved_config_sha256") != resolved_sha256:
         raise ValueError("resolved stage configuration SHA256 mismatch")
@@ -389,15 +363,9 @@ def validate_stage_execution_record(
         raise ValueError("stage artifact record SHA256 mismatch")
 
     for label, payload in (("resolved", resolved), ("artifact", artifact)):
-        if (
-            payload.get("schema") != _EXECUTION_RECORD_SCHEMA
-            or payload.get("schema_version") != 1
-        ):
+        if payload.get("schema") != _EXECUTION_RECORD_SCHEMA or payload.get("schema_version") != 1:
             raise ValueError(f"invalid {label} stage execution record schema")
-        if (
-            payload.get("stage") != stage
-            or payload.get("execution_identity") != execution_identity
-        ):
+        if payload.get("stage") != stage or payload.get("execution_identity") != execution_identity:
             raise ValueError(f"{label} stage execution identity mismatch")
         for key in ("status", "skip_reason", "started_at", "ended_at"):
             if payload.get(key) != pointer.get(key):
@@ -436,9 +404,7 @@ def validate_stage_execution_record(
         "descriptor_resolution"
     ):
         raise ValueError("resolved descriptor input provenance mismatch")
-    if resolved_provenance.get("capability_snapshot") != pointer.get(
-        "capability_snapshot"
-    ):
+    if resolved_provenance.get("capability_snapshot") != pointer.get("capability_snapshot"):
         raise ValueError("resolved capability provenance mismatch")
 
     expected_execution_identity = stable_hash(
@@ -461,12 +427,8 @@ def validate_stage_execution_record(
         raise ValueError("stage execution identity does not match record content")
 
     artifact_identity_payload = dict(artifact)
-    artifact_identity = artifact_identity_payload.pop(
-        "artifact_manifest_identity", None
-    )
-    expected_artifact_identity = stable_hash(
-        artifact_identity_payload, prefix=f"{stage}_artifacts"
-    )
+    artifact_identity = artifact_identity_payload.pop("artifact_manifest_identity", None)
+    expected_artifact_identity = stable_hash(artifact_identity_payload, prefix=f"{stage}_artifacts")
     if (
         artifact_identity != expected_artifact_identity
         or record.get("artifact_manifest_identity") != expected_artifact_identity

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -18,8 +18,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import shutil
+import sys
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,12 +35,192 @@ __all__ = [
     "StageManifest",
     "read_stage_manifest",
     "semantic_stage_config",
+    "write_stage_execution_record",
     "write_stage_manifest",
 ]
 
 
+_EXECUTION_RECORD_SCHEMA = "puzzletron.stage-execution/v1"
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _json_bytes(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(canonicalize(payload), indent=2, sort_keys=True) + "\n").encode()
+
+
+def _replay_contract(
+    config: dict[str, Any],
+    stage: str,
+    resolved_config_path: Path,
+) -> dict[str, Any]:
+    runtime = config.get("_runtime") or {}
+    repository_root = Path(__file__).resolve().parents[3]
+    command = [
+        sys.executable,
+        str(repository_root / "examples" / "puzzletron" / "main.py"),
+        "--config",
+        str(resolved_config_path),
+        "--stage",
+        stage,
+    ]
+    gpus_per_node = runtime.get("gpus_per_node")
+    if gpus_per_node is not None:
+        command.extend(("--gpus-per-node", str(gpus_per_node)))
+    command.append("--force")
+    return {
+        "available": True,
+        "argv": command,
+        "working_directory": str(repository_root),
+    }
+
+
+def _publish_immutable_record(
+    record_dir: Path,
+    files: dict[str, bytes],
+) -> None:
+    record_dir.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{record_dir.name}.", dir=record_dir.parent))
+    try:
+        for name, content in files.items():
+            (temporary / name).write_bytes(content)
+        try:
+            temporary.rename(record_dir)
+            return
+        except OSError:
+            if not record_dir.is_dir():
+                raise
+        mismatches = [
+            name
+            for name, content in files.items()
+            if not (record_dir / name).is_file() or (record_dir / name).read_bytes() != content
+        ]
+        if mismatches:
+            raise FileExistsError(
+                f"immutable stage execution record already exists with different content: "
+                f"{record_dir} ({', '.join(mismatches)})"
+            )
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+
+
+def write_stage_execution_record(
+    manifest_path: str | Path,
+    manifest_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Persist immutable resolved config and artifact metadata for one execution."""
+
+    manifest_path = Path(manifest_path).absolute()
+    if manifest_path.parent.name != "manifests":
+        raise ValueError(
+            f"stage manifest must use the campaign manifests directory: {manifest_path}"
+        )
+    root = manifest_path.parent.parent
+    stage = str(manifest_payload.get("stage") or "")
+    if not stage or Path(stage).name != stage or stage in {".", ".."}:
+        raise ValueError(f"invalid stage identifier for execution record: {stage!r}")
+
+    authored_config = canonicalize(manifest_payload.get("config") or {})
+    raw_effective_config = manifest_payload.get("effective_config")
+    effective_config = canonicalize(
+        authored_config if raw_effective_config is None else raw_effective_config
+    )
+    authored_config_identity = str(
+        manifest_payload.get("config_identity")
+        or stable_hash(authored_config, prefix=f"{stage}_cfg")
+    )
+    resolved_config_identity = stable_hash(effective_config, prefix=f"{stage}_resolved_cfg")
+    execution_identity = stable_hash(
+        {
+            "stage": stage,
+            "status": manifest_payload.get("status"),
+            "started_at": manifest_payload.get("started_at"),
+            "ended_at": manifest_payload.get("ended_at"),
+            "authored_config_identity": authored_config_identity,
+            "resolved_config_identity": resolved_config_identity,
+            "semantic_config_identity": manifest_payload.get("semantic_config_identity"),
+            "semantic_identity": manifest_payload.get("semantic_identity"),
+            "capability_snapshot": manifest_payload.get("capability_snapshot"),
+        },
+        prefix=f"{stage}_execution",
+    )
+    record_dir = root / "manifests" / "executions" / stage / execution_identity
+    resolved_path = record_dir / "resolved_config.json"
+    artifact_path = record_dir / "artifact_manifest.json"
+    resolved_relative = str(resolved_path.relative_to(root))
+    artifact_relative = str(artifact_path.relative_to(root))
+
+    inputs = manifest_payload.get("inputs") or {}
+    runtime = effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
+    runtime = runtime if isinstance(runtime, dict) else {}
+    resolved_payload = {
+        "schema": _EXECUTION_RECORD_SCHEMA,
+        "schema_version": 1,
+        "stage": stage,
+        "status": manifest_payload.get("status"),
+        "started_at": manifest_payload.get("started_at"),
+        "ended_at": manifest_payload.get("ended_at"),
+        "execution_identity": execution_identity,
+        "authored_config_identity": authored_config_identity,
+        "resolved_config_identity": resolved_config_identity,
+        "semantic_config": manifest_payload.get("semantic_config") or {},
+        "semantic_config_identity": manifest_payload.get("semantic_config_identity"),
+        "semantic_identity": manifest_payload.get("semantic_identity"),
+        "effective_config": effective_config,
+        "provenance": {
+            "authored_config_path": runtime.get("config_path"),
+            "overrides": list(runtime.get("overrides") or ()),
+            "implementation": manifest_payload.get("implementation_provenance") or {},
+            "descriptor_resolution": inputs.get("descriptor_resolution"),
+            "capability_snapshot": manifest_payload.get("capability_snapshot"),
+        },
+        "replay": _replay_contract(effective_config, stage, resolved_path),
+    }
+    resolved_bytes = _json_bytes(resolved_payload)
+    resolved_sha256 = hashlib.sha256(resolved_bytes).hexdigest()
+
+    declared_outputs = manifest_payload.get("outputs") or {}
+    artifact_payload = {
+        "schema": _EXECUTION_RECORD_SCHEMA,
+        "schema_version": 1,
+        "stage": stage,
+        "status": manifest_payload.get("status"),
+        "started_at": manifest_payload.get("started_at"),
+        "ended_at": manifest_payload.get("ended_at"),
+        "execution_identity": execution_identity,
+        "resolved_config": {
+            "path": resolved_relative,
+            "identity": resolved_config_identity,
+            "sha256": resolved_sha256,
+        },
+        "stage_manifest": {
+            "path": str(manifest_path.relative_to(root)),
+            "semantic_identity": manifest_payload.get("semantic_identity"),
+        },
+        "artifact_contract": "stage-manifest-outputs",
+        "declared_outputs": declared_outputs,
+    }
+    artifact_identity = stable_hash(artifact_payload, prefix=f"{stage}_artifacts")
+    artifact_payload["artifact_manifest_identity"] = artifact_identity
+    artifact_bytes = _json_bytes(artifact_payload)
+    _publish_immutable_record(
+        record_dir,
+        {
+            resolved_path.name: resolved_bytes,
+            artifact_path.name: artifact_bytes,
+        },
+    )
+    return {
+        "schema": _EXECUTION_RECORD_SCHEMA,
+        "execution_identity": execution_identity,
+        "resolved_config_path": resolved_relative,
+        "resolved_config_identity": resolved_config_identity,
+        "artifact_manifest_path": artifact_relative,
+        "artifact_manifest_identity": artifact_identity,
+    }
 
 
 @dataclass
@@ -53,6 +237,8 @@ class StageManifest:
     semantic_config: dict[str, Any] | None = None
     implementation_provenance: dict[str, Any] = field(default_factory=dict)
     skip_reason: str | None = None
+    effective_config: dict[str, Any] | None = None
+    execution_record: dict[str, Any] | None = None
     stale_reason: str | None = None
     started_at: str = field(default_factory=_now_iso)
     ended_at: str | None = None
@@ -117,6 +303,8 @@ class StageManifest:
             "semantic_config_identity": self.semantic_config_identity,
             "semantic_identity": self.semantic_identity,
             "implementation_provenance": canonicalize(self.implementation_provenance),
+            "effective_config": canonicalize(self.effective_config),
+            "execution_record": canonicalize(self.execution_record),
             "capability_snapshot": canonicalize(self.capability_snapshot),
             "stale_reason": self.stale_reason,
             "started_at": self.started_at,
@@ -133,6 +321,7 @@ def write_stage_manifest(path: str | Path, manifest: StageManifest) -> None:
     if os.environ.get("RANK") not in (None, "", "0"):
         return
     path = Path(path)
+    manifest.execution_record = write_stage_execution_record(path, manifest.to_dict())
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n")

--- a/modelopt/torch/puzzletron/pipeline_config.py
+++ b/modelopt/torch/puzzletron/pipeline_config.py
@@ -228,9 +228,7 @@ def normalize_pipeline_config(config: DictConfig | dict[str, Any]) -> dict[str, 
     _deep_update_missing(convert, "teacher_dir", cfg.get("teacher_dir"))
     _deep_update_missing(sort_sanity, "include_reverse", True)
     _normalize_positive_count(aiperf, "num_best_to_eval", "aiperf")
-    _normalize_positive_count(
-        global_distillation, "num_best_to_distill", "global_distillation"
-    )
+    _normalize_positive_count(global_distillation, "num_best_to_distill", "global_distillation")
     if "dir" in experiment and "teacher_dir" not in convert:
         convert["teacher_dir"] = str(Path(experiment["dir"]) / "ckpts" / "teacher")
 
@@ -367,9 +365,7 @@ def _set_missing(node: DictConfig, key: str, value: Any) -> None:
         node[key] = value
 
 
-def adapt_runtime_hydra_config(
-    hydra_cfg: DictConfig, config: dict[str, Any]
-) -> DictConfig:
+def adapt_runtime_hydra_config(hydra_cfg: DictConfig, config: dict[str, Any]) -> DictConfig:
     """Fill runtime Hydra fields from the unified config boundary.
 
     This adapter exists only at the stage boundary. It keeps the new canonical
@@ -388,9 +384,7 @@ def adapt_runtime_hydra_config(
         or _nested(config, "data", "path")
         or config.get("dataset_path")
     )
-    canonical_data = (
-        PuzzletronDataSpec.from_mapping(config["data"]) if config.get("data") else None
-    )
+    canonical_data = PuzzletronDataSpec.from_mapping(config["data"]) if config.get("data") else None
 
     _set_missing(hydra_cfg, "puzzle_dir", experiment_dir)
     _set_missing(hydra_cfg, "input_hf_model_path", model_source)
@@ -415,20 +409,14 @@ def adapt_runtime_hydra_config(
         _set_missing(
             pruning,
             "activations_log_dir",
-            str(
-                Path(hydra_cfg.puzzle_dir) / "pruning" / "pruning_scores" / "activation"
-            )
+            str(Path(hydra_cfg.puzzle_dir) / "pruning" / "pruning_scores" / "activation")
             if hydra_cfg.get("puzzle_dir") is not None
             else None,
         )
         if "activation_hooks_kwargs" not in pruning:
-            pruning.activation_hooks_kwargs = {
-                "method": calibration.get("ffn_method", "iterative")
-            }
+            pruning.activation_hooks_kwargs = {"method": calibration.get("ffn_method", "iterative")}
         automodel = _ensure_dictconfig_child(pruning, "automodel")
-        _set_missing(
-            automodel, "force_hf", _nested(config, "model", "force_hf", default=True)
-        )
+        _set_missing(automodel, "force_hf", _nested(config, "model", "force_hf", default=True))
         _set_missing(automodel, "use_puzzletron_dataloader", True)
 
     for stage in ("depth", "bypass"):
@@ -454,8 +442,7 @@ def adapt_runtime_hydra_config(
         _set_missing(
             scoring,
             "eval_samples",
-            _nested(config, "replacement_scoring", "num_samples")
-            or data.get("num_samples"),
+            _nested(config, "replacement_scoring", "num_samples") or data.get("num_samples"),
         )
         _set_missing(scoring, "micro_batch_size", data.get("micro_batch_size", 1))
         if canonical_data is not None:
@@ -463,9 +450,7 @@ def adapt_runtime_hydra_config(
             _set_missing(scoring, "varlen", canonical_data.legacy_varlen)
         _set_missing(scoring, "backend", "automodel")
         automodel = _ensure_dictconfig_child(scoring, "automodel")
-        _set_missing(
-            automodel, "force_hf", _nested(config, "model", "force_hf", default=True)
-        )
+        _set_missing(automodel, "force_hf", _nested(config, "model", "force_hf", default=True))
         _set_missing(
             automodel,
             "temperature",

--- a/modelopt/torch/puzzletron/pipeline_config.py
+++ b/modelopt/torch/puzzletron/pipeline_config.py
@@ -298,7 +298,7 @@ def load_runtime_hydra_config(config: dict[str, Any]) -> DictConfig:
     """Reconstruct the instantiated Hydra config used by GPU-heavy stages."""
     runtime = dict(config.get("_runtime") or {})
     config_path = runtime.get("config_path")
-    if runtime.get("resolved_config_path") or not config_path:
+    if not config_path:
         hydra_cfg = OmegaConf.create(config)
         OmegaConf.set_struct(hydra_cfg, False)
         _install_runtime_section_aliases(hydra_cfg)

--- a/modelopt/torch/puzzletron/pipeline_config.py
+++ b/modelopt/torch/puzzletron/pipeline_config.py
@@ -367,7 +367,9 @@ def _set_missing(node: DictConfig, key: str, value: Any) -> None:
         node[key] = value
 
 
-def adapt_runtime_hydra_config(hydra_cfg: DictConfig, config: dict[str, Any]) -> DictConfig:
+def adapt_runtime_hydra_config(
+    hydra_cfg: DictConfig, config: dict[str, Any]
+) -> DictConfig:
     """Fill runtime Hydra fields from the unified config boundary.
 
     This adapter exists only at the stage boundary. It keeps the new canonical
@@ -386,7 +388,9 @@ def adapt_runtime_hydra_config(hydra_cfg: DictConfig, config: dict[str, Any]) ->
         or _nested(config, "data", "path")
         or config.get("dataset_path")
     )
-    canonical_data = PuzzletronDataSpec.from_mapping(config["data"]) if config.get("data") else None
+    canonical_data = (
+        PuzzletronDataSpec.from_mapping(config["data"]) if config.get("data") else None
+    )
 
     _set_missing(hydra_cfg, "puzzle_dir", experiment_dir)
     _set_missing(hydra_cfg, "input_hf_model_path", model_source)
@@ -411,14 +415,20 @@ def adapt_runtime_hydra_config(hydra_cfg: DictConfig, config: dict[str, Any]) ->
         _set_missing(
             pruning,
             "activations_log_dir",
-            str(Path(hydra_cfg.puzzle_dir) / "pruning" / "pruning_scores" / "activation")
+            str(
+                Path(hydra_cfg.puzzle_dir) / "pruning" / "pruning_scores" / "activation"
+            )
             if hydra_cfg.get("puzzle_dir") is not None
             else None,
         )
         if "activation_hooks_kwargs" not in pruning:
-            pruning.activation_hooks_kwargs = {"method": calibration.get("ffn_method", "iterative")}
+            pruning.activation_hooks_kwargs = {
+                "method": calibration.get("ffn_method", "iterative")
+            }
         automodel = _ensure_dictconfig_child(pruning, "automodel")
-        _set_missing(automodel, "force_hf", _nested(config, "model", "force_hf", default=True))
+        _set_missing(
+            automodel, "force_hf", _nested(config, "model", "force_hf", default=True)
+        )
         _set_missing(automodel, "use_puzzletron_dataloader", True)
 
     for stage in ("depth", "bypass"):
@@ -444,7 +454,8 @@ def adapt_runtime_hydra_config(hydra_cfg: DictConfig, config: dict[str, Any]) ->
         _set_missing(
             scoring,
             "eval_samples",
-            _nested(config, "replacement_scoring", "num_samples") or data.get("num_samples"),
+            _nested(config, "replacement_scoring", "num_samples")
+            or data.get("num_samples"),
         )
         _set_missing(scoring, "micro_batch_size", data.get("micro_batch_size", 1))
         if canonical_data is not None:
@@ -452,12 +463,18 @@ def adapt_runtime_hydra_config(hydra_cfg: DictConfig, config: dict[str, Any]) ->
             _set_missing(scoring, "varlen", canonical_data.legacy_varlen)
         _set_missing(scoring, "backend", "automodel")
         automodel = _ensure_dictconfig_child(scoring, "automodel")
-        _set_missing(automodel, "force_hf", _nested(config, "model", "force_hf", default=True))
         _set_missing(
-            automodel, "temperature", _nested(config, "replacement_scoring", "temperature")
+            automodel, "force_hf", _nested(config, "model", "force_hf", default=True)
         )
         _set_missing(
-            automodel, "chunk_size", _nested(config, "replacement_scoring", "chunk_size")
+            automodel,
+            "temperature",
+            _nested(config, "replacement_scoring", "temperature"),
+        )
+        _set_missing(
+            automodel,
+            "chunk_size",
+            _nested(config, "replacement_scoring", "chunk_size"),
         )
 
     if "realize_model" in hydra_cfg:

--- a/modelopt/torch/puzzletron/pipeline_config.py
+++ b/modelopt/torch/puzzletron/pipeline_config.py
@@ -300,7 +300,7 @@ def load_runtime_hydra_config(config: dict[str, Any]) -> DictConfig:
     """Reconstruct the instantiated Hydra config used by GPU-heavy stages."""
     runtime = dict(config.get("_runtime") or {})
     config_path = runtime.get("config_path")
-    if not config_path:
+    if runtime.get("resolved_config_path") or not config_path:
         hydra_cfg = OmegaConf.create(config)
         OmegaConf.set_struct(hydra_cfg, False)
         _install_runtime_section_aliases(hydra_cfg)

--- a/modelopt/torch/puzzletron/stage_runner.py
+++ b/modelopt/torch/puzzletron/stage_runner.py
@@ -223,15 +223,6 @@ def run_stage(
     except CapabilityValidationError:
         raise
 
-    manifest = StageManifest(
-        stage=stage,
-        inputs={
-            "config": cfg,
-            "descriptor_resolution": resolution.to_dict() if resolution else None,
-        },
-        config=cfg,
-        capability_snapshot=resolution.capabilities.to_dict() if resolution else None,
-    )
     runtime_cfg = copy.deepcopy(cfg)
     if resolution is not None:
         runtime = dict(runtime_cfg.get("_runtime") or {})
@@ -241,6 +232,16 @@ def run_stage(
             descriptor_confidence=resolution.confidence,
         )
         runtime_cfg["_runtime"] = runtime
+    manifest = StageManifest(
+        stage=stage,
+        inputs={
+            "config": cfg,
+            "descriptor_resolution": resolution.to_dict() if resolution else None,
+        },
+        config=cfg,
+        effective_config=runtime_cfg,
+        capability_snapshot=resolution.capabilities.to_dict() if resolution else None,
+    )
 
     handler_map = handlers
     if handler_map is None:

--- a/modelopt/torch/puzzletron/stage_runner.py
+++ b/modelopt/torch/puzzletron/stage_runner.py
@@ -239,7 +239,7 @@ def run_stage(
             "descriptor_resolution": resolution.to_dict() if resolution else None,
         },
         config=cfg,
-        effective_config=runtime_cfg,
+        effective_config=copy.deepcopy(runtime_cfg),
         capability_snapshot=resolution.capabilities.to_dict() if resolution else None,
     )
 

--- a/modelopt/torch/puzzletron/stage_runner.py
+++ b/modelopt/torch/puzzletron/stage_runner.py
@@ -55,7 +55,9 @@ def normalize_config(config: DictConfig | dict[str, Any]) -> dict[str, Any]:
     return normalize_pipeline_config(config)
 
 
-def _get_nested(config: dict[str, Any], path: tuple[str, ...], default: Any = None) -> Any:
+def _get_nested(
+    config: dict[str, Any], path: tuple[str, ...], default: Any = None
+) -> Any:
     value: Any = config
     for key in path:
         if not isinstance(value, dict) or key not in value:
@@ -101,7 +103,9 @@ def _resolve_capabilities(config: dict[str, Any]) -> DescriptorResolution | None
     if descriptor_override and (not source or not Path(str(source)).exists()):
         return resolve_descriptor_by_name(descriptor_override)
     if not source:
-        raise ValueError("Puzzletron config must define model.source or model.descriptor_override")
+        raise ValueError(
+            "Puzzletron config must define model.source or model.descriptor_override"
+        )
     return resolve_descriptor_from_pretrained(
         source,
         trust_remote_code=bool(model_cfg.get("trust_remote_code", False)),
@@ -140,7 +144,9 @@ def _preflight(
             break
     model_cfg = config.get("model") or {}
     library_cfg = config.get("library") or {}
-    runtime_stats_cfg = (config.get("calc_subblock_stats") or {}).get("runtime_stats") or {}
+    runtime_stats_cfg = (config.get("calc_subblock_stats") or {}).get(
+        "runtime_stats"
+    ) or {}
     capability_validation = config.get("capability_validation") or {}
     require_vllm = (
         bool((config.get("vllm_stats") or {}).get("enabled", False))
@@ -194,7 +200,8 @@ def run_stage(
     config: DictConfig | dict[str, Any],
     stage: str,
     *,
-    handlers: dict[str, Callable[[dict[str, Any], StageManifest], StageResult]] | None = None,
+    handlers: dict[str, Callable[[dict[str, Any], StageManifest], StageResult]]
+    | None = None,
 ) -> StageResult:
     """Run a Puzzletron stage through the manifest and capability boundary.
 
@@ -203,7 +210,9 @@ def run_stage(
     """
     stage = canonical_stage_name(stage)
     if stage not in STAGES:
-        raise ValueError(f"Unknown Puzzletron stage '{stage}'. Expected one of {STAGES}")
+        raise ValueError(
+            f"Unknown Puzzletron stage '{stage}'. Expected one of {STAGES}"
+        )
 
     cfg = normalize_config(config)
     if not stage_is_enabled(stage, cfg):

--- a/modelopt/torch/puzzletron/stage_runner.py
+++ b/modelopt/torch/puzzletron/stage_runner.py
@@ -55,9 +55,7 @@ def normalize_config(config: DictConfig | dict[str, Any]) -> dict[str, Any]:
     return normalize_pipeline_config(config)
 
 
-def _get_nested(
-    config: dict[str, Any], path: tuple[str, ...], default: Any = None
-) -> Any:
+def _get_nested(config: dict[str, Any], path: tuple[str, ...], default: Any = None) -> Any:
     value: Any = config
     for key in path:
         if not isinstance(value, dict) or key not in value:
@@ -103,9 +101,7 @@ def _resolve_capabilities(config: dict[str, Any]) -> DescriptorResolution | None
     if descriptor_override and (not source or not Path(str(source)).exists()):
         return resolve_descriptor_by_name(descriptor_override)
     if not source:
-        raise ValueError(
-            "Puzzletron config must define model.source or model.descriptor_override"
-        )
+        raise ValueError("Puzzletron config must define model.source or model.descriptor_override")
     return resolve_descriptor_from_pretrained(
         source,
         trust_remote_code=bool(model_cfg.get("trust_remote_code", False)),
@@ -144,9 +140,7 @@ def _preflight(
             break
     model_cfg = config.get("model") or {}
     library_cfg = config.get("library") or {}
-    runtime_stats_cfg = (config.get("calc_subblock_stats") or {}).get(
-        "runtime_stats"
-    ) or {}
+    runtime_stats_cfg = (config.get("calc_subblock_stats") or {}).get("runtime_stats") or {}
     capability_validation = config.get("capability_validation") or {}
     require_vllm = (
         bool((config.get("vllm_stats") or {}).get("enabled", False))
@@ -200,8 +194,7 @@ def run_stage(
     config: DictConfig | dict[str, Any],
     stage: str,
     *,
-    handlers: dict[str, Callable[[dict[str, Any], StageManifest], StageResult]]
-    | None = None,
+    handlers: dict[str, Callable[[dict[str, Any], StageManifest], StageResult]] | None = None,
 ) -> StageResult:
     """Run a Puzzletron stage through the manifest and capability boundary.
 
@@ -210,9 +203,7 @@ def run_stage(
     """
     stage = canonical_stage_name(stage)
     if stage not in STAGES:
-        raise ValueError(
-            f"Unknown Puzzletron stage '{stage}'. Expected one of {STAGES}"
-        )
+        raise ValueError(f"Unknown Puzzletron stage '{stage}'. Expected one of {STAGES}")
 
     cfg = normalize_config(config)
     if not stage_is_enabled(stage, cfg):

--- a/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
+++ b/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import dataclasses
@@ -551,6 +566,7 @@ def test_stage_runtime_receives_inferred_descriptor_without_persisting_override(
     def handler(config, manifest):
         observed["runtime_descriptor"] = config["_runtime"]["descriptor"]
         observed["manifest_config"] = manifest.config
+        observed["manifest_effective_config"] = manifest.effective_config
         observed["resolution"] = manifest.inputs["descriptor_resolution"]
         return StageResult(
             stage="width_importance",
@@ -574,6 +590,7 @@ def test_stage_runtime_receives_inferred_descriptor_without_persisting_override(
 
     assert observed["runtime_descriptor"] == "llama"
     assert "_runtime" not in observed["manifest_config"]
+    assert observed["manifest_effective_config"]["_runtime"]["descriptor"] == "llama"
     assert "descriptor_override" not in observed["manifest_config"]["model"]
     assert observed["resolution"]["name"] == "llama"
 

--- a/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
+++ b/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
@@ -27,7 +27,9 @@ from modelopt.torch.puzzletron.anymodel.capabilities import (
     default_capabilities,
     validate_capabilities,
 )
-from modelopt.torch.puzzletron.anymodel.models.gpt_oss.gpt_oss_converter import GptOssConverter
+from modelopt.torch.puzzletron.anymodel.models.gpt_oss.gpt_oss_converter import (
+    GptOssConverter,
+)
 from modelopt.torch.puzzletron.anymodel.models.gpt_oss.gpt_oss_model_descriptor import (
     GptOssModelDescriptor,
 )
@@ -41,7 +43,10 @@ from modelopt.torch.puzzletron.anymodel.models.qwen3_5.qwen3_5_model_descriptor 
     Qwen3P5TextModelDescriptor,
     Qwen3P5VLModelDescriptor,
 )
-from modelopt.torch.puzzletron.anymodel.registry import infer_descriptor_name, resolve_descriptor
+from modelopt.torch.puzzletron.anymodel.registry import (
+    infer_descriptor_name,
+    resolve_descriptor,
+)
 from modelopt.torch.puzzletron.block_config import (
     AttentionConfig,
     BlockConfig,
@@ -346,17 +351,27 @@ def test_nemotron_hidden_width_spec_covers_hf_and_native_hybrid_tensors() -> Non
         "backbone.layers.1.mixer.q_proj.weight": torch.zeros(8, 2688),
         "backbone.layers.1.mixer.o_proj.weight": torch.zeros(2688, 8),
         "backbone.layers.2.mixer.gate.weight": torch.zeros(4, 2688),
-        "backbone.layers.2.mixer.fc1_latent_proj.weight": torch.zeros(latent_size, 2688),
-        "backbone.layers.2.mixer.fc2_latent_proj.weight": torch.zeros(2688, latent_size),
+        "backbone.layers.2.mixer.fc1_latent_proj.weight": torch.zeros(
+            latent_size, 2688
+        ),
+        "backbone.layers.2.mixer.fc2_latent_proj.weight": torch.zeros(
+            2688, latent_size
+        ),
         "backbone.layers.2.mixer.experts.0.up_proj.weight": torch.zeros(6, latent_size),
-        "backbone.layers.2.mixer.experts.0.down_proj.weight": torch.zeros(latent_size, 6),
+        "backbone.layers.2.mixer.experts.0.down_proj.weight": torch.zeros(
+            latent_size, 6
+        ),
         "backbone.layers.2.mixer.shared_experts.up_proj.weight": torch.zeros(12, 2688),
-        "backbone.layers.2.mixer.shared_experts.down_proj.weight": torch.zeros(2688, 12),
+        "backbone.layers.2.mixer.shared_experts.down_proj.weight": torch.zeros(
+            2688, 12
+        ),
         "backbone.norm_f.weight": torch.zeros(2688),
         "lm_head.weight": torch.zeros(8, 2688),
         "model.layers.3.mixer.fc1_latent_proj.weight": torch.zeros(latent_size, 2688),
         "model.layers.3.mixer.fc2_latent_proj.weight": torch.zeros(2688, latent_size),
-        "model.layers.3.mixer.experts.gate_and_up_projs": torch.zeros(4, latent_size, 6),
+        "model.layers.3.mixer.experts.gate_and_up_projs": torch.zeros(
+            4, latent_size, 6
+        ),
         "model.layers.3.mixer.experts.down_projs": torch.zeros(4, 6, latent_size),
         "mtp.layers.0.eh_proj.weight": torch.zeros(2688, 2 * 2688),
         "mtp.layers.0.enorm.weight": torch.zeros(2688),
@@ -469,7 +484,9 @@ def test_nemotron_moe_variant_axes_cover_scoring_and_materialization() -> None:
         SimpleNamespace(hidden_size=2688)
     ).axes
 
-    assert axes["moe_experts"].runtime_slice_impl == "solution_recipe.moe_expert_reroute"
+    assert (
+        axes["moe_experts"].runtime_slice_impl == "solution_recipe.moe_expert_reroute"
+    )
     assert axes["moe_top_k"].materialize_impl == "materialize.config_only_moe_top_k"
 
 
@@ -485,7 +502,9 @@ def test_nemotron_nano_capabilities_exclude_absent_latent_axis() -> None:
     assert "moe_latent_dim" in super_axes
 
 
-def test_nemotron_equivalence_tolerance_accounts_for_bf16_hidden_basis_permutation() -> None:
+def test_nemotron_equivalence_tolerance_accounts_for_bf16_hidden_basis_permutation() -> (
+    None
+):
     assert NemotronHModelDescriptor.checkpoint_equivalence_tolerances() == {
         "max_abs_lm_loss_delta": 5.0e-3,
         "max_kl_div": 1.0e-2,
@@ -529,7 +548,12 @@ def test_gpt_oss_embedding_spec_preserves_mxfp4_input_channel_blocks() -> None:
 
     assert len(audit["handled"]) == len(state)
     assert torch.equal(order, torch.cat((torch.arange(32, 64), torch.arange(32))))
-    assert sliced["model.layers.0.mlp.experts.gate_up_proj_blocks"].shape == (2, 128, 1, 16)
+    assert sliced["model.layers.0.mlp.experts.gate_up_proj_blocks"].shape == (
+        2,
+        128,
+        1,
+        16,
+    )
     assert sliced["model.layers.0.mlp.experts.down_proj_blocks"].shape == (2, 32, 2, 16)
 
 
@@ -815,9 +839,7 @@ def test_nemotron_runtime_proxy_supplies_legacy_hybrid_pattern(monkeypatch) -> N
     monkeypatch.setattr(
         NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfig
     )
-    monkeypatch.setattr(
-        NemotronHModelDescriptor, "_runtime_model_cls", lambda: object
-    )
+    monkeypatch.setattr(NemotronHModelDescriptor, "_runtime_model_cls", lambda: object)
 
     with pytest.raises(_CapturedConfig):
         NemotronHModelDescriptor.create_runtime_benchmark_model(runtime, blocks)
@@ -858,12 +880,16 @@ def test_nemotron_runtime_proxy_uses_active_mamba_shape_for_global_initializatio
         model_config_value=lambda name, default=None: values.get(name, default),
     )
     blocks = [
-        BlockConfig(subblock_configs=(AttentionConfig(num_query_heads=4, num_kv_heads=2),)),
+        BlockConfig(
+            subblock_configs=(AttentionConfig(num_query_heads=4, num_kv_heads=2),)
+        ),
         BlockConfig(
             subblock_configs=(MambaConfig(num_heads=48, head_dim=56, state_dim=96),)
         ),
     ]
-    monkeypatch.setattr(NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfig)
+    monkeypatch.setattr(
+        NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfig
+    )
     monkeypatch.setattr(NemotronHModelDescriptor, "_runtime_model_cls", lambda: object)
 
     with pytest.raises(_CapturedConfig):
@@ -891,10 +917,14 @@ def test_llama_requests_scaffold_only_for_cacheless_candidate() -> None:
 
 def test_nemotron_requests_attention_scaffold_for_cacheless_candidates() -> None:
     attention = BlockConfig(
-        subblock_configs=(AttentionConfig(no_op=False, num_query_heads=32, num_kv_heads=2),)
+        subblock_configs=(
+            AttentionConfig(no_op=False, num_query_heads=32, num_kv_heads=2),
+        )
     )
     mamba = BlockConfig(
-        subblock_configs=(MambaConfig(no_op=False, num_heads=48, head_dim=64, state_dim=128),)
+        subblock_configs=(
+            MambaConfig(no_op=False, num_heads=48, head_dim=64, state_dim=128),
+        )
     )
     moe = BlockConfig(
         subblock_configs=(
@@ -902,7 +932,9 @@ def test_nemotron_requests_attention_scaffold_for_cacheless_candidates() -> None
         )
     )
 
-    assert NemotronHModelDescriptor.runtime_benchmark_scaffold_policy(attention) == "none"
+    assert (
+        NemotronHModelDescriptor.runtime_benchmark_scaffold_policy(attention) == "none"
+    )
     assert (
         NemotronHModelDescriptor.runtime_benchmark_scaffold_policy(mamba)
         == "attention_scaffold_per_pp_stage"
@@ -958,18 +990,29 @@ def test_nemotron_runtime_bounding_preserves_native_moe_and_mamba_families() -> 
         subblock_configs=(MambaConfig(num_heads=64, head_dim=32), FFNConfig(no_op=True))
     )
 
-    bounded_moe = NemotronHModelDescriptor._runtime_proxy_block_config(runtime, moe_block)
-    bounded_mamba = NemotronHModelDescriptor._runtime_proxy_block_config(runtime, mamba_block)
+    bounded_moe = NemotronHModelDescriptor._runtime_proxy_block_config(
+        runtime, moe_block
+    )
+    bounded_mamba = NemotronHModelDescriptor._runtime_proxy_block_config(
+        runtime, mamba_block
+    )
 
     moe = bounded_moe.require_subblock("moe")
-    assert (moe.num_experts, moe.expert_intermediate_size, moe.latent_dim, moe.top_k) == (
+    assert (
+        moe.num_experts,
+        moe.expert_intermediate_size,
+        moe.latent_dim,
+        moe.top_k,
+    ) == (
         8,
         256,
         128,
         2,
     )
     assert bounded_moe.require_subblock("attention").no_op is True
-    assert bounded_mamba.require_subblock("mamba") == mamba_block.require_subblock("mamba")
+    assert bounded_mamba.require_subblock("mamba") == mamba_block.require_subblock(
+        "mamba"
+    )
 
 
 def test_nemotron_runtime_uses_exact_moe_dimensions_by_default() -> None:

--- a/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
+++ b/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
@@ -27,9 +27,7 @@ from modelopt.torch.puzzletron.anymodel.capabilities import (
     default_capabilities,
     validate_capabilities,
 )
-from modelopt.torch.puzzletron.anymodel.models.gpt_oss.gpt_oss_converter import (
-    GptOssConverter,
-)
+from modelopt.torch.puzzletron.anymodel.models.gpt_oss.gpt_oss_converter import GptOssConverter
 from modelopt.torch.puzzletron.anymodel.models.gpt_oss.gpt_oss_model_descriptor import (
     GptOssModelDescriptor,
 )
@@ -43,10 +41,7 @@ from modelopt.torch.puzzletron.anymodel.models.qwen3_5.qwen3_5_model_descriptor 
     Qwen3P5TextModelDescriptor,
     Qwen3P5VLModelDescriptor,
 )
-from modelopt.torch.puzzletron.anymodel.registry import (
-    infer_descriptor_name,
-    resolve_descriptor,
-)
+from modelopt.torch.puzzletron.anymodel.registry import infer_descriptor_name, resolve_descriptor
 from modelopt.torch.puzzletron.block_config import (
     AttentionConfig,
     BlockConfig,
@@ -273,9 +268,12 @@ def test_gpt_oss_converter_preserves_each_layers_attention_window() -> None:
         for block in GptOssConverter.create_block_configs_from_main_config(config)
     ]
 
-    assert [
-        block.require_subblock("attention").sliding_window_size for block in blocks
-    ] == [128, "full", 128, "full"]
+    assert [block.require_subblock("attention").sliding_window_size for block in blocks] == [
+        128,
+        "full",
+        128,
+        "full",
+    ]
 
 
 def test_gpt_oss_hf_and_native_share_contract_field_mapping() -> None:
@@ -325,9 +323,7 @@ def test_nemotron_weight_groups_accept_native_automodel_moe_names() -> None:
     ]
     native_output_names = ["model.norm.weight", "lm_head.weight"]
 
-    groups = NemotronHModelDescriptor.get_weight_groups(
-        native_block_names + native_output_names, 1
-    )
+    groups = NemotronHModelDescriptor.get_weight_groups(native_block_names + native_output_names, 1)
 
     assert groups["block_0_ffn"] == native_block_names
     assert groups["lm_head"] == native_output_names
@@ -351,27 +347,17 @@ def test_nemotron_hidden_width_spec_covers_hf_and_native_hybrid_tensors() -> Non
         "backbone.layers.1.mixer.q_proj.weight": torch.zeros(8, 2688),
         "backbone.layers.1.mixer.o_proj.weight": torch.zeros(2688, 8),
         "backbone.layers.2.mixer.gate.weight": torch.zeros(4, 2688),
-        "backbone.layers.2.mixer.fc1_latent_proj.weight": torch.zeros(
-            latent_size, 2688
-        ),
-        "backbone.layers.2.mixer.fc2_latent_proj.weight": torch.zeros(
-            2688, latent_size
-        ),
+        "backbone.layers.2.mixer.fc1_latent_proj.weight": torch.zeros(latent_size, 2688),
+        "backbone.layers.2.mixer.fc2_latent_proj.weight": torch.zeros(2688, latent_size),
         "backbone.layers.2.mixer.experts.0.up_proj.weight": torch.zeros(6, latent_size),
-        "backbone.layers.2.mixer.experts.0.down_proj.weight": torch.zeros(
-            latent_size, 6
-        ),
+        "backbone.layers.2.mixer.experts.0.down_proj.weight": torch.zeros(latent_size, 6),
         "backbone.layers.2.mixer.shared_experts.up_proj.weight": torch.zeros(12, 2688),
-        "backbone.layers.2.mixer.shared_experts.down_proj.weight": torch.zeros(
-            2688, 12
-        ),
+        "backbone.layers.2.mixer.shared_experts.down_proj.weight": torch.zeros(2688, 12),
         "backbone.norm_f.weight": torch.zeros(2688),
         "lm_head.weight": torch.zeros(8, 2688),
         "model.layers.3.mixer.fc1_latent_proj.weight": torch.zeros(latent_size, 2688),
         "model.layers.3.mixer.fc2_latent_proj.weight": torch.zeros(2688, latent_size),
-        "model.layers.3.mixer.experts.gate_and_up_projs": torch.zeros(
-            4, latent_size, 6
-        ),
+        "model.layers.3.mixer.experts.gate_and_up_projs": torch.zeros(4, latent_size, 6),
         "model.layers.3.mixer.experts.down_projs": torch.zeros(4, 6, latent_size),
         "mtp.layers.0.eh_proj.weight": torch.zeros(2688, 2 * 2688),
         "mtp.layers.0.enorm.weight": torch.zeros(2688),
@@ -443,9 +429,7 @@ def test_nemotron_nano_hidden_width_spec_slices_non_latent_experts() -> None:
         tie_word_embeddings=False,
         moe_latent_size=None,
     )
-    spec = NemotronHModelDescriptor.embedding_pruning_spec(
-        config, widths=(8, 4), alignment=1
-    )
+    spec = NemotronHModelDescriptor.embedding_pruning_spec(config, widths=(8, 4), alignment=1)
     state = {
         "backbone.layers.2.mixer.experts.0.up_proj.weight": torch.zeros(6, 8),
         "backbone.layers.2.mixer.experts.0.down_proj.weight": torch.zeros(8, 6),
@@ -480,13 +464,9 @@ def test_nemotron_capabilities_include_hidden_width_pipeline() -> None:
 
 
 def test_nemotron_moe_variant_axes_cover_scoring_and_materialization() -> None:
-    axes = NemotronHModelDescriptor.puzzletron_capabilities(
-        SimpleNamespace(hidden_size=2688)
-    ).axes
+    axes = NemotronHModelDescriptor.puzzletron_capabilities(SimpleNamespace(hidden_size=2688)).axes
 
-    assert (
-        axes["moe_experts"].runtime_slice_impl == "solution_recipe.moe_expert_reroute"
-    )
+    assert axes["moe_experts"].runtime_slice_impl == "solution_recipe.moe_expert_reroute"
     assert axes["moe_top_k"].materialize_impl == "materialize.config_only_moe_top_k"
 
 
@@ -502,9 +482,7 @@ def test_nemotron_nano_capabilities_exclude_absent_latent_axis() -> None:
     assert "moe_latent_dim" in super_axes
 
 
-def test_nemotron_equivalence_tolerance_accounts_for_bf16_hidden_basis_permutation() -> (
-    None
-):
+def test_nemotron_equivalence_tolerance_accounts_for_bf16_hidden_basis_permutation() -> None:
     assert NemotronHModelDescriptor.checkpoint_equivalence_tolerances() == {
         "max_abs_lm_loss_delta": 5.0e-3,
         "max_kl_div": 1.0e-2,
@@ -530,9 +508,7 @@ def test_gpt_oss_pipeline_patch_restores_native_inner_forward() -> None:
 
 def test_gpt_oss_embedding_spec_preserves_mxfp4_input_channel_blocks() -> None:
     config = SimpleNamespace(hidden_size=64, tie_word_embeddings=False)
-    spec = GptOssModelDescriptor.embedding_pruning_spec(
-        config, widths=(64, 32), alignment=32
-    )
+    spec = GptOssModelDescriptor.embedding_pruning_spec(config, widths=(64, 32), alignment=32)
     state = {
         "model.layers.0.mlp.experts.gate_up_proj_blocks": torch.zeros(2, 128, 2, 16),
         "model.layers.0.mlp.experts.gate_up_proj_scales": torch.zeros(2, 128, 2),
@@ -559,9 +535,7 @@ def test_gpt_oss_embedding_spec_preserves_mxfp4_input_channel_blocks() -> None:
 
 def test_gpt_oss_embedding_spec_slices_post_bypass_fused_experts() -> None:
     config = SimpleNamespace(hidden_size=64, tie_word_embeddings=False)
-    spec = GptOssModelDescriptor.embedding_pruning_spec(
-        config, widths=(64, 32), alignment=32
-    )
+    spec = GptOssModelDescriptor.embedding_pruning_spec(config, widths=(64, 32), alignment=32)
     state = {
         "model.layers.0.mlp.experts.gate_up_proj": torch.zeros(2, 64, 128),
         "model.layers.0.mlp.experts.down_proj": torch.zeros(2, 128, 64),
@@ -650,9 +624,7 @@ def test_gpt_oss_declares_attention_sink_as_query_head_state() -> None:
 def test_generic_window_capability_is_discovered_for_non_gpt_attention() -> None:
     config = _text_config(sliding_window=512)
 
-    axis = LlamaModelDescriptor.puzzletron_capabilities(config).axes[
-        "sliding_window_size"
-    ]
+    axis = LlamaModelDescriptor.puzzletron_capabilities(config).axes["sliding_window_size"]
 
     assert axis.variant_only
     assert axis.vllm_export
@@ -697,12 +669,8 @@ def test_stage_preflight_requires_vllm_control_for_runtime_stats(monkeypatch) ->
         {
             "model": {"force_hf": False},
             "parallel": {"ep": 1},
-            "search_space": {
-                "axes": {"mla_q_lora_rank": {"enabled": True, "values": [384]}}
-            },
-            "calc_subblock_stats": {
-                "runtime_stats": {"enabled": True, "backend": "vllm"}
-            },
+            "search_space": {"axes": {"mla_q_lora_rank": {"enabled": True, "values": [384]}}},
+            "calc_subblock_stats": {"runtime_stats": {"enabled": True, "backend": "vllm"}},
         },
         SimpleNamespace(capabilities=object()),
         stage="library",
@@ -813,7 +781,7 @@ def test_nemotron_updates_remote_read_only_layer_types_through_hybrid_pattern() 
 def test_nemotron_runtime_proxy_supplies_legacy_hybrid_pattern(monkeypatch) -> None:
     captured = {}
 
-    class _CapturedConfig(Exception):
+    class _CapturedConfigError(Exception):
         def __init__(self, hybrid_override_pattern=None, **kwargs):
             captured.update(kwargs)
             captured["hybrid_override_pattern"] = hybrid_override_pattern
@@ -837,11 +805,11 @@ def test_nemotron_runtime_proxy_supplies_legacy_hybrid_pattern(monkeypatch) -> N
         )
     ]
     monkeypatch.setattr(
-        NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfig
+        NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfigError
     )
     monkeypatch.setattr(NemotronHModelDescriptor, "_runtime_model_cls", lambda: object)
 
-    with pytest.raises(_CapturedConfig):
+    with pytest.raises(_CapturedConfigError):
         NemotronHModelDescriptor.create_runtime_benchmark_model(runtime, blocks)
 
     assert "layers_block_type" not in captured
@@ -864,7 +832,7 @@ def test_nemotron_runtime_proxy_uses_active_mamba_shape_for_global_initializatio
 ) -> None:
     captured = {}
 
-    class _CapturedConfig(Exception):
+    class _CapturedConfigError(Exception):
         def __init__(self, **kwargs):
             captured.update(kwargs)
             raise self
@@ -880,19 +848,15 @@ def test_nemotron_runtime_proxy_uses_active_mamba_shape_for_global_initializatio
         model_config_value=lambda name, default=None: values.get(name, default),
     )
     blocks = [
-        BlockConfig(
-            subblock_configs=(AttentionConfig(num_query_heads=4, num_kv_heads=2),)
-        ),
-        BlockConfig(
-            subblock_configs=(MambaConfig(num_heads=48, head_dim=56, state_dim=96),)
-        ),
+        BlockConfig(subblock_configs=(AttentionConfig(num_query_heads=4, num_kv_heads=2),)),
+        BlockConfig(subblock_configs=(MambaConfig(num_heads=48, head_dim=56, state_dim=96),)),
     ]
     monkeypatch.setattr(
-        NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfig
+        NemotronHModelDescriptor, "_runtime_config_cls", lambda: _CapturedConfigError
     )
     monkeypatch.setattr(NemotronHModelDescriptor, "_runtime_model_cls", lambda: object)
 
-    with pytest.raises(_CapturedConfig):
+    with pytest.raises(_CapturedConfigError):
         NemotronHModelDescriptor.create_runtime_benchmark_model(runtime, blocks)
 
     assert captured["mamba_num_heads"] == 48
@@ -901,12 +865,8 @@ def test_nemotron_runtime_proxy_uses_active_mamba_shape_for_global_initializatio
 
 
 def test_llama_requests_scaffold_only_for_cacheless_candidate() -> None:
-    attention = BlockConfig(
-        subblock_configs=(AttentionConfig(no_op=False), FFNConfig(no_op=True))
-    )
-    ffn = BlockConfig(
-        subblock_configs=(AttentionConfig(no_op=True), FFNConfig(no_op=False))
-    )
+    attention = BlockConfig(subblock_configs=(AttentionConfig(no_op=False), FFNConfig(no_op=True)))
+    ffn = BlockConfig(subblock_configs=(AttentionConfig(no_op=True), FFNConfig(no_op=False)))
 
     assert LlamaModelDescriptor.runtime_benchmark_scaffold_policy(attention) == "none"
     assert (
@@ -917,24 +877,16 @@ def test_llama_requests_scaffold_only_for_cacheless_candidate() -> None:
 
 def test_nemotron_requests_attention_scaffold_for_cacheless_candidates() -> None:
     attention = BlockConfig(
-        subblock_configs=(
-            AttentionConfig(no_op=False, num_query_heads=32, num_kv_heads=2),
-        )
+        subblock_configs=(AttentionConfig(no_op=False, num_query_heads=32, num_kv_heads=2),)
     )
     mamba = BlockConfig(
-        subblock_configs=(
-            MambaConfig(no_op=False, num_heads=48, head_dim=64, state_dim=128),
-        )
+        subblock_configs=(MambaConfig(no_op=False, num_heads=48, head_dim=64, state_dim=128),)
     )
     moe = BlockConfig(
-        subblock_configs=(
-            MoEConfig(no_op=False, num_experts=16, expert_intermediate_size=512),
-        )
+        subblock_configs=(MoEConfig(no_op=False, num_experts=16, expert_intermediate_size=512),)
     )
 
-    assert (
-        NemotronHModelDescriptor.runtime_benchmark_scaffold_policy(attention) == "none"
-    )
+    assert NemotronHModelDescriptor.runtime_benchmark_scaffold_policy(attention) == "none"
     assert (
         NemotronHModelDescriptor.runtime_benchmark_scaffold_policy(mamba)
         == "attention_scaffold_per_pp_stage"
@@ -990,12 +942,8 @@ def test_nemotron_runtime_bounding_preserves_native_moe_and_mamba_families() -> 
         subblock_configs=(MambaConfig(num_heads=64, head_dim=32), FFNConfig(no_op=True))
     )
 
-    bounded_moe = NemotronHModelDescriptor._runtime_proxy_block_config(
-        runtime, moe_block
-    )
-    bounded_mamba = NemotronHModelDescriptor._runtime_proxy_block_config(
-        runtime, mamba_block
-    )
+    bounded_moe = NemotronHModelDescriptor._runtime_proxy_block_config(runtime, moe_block)
+    bounded_mamba = NemotronHModelDescriptor._runtime_proxy_block_config(runtime, mamba_block)
 
     moe = bounded_moe.require_subblock("moe")
     assert (
@@ -1010,9 +958,7 @@ def test_nemotron_runtime_bounding_preserves_native_moe_and_mamba_families() -> 
         2,
     )
     assert bounded_moe.require_subblock("attention").no_op is True
-    assert bounded_mamba.require_subblock("mamba") == mamba_block.require_subblock(
-        "mamba"
-    )
+    assert bounded_mamba.require_subblock("mamba") == mamba_block.require_subblock("mamba")
 
 
 def test_nemotron_runtime_uses_exact_moe_dimensions_by_default() -> None:

--- a/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
+++ b/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
@@ -568,6 +568,7 @@ def test_stage_runtime_receives_inferred_descriptor_without_persisting_override(
         observed["manifest_config"] = manifest.config
         observed["manifest_effective_config"] = manifest.effective_config
         observed["resolution"] = manifest.inputs["descriptor_resolution"]
+        config["_runtime"]["descriptor"] = "mutated-by-handler"
         return StageResult(
             stage="width_importance",
             status="success",

--- a/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
+++ b/tests/unit/torch/puzzletron/test_cross_model_descriptors.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tests for Puzzletron cross-model descriptor selection and integration."""
+
 from __future__ import annotations
 
 import dataclasses

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -23,11 +23,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from examples.puzzletron.main import (
-    _completion_is_valid,
-    _mark_completion,
-    _resume_kwargs,
-)
+from examples.puzzletron.main import _completion_is_valid, _mark_completion, _resume_kwargs
 from modelopt.torch.puzzletron.identity import stable_hash
 from modelopt.torch.puzzletron.manifest import (
     StageManifest,
@@ -135,6 +131,28 @@ def test_execution_record_preserves_provenance_and_cross_record_timestamps(
     }
 
 
+def test_execution_record_binds_terminal_skip_reason(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(stage="tokenize_data", config=config)
+    manifest.complete(status="skipped", skip_reason="disabled")
+    manifest_path = tmp_path / "manifests" / "tokenize_data.json"
+
+    write_stage_manifest(manifest_path, manifest)
+
+    pointer = json.loads(manifest_path.read_text())
+    record = pointer["execution_record"]
+    resolved = json.loads((tmp_path / record["resolved_config_path"]).read_text())
+    artifact = json.loads((tmp_path / record["artifact_manifest_path"]).read_text())
+    assert pointer["skip_reason"] == resolved["skip_reason"] == artifact["skip_reason"]
+
+    pointer["skip_reason"] = "tampered"
+    manifest_path.write_text(json.dumps(pointer))
+    with pytest.raises(ValueError, match="resolved stage execution skip_reason mismatch"):
+        validate_stage_execution_record(manifest_path, expected_stage="tokenize_data")
+
+
 def test_artifact_manifest_separates_output_pointer_from_immutable_evidence(
     tmp_path: Path,
 ) -> None:
@@ -162,17 +180,10 @@ def test_artifact_manifest_separates_output_pointer_from_immutable_evidence(
     }
     assert artifacts["started_at"] == canonical["started_at"]
     assert artifacts["ended_at"] == canonical["ended_at"]
-    assert (
-        artifacts["artifact_manifest_identity"] == record["artifact_manifest_identity"]
-    )
+    assert artifacts["artifact_manifest_identity"] == record["artifact_manifest_identity"]
     resolved_bytes = (tmp_path / record["resolved_config_path"]).read_bytes()
-    assert (
-        artifacts["resolved_config"]["sha256"]
-        == hashlib.sha256(resolved_bytes).hexdigest()
-    )
-    required_patterns = _resume_kwargs(config, config_path, "convert")[
-        "required_patterns"
-    ]
+    assert artifacts["resolved_config"]["sha256"] == hashlib.sha256(resolved_bytes).hexdigest()
+    required_patterns = _resume_kwargs(config, config_path, "convert")["required_patterns"]
     assert record["resolved_config_path"] in required_patterns
     assert record["artifact_manifest_path"] in required_patterns
 
@@ -236,8 +247,9 @@ def test_ephemeral_runtime_change_preserves_resolved_config_identity(
     write_stage_manifest(manifest_path, original)
     write_stage_manifest(manifest_path, changed)
 
-    assert original.execution_record["resolved_config_identity"] == (
-        changed.execution_record["resolved_config_identity"]
+    assert (
+        original.execution_record["resolved_config_identity"]
+        == (changed.execution_record["resolved_config_identity"])
     )
     assert (tmp_path / original.execution_record["resolved_config_path"]).is_file()
     assert (tmp_path / changed.execution_record["resolved_config_path"]).is_file()
@@ -266,11 +278,13 @@ def test_same_config_rerun_creates_a_distinct_execution_record(tmp_path: Path) -
     write_stage_manifest(manifest_path, original)
     write_stage_manifest(manifest_path, rerun)
 
-    assert original.execution_record["execution_identity"] != (
-        rerun.execution_record["execution_identity"]
+    assert (
+        original.execution_record["execution_identity"]
+        != (rerun.execution_record["execution_identity"])
     )
-    assert original.execution_record["resolved_config_identity"] == (
-        rerun.execution_record["resolved_config_identity"]
+    assert (
+        original.execution_record["resolved_config_identity"]
+        == (rerun.execution_record["resolved_config_identity"])
     )
 
 
@@ -291,11 +305,13 @@ def test_implementation_provenance_change_creates_a_distinct_execution_record(
 
     write_stage_manifest(manifest_path, changed)
 
-    assert original.execution_record["execution_identity"] != (
-        changed.execution_record["execution_identity"]
+    assert (
+        original.execution_record["execution_identity"]
+        != (changed.execution_record["execution_identity"])
     )
-    assert original.execution_record["resolved_config_identity"] == (
-        changed.execution_record["resolved_config_identity"]
+    assert (
+        original.execution_record["resolved_config_identity"]
+        == (changed.execution_record["resolved_config_identity"])
     )
 
 
@@ -341,9 +357,7 @@ def test_artifact_contract_preserves_declared_output_before_it_exists(
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
     late_output = tmp_path / "ckpts" / "scoring-parent.json"
-    manifest = StageManifest(
-        stage="convert", config=_stage_config(tmp_path, config_path)
-    )
+    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
     manifest.complete(outputs={"scoring_parent_artifact": str(late_output)})
 
     write_stage_manifest(tmp_path / "manifests" / "convert.json", manifest)
@@ -369,7 +383,7 @@ def test_resume_remains_compatible_with_historical_stage_manifest(
     config = _stage_config(tmp_path, config_path)
     manifest = StageManifest(
         stage="convert",
-        status="imported",
+        status="success",
         outputs={"teacher_dir": str(teacher_config.parent)},
         config=config,
     )
@@ -389,9 +403,7 @@ def test_resume_remains_compatible_with_historical_stage_manifest(
     ["resolved_config_path", "artifact_manifest_path"],
     ids=["resolved-config", "artifact-manifest"],
 )
-def test_resume_requires_both_execution_record_files(
-    tmp_path: Path, record_key: str
-) -> None:
+def test_resume_requires_both_execution_record_files(tmp_path: Path, record_key: str) -> None:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
     teacher_config = tmp_path / "ckpts" / "teacher" / "config.json"
@@ -407,7 +419,7 @@ def test_resume_requires_both_execution_record_files(
     assert _completion_is_valid(config, config_path, "convert")
 
     (tmp_path / manifest.execution_record[record_key]).unlink()
-    with pytest.raises(ValueError, match="invalid .* record"):
+    with pytest.raises(ValueError, match=r"invalid .* record"):
         _completion_is_valid(config, config_path, "convert")
 
 
@@ -540,14 +552,10 @@ def test_writer_rejects_symlinked_execution_record_ancestor(tmp_path: Path) -> N
     manifests_dir.mkdir()
     external_executions = tmp_path / "external-executions"
     external_executions.mkdir()
-    (manifests_dir / "executions").symlink_to(
-        external_executions, target_is_directory=True
-    )
+    (manifests_dir / "executions").symlink_to(external_executions, target_is_directory=True)
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
-    manifest = StageManifest(
-        stage="convert", config=_stage_config(tmp_path, config_path)
-    )
+    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
     manifest.complete()
 
     with pytest.raises(ValueError, match="stage execution record path is symlinked"):
@@ -584,9 +592,7 @@ def test_validator_rejects_symlinked_execution_record_paths(
 ) -> None:
     manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
     if location == "stage-ancestor":
-        stage_dir = (
-            tmp_path / manifest.execution_record["resolved_config_path"]
-        ).parent.parent
+        stage_dir = (tmp_path / manifest.execution_record["resolved_config_path"]).parent.parent
         external_stage_dir = stage_dir.with_name("external-convert")
         stage_dir.rename(external_stage_dir)
         stage_dir.symlink_to(external_stage_dir, target_is_directory=True)
@@ -619,9 +625,7 @@ def test_resolved_content_tamper_is_rejected_after_outer_sha_is_updated(
     )
     _rewrite_json_record(manifest_path, pointer)
 
-    with pytest.raises(
-        ValueError, match="resolved stage configuration identity mismatch"
-    ):
+    with pytest.raises(ValueError, match="resolved stage configuration identity mismatch"):
         validate_stage_execution_record(manifest_path, expected_stage="convert")
 
 
@@ -714,9 +718,7 @@ def test_resume_recomputes_canonical_pointer_identities(
     manifest_path = tmp_path / "manifests" / "convert.json"
     write_stage_manifest(manifest_path, manifest)
     pointer = json.loads(manifest_path.read_text())
-    if field == "config":
-        pointer[field]["model"]["revision"] = "tampered"
-    elif field == "semantic_config":
+    if field in {"config", "semantic_config"}:
         pointer[field]["model"]["revision"] = "tampered"
     elif field == "capability_snapshot":
         pointer[field]["backend"] = "tampered"

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -27,12 +26,14 @@ import pytest
 from examples.puzzletron.main import (
     _completion_is_valid,
     _mark_completion,
-    _pipeline_config_from_path,
     _resume_kwargs,
 )
 from modelopt.torch.puzzletron.identity import stable_hash
-from modelopt.torch.puzzletron.manifest import StageManifest, write_stage_manifest
-from modelopt.torch.puzzletron.pipeline_config import load_runtime_hydra_config
+from modelopt.torch.puzzletron.manifest import (
+    StageManifest,
+    validate_stage_execution_record,
+    write_stage_manifest,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -51,74 +52,136 @@ def _stage_config(tmp_path: Path, config_path: Path) -> dict:
     }
 
 
-def test_stage_manifest_persists_resolved_config_and_artifact_manifest(tmp_path: Path) -> None:
+def _write_convert_record(
+    tmp_path: Path,
+    *,
+    inputs: dict | None = None,
+    outputs: dict | None = None,
+    capability_snapshot: dict | None = None,
+    implementation_provenance: dict | None = None,
+) -> tuple[Path, Path, dict, StageManifest]:
     config_path = tmp_path / "experiment.yaml"
-    config_path.write_text("model:\n  revision: revision-1\n")
-    summary_path = tmp_path / "artifacts" / "summary.json"
-    summary_path.parent.mkdir()
-    summary_path.write_text('{"score": 1}\n')
+    config_path.write_text("model: {}\n")
     config = _stage_config(tmp_path, config_path)
     manifest = StageManifest(
         stage="convert",
         config=config,
-        implementation_provenance={"source_identity": "source-v1"},
+        inputs=inputs or {},
+        capability_snapshot=capability_snapshot,
+        implementation_provenance=implementation_provenance or {},
+        started_at="2026-08-06T10:00:00+00:00",
+        ended_at="2026-08-06T10:01:00+00:00",
+        status="success",
     )
-    manifest.complete(outputs={"summary_path": str(summary_path)})
-
+    if outputs is not None:
+        manifest.outputs = outputs
     manifest_path = tmp_path / "manifests" / "convert.json"
     write_stage_manifest(manifest_path, manifest)
+    return manifest_path, config_path, config, manifest
+
+
+def _rewrite_json_record(path: Path, payload: dict) -> str:
+    content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    path.write_text(content)
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def test_stage_manifest_persists_path_neutral_resolved_stage_config(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _config_path, config, _manifest = _write_convert_record(tmp_path)
 
     canonical = json.loads(manifest_path.read_text())
     record = canonical["execution_record"]
     resolved = json.loads((tmp_path / record["resolved_config_path"]).read_text())
-    artifacts = json.loads((tmp_path / record["artifact_manifest_path"]).read_text())
-    assert resolved["effective_config"] == config
-    assert resolved["started_at"] == canonical["started_at"]
-    assert resolved["ended_at"] == canonical["ended_at"]
+    assert "effective_config" not in canonical
+    assert resolved["resolved_stage_config"] == {
+        "convert": config["convert"],
+        "model": config["model"],
+    }
+    assert resolved["resolved_config_identity"] == stable_hash(
+        resolved["resolved_stage_config"], prefix="convert_resolved_cfg"
+    )
+
+
+def test_execution_record_preserves_provenance_and_cross_record_timestamps(
+    tmp_path: Path,
+) -> None:
+    manifest_path, config_path, _config, _manifest = _write_convert_record(
+        tmp_path,
+        inputs={"descriptor_resolution": {"descriptor": "llama"}},
+        capability_snapshot={"backend": "hf"},
+        implementation_provenance={"revision": "worker-v1"},
+    )
+    canonical = json.loads(manifest_path.read_text())
+    record = canonical["execution_record"]
+    resolved = json.loads((tmp_path / record["resolved_config_path"]).read_text())
+    artifact = json.loads((tmp_path / record["artifact_manifest_path"]).read_text())
+
+    assert resolved["started_at"] == artifact["started_at"] == canonical["started_at"]
+    assert resolved["ended_at"] == artifact["ended_at"] == canonical["ended_at"]
     assert resolved["authored_config_identity"] == canonical["config_identity"]
     assert resolved["resolved_config_identity"] == record["resolved_config_identity"]
     assert resolved["provenance"] == {
         "authored_config_path": str(config_path),
         "overrides": ["model.revision=revision-1"],
-        "implementation": {"source_identity": "source-v1"},
-        "descriptor_resolution": None,
-        "capability_snapshot": None,
+        "implementation": {"revision": "worker-v1"},
+        "descriptor_resolution": {"descriptor": "llama"},
+        "capability_snapshot": {"backend": "hf"},
     }
-    assert resolved["replay"]["argv"] == [
-        sys.executable,
-        f"{resolved['replay']['working_directory']}/examples/puzzletron/main.py",
-        "--config",
-        str(tmp_path / record["resolved_config_path"]),
-        "--stage",
-        "convert",
-        "--gpus-per-node",
-        "4",
-        "--force",
-    ]
-    assert resolved["resolved_config_identity"] == stable_hash(
-        resolved["effective_config"], prefix="convert_resolved_cfg"
-    )
-    assert artifacts["declared_outputs"] == {"summary_path": str(summary_path)}
-    assert artifacts["artifact_contract"] == "stage-manifest-outputs"
+    assert artifact["stage_manifest"] == {
+        "path": "manifests/convert.json",
+        "semantic_identity": canonical["semantic_identity"],
+    }
+
+
+def test_artifact_manifest_separates_output_pointer_from_immutable_evidence(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(stage="convert", config=config)
+    manifest.complete(outputs={"summary_path": str(summary_path)})
+    manifest_path = tmp_path / "manifests" / "convert.json"
+
+    write_stage_manifest(manifest_path, manifest)
+
+    canonical = json.loads(manifest_path.read_text())
+    record = canonical["execution_record"]
+    artifacts = json.loads((tmp_path / record["artifact_manifest_path"]).read_text())
+    assert artifacts["canonical_output_pointers"] == {"summary_path": str(summary_path)}
+    assert artifacts["artifact_contract"] == "stage-manifest-output-pointers/v1"
+    assert artifacts["immutable_evidence"]["summary_path"] == {
+        "path": str(summary_path),
+        "size": len(summary_path.read_bytes()),
+        "sha256": hashlib.sha256(summary_path.read_bytes()).hexdigest(),
+    }
     assert artifacts["started_at"] == canonical["started_at"]
     assert artifacts["ended_at"] == canonical["ended_at"]
-    assert artifacts["artifact_manifest_identity"] == record["artifact_manifest_identity"]
+    assert (
+        artifacts["artifact_manifest_identity"] == record["artifact_manifest_identity"]
+    )
     resolved_bytes = (tmp_path / record["resolved_config_path"]).read_bytes()
-    assert artifacts["resolved_config"]["sha256"] == hashlib.sha256(resolved_bytes).hexdigest()
-    required_patterns = _resume_kwargs(config, config_path, "convert")["required_patterns"]
+    assert (
+        artifacts["resolved_config"]["sha256"]
+        == hashlib.sha256(resolved_bytes).hexdigest()
+    )
+    required_patterns = _resume_kwargs(config, config_path, "convert")[
+        "required_patterns"
+    ]
     assert record["resolved_config_path"] in required_patterns
     assert record["artifact_manifest_path"] in required_patterns
 
-    config_path.write_text("model:\n  revision: mutated-after-execution\n")
-    replayed = _pipeline_config_from_path(tmp_path / record["resolved_config_path"])
-    assert replayed["model"] == config["model"]
-    assert replayed["_runtime"]["resolved_config_path"] == str(
-        (tmp_path / record["resolved_config_path"]).resolve()
-    )
-    assert load_runtime_hydra_config(replayed).model.revision == "revision-1"
 
-
-@pytest.mark.parametrize("record_key", ["resolved_config_path", "artifact_manifest_path"])
+@pytest.mark.parametrize(
+    "record_key",
+    ["resolved_config_path", "artifact_manifest_path"],
+    ids=["resolved-config", "artifact-manifest"],
+)
 def test_stage_execution_record_is_immutable_and_idempotent(
     tmp_path: Path,
     record_key: str,
@@ -143,21 +206,27 @@ def test_stage_execution_record_is_immutable_and_idempotent(
         write_stage_manifest(manifest_path, manifest)
 
 
-def test_effective_config_change_creates_a_distinct_execution_record(tmp_path: Path) -> None:
+def test_ephemeral_runtime_change_preserves_resolved_config_identity(
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
+    authored_config = _stage_config(tmp_path, config_path)
+    original_effective_config = _stage_config(tmp_path, config_path)
     original = StageManifest(
         stage="convert",
-        config=_stage_config(tmp_path, config_path),
+        config=authored_config,
+        effective_config=original_effective_config,
         started_at="2026-08-06T10:00:00+00:00",
         ended_at="2026-08-06T10:01:00+00:00",
         status="success",
     )
-    changed_config = _stage_config(tmp_path, config_path)
-    changed_config["model"]["revision"] = "revision-2"
+    changed_effective_config = _stage_config(tmp_path, config_path)
+    changed_effective_config["_runtime"]["descriptor"] = "llama"
     changed = StageManifest(
         stage="convert",
-        config=changed_config,
+        config=authored_config,
+        effective_config=changed_effective_config,
         started_at=original.started_at,
         ended_at=original.ended_at,
         status="success",
@@ -167,9 +236,8 @@ def test_effective_config_change_creates_a_distinct_execution_record(tmp_path: P
     write_stage_manifest(manifest_path, original)
     write_stage_manifest(manifest_path, changed)
 
-    assert (
-        original.execution_record["execution_identity"]
-        != (changed.execution_record["execution_identity"])
+    assert original.execution_record["resolved_config_identity"] == (
+        changed.execution_record["resolved_config_identity"]
     )
     assert (tmp_path / original.execution_record["resolved_config_path"]).is_file()
     assert (tmp_path / changed.execution_record["resolved_config_path"]).is_file()
@@ -198,17 +266,42 @@ def test_same_config_rerun_creates_a_distinct_execution_record(tmp_path: Path) -
     write_stage_manifest(manifest_path, original)
     write_stage_manifest(manifest_path, rerun)
 
-    assert (
-        original.execution_record["execution_identity"]
-        != (rerun.execution_record["execution_identity"])
+    assert original.execution_record["execution_identity"] != (
+        rerun.execution_record["execution_identity"]
     )
-    assert (
-        original.execution_record["resolved_config_identity"]
-        == (rerun.execution_record["resolved_config_identity"])
+    assert original.execution_record["resolved_config_identity"] == (
+        rerun.execution_record["resolved_config_identity"]
     )
 
 
-def test_effective_config_none_falls_back_but_empty_mapping_is_preserved(tmp_path: Path) -> None:
+def test_implementation_provenance_change_creates_a_distinct_execution_record(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _config_path, config, original = _write_convert_record(
+        tmp_path, implementation_provenance={"revision": "worker-v1"}
+    )
+    changed = StageManifest(
+        stage="convert",
+        config=config,
+        implementation_provenance={"revision": "worker-v2"},
+        started_at=original.started_at,
+        ended_at=original.ended_at,
+        status=original.status,
+    )
+
+    write_stage_manifest(manifest_path, changed)
+
+    assert original.execution_record["execution_identity"] != (
+        changed.execution_record["execution_identity"]
+    )
+    assert original.execution_record["resolved_config_identity"] == (
+        changed.execution_record["resolved_config_identity"]
+    )
+
+
+def test_effective_config_none_falls_back_but_empty_mapping_is_preserved(
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
     authored_config = _stage_config(tmp_path, config_path)
@@ -235,53 +328,53 @@ def test_effective_config_none_falls_back_but_empty_mapping_is_preserved(tmp_pat
     write_stage_manifest(manifest_path, empty)
     empty_path = tmp_path / empty.execution_record["resolved_config_path"]
 
-    assert json.loads(fallback_path.read_text())["effective_config"] == authored_config
-    assert json.loads(empty_path.read_text())["effective_config"] == {}
+    assert json.loads(fallback_path.read_text())["resolved_stage_config"] == {
+        "convert": authored_config["convert"],
+        "model": authored_config["model"],
+    }
+    assert json.loads(empty_path.read_text())["resolved_stage_config"] == {}
 
 
-def test_artifact_contract_preserves_declared_output_before_it_exists(tmp_path: Path) -> None:
+def test_artifact_contract_preserves_declared_output_before_it_exists(
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
     late_output = tmp_path / "ckpts" / "scoring-parent.json"
-    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
+    manifest = StageManifest(
+        stage="convert", config=_stage_config(tmp_path, config_path)
+    )
     manifest.complete(outputs={"scoring_parent_artifact": str(late_output)})
 
     write_stage_manifest(tmp_path / "manifests" / "convert.json", manifest)
 
     artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
     artifact_manifest = json.loads(artifact_path.read_text())
-    assert artifact_manifest["artifact_contract"] == "stage-manifest-outputs"
-    assert artifact_manifest["declared_outputs"] == {"scoring_parent_artifact": str(late_output)}
+    assert artifact_manifest["artifact_contract"] == "stage-manifest-output-pointers/v1"
+    assert artifact_manifest["canonical_output_pointers"] == {
+        "scoring_parent_artifact": str(late_output)
+    }
+    assert artifact_manifest["immutable_evidence"] == {}
     assert not late_output.exists()
 
 
-def test_resolved_config_loader_rejects_tampering(tmp_path: Path) -> None:
-    config_path = tmp_path / "experiment.yaml"
-    config_path.write_text("model: {}\n")
-    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
-    manifest.complete()
-    write_stage_manifest(tmp_path / "manifests" / "convert.json", manifest)
-    resolved_path = tmp_path / manifest.execution_record["resolved_config_path"]
-    resolved = json.loads(resolved_path.read_text())
-    resolved["effective_config"]["model"]["revision"] = "tampered"
-    resolved_path.write_text(json.dumps(resolved))
-
-    with pytest.raises(ValueError, match="identity mismatch"):
-        _pipeline_config_from_path(resolved_path)
-
-
-def test_resume_remains_compatible_with_historical_stage_manifest(tmp_path: Path) -> None:
+def test_resume_remains_compatible_with_historical_stage_manifest(
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
     teacher_config = tmp_path / "ckpts" / "teacher" / "config.json"
     teacher_config.parent.mkdir(parents=True)
     teacher_config.write_text("{}\n")
     config = _stage_config(tmp_path, config_path)
-    manifest = StageManifest(stage="convert", config=config)
-    manifest.complete(outputs={"teacher_dir": str(teacher_config.parent)})
+    manifest = StageManifest(
+        stage="convert",
+        status="imported",
+        outputs={"teacher_dir": str(teacher_config.parent)},
+        config=config,
+    )
     historical_payload = manifest.to_dict()
-    historical_payload.pop("effective_config")
-    historical_payload.pop("execution_record")
+    assert "execution_record" not in historical_payload
     manifest_path = tmp_path / "manifests" / "convert.json"
     manifest_path.parent.mkdir()
     manifest_path.write_text(json.dumps(historical_payload))
@@ -291,7 +384,14 @@ def test_resume_remains_compatible_with_historical_stage_manifest(tmp_path: Path
     assert _completion_is_valid(config, config_path, "convert")
 
 
-def test_resume_requires_execution_record_files(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "record_key",
+    ["resolved_config_path", "artifact_manifest_path"],
+    ids=["resolved-config", "artifact-manifest"],
+)
+def test_resume_requires_both_execution_record_files(
+    tmp_path: Path, record_key: str
+) -> None:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text("model: {}\n")
     teacher_config = tmp_path / "ckpts" / "teacher" / "config.json"
@@ -306,5 +406,325 @@ def test_resume_requires_execution_record_files(tmp_path: Path) -> None:
     _mark_completion(config, config_path, "convert")
     assert _completion_is_valid(config, config_path, "convert")
 
-    (tmp_path / manifest.execution_record["resolved_config_path"]).unlink()
-    assert not _completion_is_valid(config, config_path, "convert")
+    (tmp_path / manifest.execution_record[record_key]).unlink()
+    with pytest.raises(ValueError, match="invalid .* record"):
+        _completion_is_valid(config, config_path, "convert")
+
+
+@pytest.mark.parametrize(
+    "record",
+    [None, {}],
+    ids=["null-record", "empty-record"],
+)
+def test_resume_rejects_malformed_execution_record_structure(
+    tmp_path: Path,
+    record: object,
+) -> None:
+    manifest_path, config_path, config, _manifest = _write_convert_record(tmp_path)
+    payload = json.loads(manifest_path.read_text())
+    payload["execution_record"] = record
+    manifest_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="invalid stage execution record"):
+        _resume_kwargs(config, config_path, "convert")
+
+
+@pytest.mark.parametrize(
+    ("record_key", "value"),
+    [
+        ("resolved_config_path", None),
+        ("resolved_config_path", ""),
+        ("resolved_config_path", 1),
+        ("artifact_manifest_path", None),
+        ("artifact_manifest_path", ""),
+        ("artifact_manifest_path", 1),
+    ],
+    ids=[
+        "missing-resolved-path",
+        "empty-resolved-path",
+        "non-string-resolved-path",
+        "missing-artifact-path",
+        "empty-artifact-path",
+        "non-string-artifact-path",
+    ],
+)
+def test_resume_rejects_malformed_execution_record_paths(
+    tmp_path: Path,
+    record_key: str,
+    value: object,
+) -> None:
+    manifest_path, config_path, config, _manifest = _write_convert_record(tmp_path)
+    pointer = json.loads(manifest_path.read_text())
+    if value is None:
+        pointer["execution_record"].pop(record_key)
+    else:
+        pointer["execution_record"][record_key] = value
+    manifest_path.write_text(json.dumps(pointer))
+
+    with pytest.raises(ValueError, match="invalid stage execution record path"):
+        _resume_kwargs(config, config_path, "convert")
+
+
+@pytest.mark.parametrize(
+    "execution_identity",
+    [None, "", 1],
+    ids=["missing", "empty", "non-string"],
+)
+def test_resume_rejects_invalid_execution_identity(
+    tmp_path: Path,
+    execution_identity: object,
+) -> None:
+    manifest_path, config_path, config, _manifest = _write_convert_record(tmp_path)
+    pointer = json.loads(manifest_path.read_text())
+    if execution_identity is None:
+        pointer["execution_record"].pop("execution_identity")
+    else:
+        pointer["execution_record"]["execution_identity"] = execution_identity
+    manifest_path.write_text(json.dumps(pointer))
+
+    with pytest.raises(ValueError, match="invalid stage execution identity"):
+        _resume_kwargs(config, config_path, "convert")
+
+
+@pytest.mark.parametrize(
+    "record_key",
+    ["resolved_config_path", "artifact_manifest_path"],
+    ids=["resolved-config", "artifact-manifest"],
+)
+@pytest.mark.parametrize("unsafe_path", ["../outside.json", "/tmp/outside.json"])
+def test_resume_rejects_unsafe_execution_record_paths(
+    tmp_path: Path,
+    record_key: str,
+    unsafe_path: str,
+) -> None:
+    manifest_path, config_path, config, _manifest = _write_convert_record(tmp_path)
+    payload = json.loads(manifest_path.read_text())
+    payload["execution_record"][record_key] = unsafe_path
+    manifest_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="unsafe stage execution record path"):
+        _resume_kwargs(config, config_path, "convert")
+
+
+@pytest.mark.parametrize(
+    ("record_key", "message"),
+    [
+        ("resolved_config_path", "resolved stage configuration SHA256 mismatch"),
+        ("artifact_manifest_path", "stage artifact record SHA256 mismatch"),
+    ],
+    ids=["resolved-config", "artifact-manifest"],
+)
+def test_resume_rejects_tampered_immutable_stage_record(
+    tmp_path: Path,
+    record_key: str,
+    message: str,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(stage="convert", config=config)
+    manifest.complete()
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    write_stage_manifest(manifest_path, manifest)
+    record_path = tmp_path / manifest.execution_record[record_key]
+    payload = json.loads(record_path.read_text())
+    payload["status"] = "tampered"
+    record_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match=message):
+        _resume_kwargs(config, config_path, "convert")
+
+
+def test_writer_rejects_symlinked_execution_record_ancestor(tmp_path: Path) -> None:
+    manifests_dir = tmp_path / "manifests"
+    manifests_dir.mkdir()
+    external_executions = tmp_path / "external-executions"
+    external_executions.mkdir()
+    (manifests_dir / "executions").symlink_to(
+        external_executions, target_is_directory=True
+    )
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    manifest = StageManifest(
+        stage="convert", config=_stage_config(tmp_path, config_path)
+    )
+    manifest.complete()
+
+    with pytest.raises(ValueError, match="stage execution record path is symlinked"):
+        write_stage_manifest(manifests_dir / "convert.json", manifest)
+
+
+@pytest.mark.parametrize(
+    "record_key",
+    ["resolved_config_path", "artifact_manifest_path"],
+    ids=["resolved-config", "artifact-manifest"],
+)
+def test_writer_rejects_symlinked_execution_record_leaf(
+    tmp_path: Path,
+    record_key: str,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    record_path = tmp_path / manifest.execution_record[record_key]
+    external_file = tmp_path / f"external-{record_path.name}"
+    external_file.write_bytes(record_path.read_bytes())
+    record_path.unlink()
+    record_path.symlink_to(external_file)
+
+    with pytest.raises(ValueError, match="stage execution record path is symlinked"):
+        write_stage_manifest(manifest_path, manifest)
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["stage-ancestor", "resolved-config-leaf", "artifact-manifest-leaf"],
+)
+def test_validator_rejects_symlinked_execution_record_paths(
+    tmp_path: Path,
+    location: str,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    if location == "stage-ancestor":
+        stage_dir = (
+            tmp_path / manifest.execution_record["resolved_config_path"]
+        ).parent.parent
+        external_stage_dir = stage_dir.with_name("external-convert")
+        stage_dir.rename(external_stage_dir)
+        stage_dir.symlink_to(external_stage_dir, target_is_directory=True)
+    else:
+        record_key = (
+            "resolved_config_path"
+            if location == "resolved-config-leaf"
+            else "artifact_manifest_path"
+        )
+        record_path = tmp_path / manifest.execution_record[record_key]
+        external_file = tmp_path / f"external-{record_path.name}"
+        external_file.write_bytes(record_path.read_bytes())
+        record_path.unlink()
+        record_path.symlink_to(external_file)
+
+    with pytest.raises(ValueError, match="stage execution record path is symlinked"):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+def test_resolved_content_tamper_is_rejected_after_outer_sha_is_updated(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    pointer = json.loads(manifest_path.read_text())
+    resolved_path = tmp_path / manifest.execution_record["resolved_config_path"]
+    resolved = json.loads(resolved_path.read_text())
+    resolved["resolved_stage_config"]["model"]["revision"] = "tampered"
+    pointer["execution_record"]["resolved_config_sha256"] = _rewrite_json_record(
+        resolved_path, resolved
+    )
+    _rewrite_json_record(manifest_path, pointer)
+
+    with pytest.raises(
+        ValueError, match="resolved stage configuration identity mismatch"
+    ):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+def test_artifact_content_tamper_is_rejected_after_outer_sha_is_updated(
+    tmp_path: Path,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    pointer = json.loads(manifest_path.read_text())
+    artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
+    artifact = json.loads(artifact_path.read_text())
+    artifact["immutable_evidence"]["forged"] = {"sha256": "0" * 64}
+    pointer["execution_record"]["artifact_manifest_sha256"] = _rewrite_json_record(
+        artifact_path, artifact
+    )
+    _rewrite_json_record(manifest_path, pointer)
+
+    with pytest.raises(ValueError, match="stage artifact record identity mismatch"):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("resolved_config", "stage artifact resolved-configuration reference mismatch"),
+        (
+            "canonical_output_pointers",
+            "stage artifact canonical output pointers mismatch",
+        ),
+    ],
+    ids=["resolved-config-cross-reference", "canonical-output-pointers"],
+)
+def test_resealed_artifact_tamper_still_fails_cross_record_validation(
+    tmp_path: Path,
+    field: str,
+    message: str,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    pointer = json.loads(manifest_path.read_text())
+    artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
+    artifact = json.loads(artifact_path.read_text())
+    if field == "resolved_config":
+        artifact[field]["identity"] = "tampered"
+    else:
+        artifact[field] = {"forged": "output.json"}
+    identity_payload = dict(artifact)
+    identity_payload.pop("artifact_manifest_identity")
+    artifact_identity = stable_hash(identity_payload, prefix="convert_artifacts")
+    artifact["artifact_manifest_identity"] = artifact_identity
+    pointer["execution_record"]["artifact_manifest_identity"] = artifact_identity
+    pointer["execution_record"]["artifact_manifest_sha256"] = _rewrite_json_record(
+        artifact_path, artifact
+    )
+    _rewrite_json_record(manifest_path, pointer)
+
+    with pytest.raises(ValueError, match=message):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("config", "stage manifest config identity mismatch"),
+        ("semantic_config", "stage manifest semantic config identity mismatch"),
+        ("capability_snapshot", "stage manifest semantic identity mismatch"),
+        ("inputs", "resolved descriptor input provenance mismatch"),
+        ("implementation_provenance", "resolved implementation provenance mismatch"),
+    ],
+    ids=[
+        "authored-config",
+        "semantic-config",
+        "capability",
+        "descriptor-input",
+        "implementation-provenance",
+    ],
+)
+def test_resume_recomputes_canonical_pointer_identities(
+    tmp_path: Path,
+    field: str,
+    message: str,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    manifest = StageManifest(
+        stage="convert",
+        config=_stage_config(tmp_path, config_path),
+        inputs={"descriptor_resolution": {"descriptor": "llama"}},
+        capability_snapshot={"backend": "hf"},
+    )
+    manifest.complete()
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    write_stage_manifest(manifest_path, manifest)
+    pointer = json.loads(manifest_path.read_text())
+    if field == "config":
+        pointer[field]["model"]["revision"] = "tampered"
+    elif field == "semantic_config":
+        pointer[field]["model"]["revision"] = "tampered"
+    elif field == "capability_snapshot":
+        pointer[field]["backend"] = "tampered"
+    elif field == "inputs":
+        pointer[field]["descriptor_resolution"]["descriptor"] = "tampered"
+    else:
+        pointer[field]["reviewer"] = "tampered"
+    manifest_path.write_text(json.dumps(pointer))
+
+    with pytest.raises(ValueError, match=message):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for immutable per-stage resolved configuration and artifact records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from examples.puzzletron.main import (
+    _completion_is_valid,
+    _mark_completion,
+    _pipeline_config_from_path,
+    _resume_kwargs,
+)
+from modelopt.torch.puzzletron.identity import stable_hash
+from modelopt.torch.puzzletron.manifest import StageManifest, write_stage_manifest
+from modelopt.torch.puzzletron.pipeline_config import load_runtime_hydra_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _stage_config(tmp_path: Path, config_path: Path) -> dict:
+    return {
+        "experiment": {"dir": str(tmp_path)},
+        "model": {"source": "example/model", "revision": "revision-1"},
+        "convert": {"teacher_dir": str(tmp_path / "ckpts" / "teacher")},
+        "_runtime": {
+            "config_path": str(config_path),
+            "overrides": ["model.revision=revision-1"],
+            "gpus_per_node": 4,
+        },
+    }
+
+
+def test_stage_manifest_persists_resolved_config_and_artifact_manifest(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model:\n  revision: revision-1\n")
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(
+        stage="convert",
+        config=config,
+        implementation_provenance={"source_identity": "source-v1"},
+    )
+    manifest.complete(outputs={"summary_path": str(summary_path)})
+
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    write_stage_manifest(manifest_path, manifest)
+
+    canonical = json.loads(manifest_path.read_text())
+    record = canonical["execution_record"]
+    resolved = json.loads((tmp_path / record["resolved_config_path"]).read_text())
+    artifacts = json.loads((tmp_path / record["artifact_manifest_path"]).read_text())
+    assert resolved["effective_config"] == config
+    assert resolved["started_at"] == canonical["started_at"]
+    assert resolved["ended_at"] == canonical["ended_at"]
+    assert resolved["authored_config_identity"] == canonical["config_identity"]
+    assert resolved["resolved_config_identity"] == record["resolved_config_identity"]
+    assert resolved["provenance"] == {
+        "authored_config_path": str(config_path),
+        "overrides": ["model.revision=revision-1"],
+        "implementation": {"source_identity": "source-v1"},
+        "descriptor_resolution": None,
+        "capability_snapshot": None,
+    }
+    assert resolved["replay"]["argv"] == [
+        sys.executable,
+        f"{resolved['replay']['working_directory']}/examples/puzzletron/main.py",
+        "--config",
+        str(tmp_path / record["resolved_config_path"]),
+        "--stage",
+        "convert",
+        "--gpus-per-node",
+        "4",
+        "--force",
+    ]
+    assert resolved["resolved_config_identity"] == stable_hash(
+        resolved["effective_config"], prefix="convert_resolved_cfg"
+    )
+    assert artifacts["declared_outputs"] == {"summary_path": str(summary_path)}
+    assert artifacts["artifact_contract"] == "stage-manifest-outputs"
+    assert artifacts["started_at"] == canonical["started_at"]
+    assert artifacts["ended_at"] == canonical["ended_at"]
+    assert artifacts["artifact_manifest_identity"] == record["artifact_manifest_identity"]
+    resolved_bytes = (tmp_path / record["resolved_config_path"]).read_bytes()
+    assert artifacts["resolved_config"]["sha256"] == hashlib.sha256(resolved_bytes).hexdigest()
+    required_patterns = _resume_kwargs(config, config_path, "convert")["required_patterns"]
+    assert record["resolved_config_path"] in required_patterns
+    assert record["artifact_manifest_path"] in required_patterns
+
+    config_path.write_text("model:\n  revision: mutated-after-execution\n")
+    replayed = _pipeline_config_from_path(tmp_path / record["resolved_config_path"])
+    assert replayed["model"] == config["model"]
+    assert replayed["_runtime"]["resolved_config_path"] == str(
+        (tmp_path / record["resolved_config_path"]).resolve()
+    )
+    assert load_runtime_hydra_config(replayed).model.revision == "revision-1"
+
+
+@pytest.mark.parametrize("record_key", ["resolved_config_path", "artifact_manifest_path"])
+def test_stage_execution_record_is_immutable_and_idempotent(
+    tmp_path: Path,
+    record_key: str,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    manifest = StageManifest(
+        stage="convert",
+        config=_stage_config(tmp_path, config_path),
+        started_at="2026-08-06T10:00:00+00:00",
+        ended_at="2026-08-06T10:01:00+00:00",
+        status="success",
+    )
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    write_stage_manifest(manifest_path, manifest)
+    write_stage_manifest(manifest_path, manifest)
+
+    record_path = tmp_path / manifest.execution_record[record_key]
+    record_path.write_text("{}\n")
+
+    with pytest.raises(FileExistsError, match="immutable stage execution record"):
+        write_stage_manifest(manifest_path, manifest)
+
+
+def test_effective_config_change_creates_a_distinct_execution_record(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    original = StageManifest(
+        stage="convert",
+        config=_stage_config(tmp_path, config_path),
+        started_at="2026-08-06T10:00:00+00:00",
+        ended_at="2026-08-06T10:01:00+00:00",
+        status="success",
+    )
+    changed_config = _stage_config(tmp_path, config_path)
+    changed_config["model"]["revision"] = "revision-2"
+    changed = StageManifest(
+        stage="convert",
+        config=changed_config,
+        started_at=original.started_at,
+        ended_at=original.ended_at,
+        status="success",
+    )
+    manifest_path = tmp_path / "manifests" / "convert.json"
+
+    write_stage_manifest(manifest_path, original)
+    write_stage_manifest(manifest_path, changed)
+
+    assert (
+        original.execution_record["execution_identity"]
+        != (changed.execution_record["execution_identity"])
+    )
+    assert (tmp_path / original.execution_record["resolved_config_path"]).is_file()
+    assert (tmp_path / changed.execution_record["resolved_config_path"]).is_file()
+
+
+def test_same_config_rerun_creates_a_distinct_execution_record(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    config = _stage_config(tmp_path, config_path)
+    original = StageManifest(
+        stage="convert",
+        config=config,
+        started_at="2026-08-06T10:00:00+00:00",
+        ended_at="2026-08-06T10:01:00+00:00",
+        status="success",
+    )
+    rerun = StageManifest(
+        stage="convert",
+        config=config,
+        started_at="2026-08-06T11:00:00+00:00",
+        ended_at="2026-08-06T11:01:00+00:00",
+        status="success",
+    )
+    manifest_path = tmp_path / "manifests" / "convert.json"
+
+    write_stage_manifest(manifest_path, original)
+    write_stage_manifest(manifest_path, rerun)
+
+    assert (
+        original.execution_record["execution_identity"]
+        != (rerun.execution_record["execution_identity"])
+    )
+    assert (
+        original.execution_record["resolved_config_identity"]
+        == (rerun.execution_record["resolved_config_identity"])
+    )
+
+
+def test_effective_config_none_falls_back_but_empty_mapping_is_preserved(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    authored_config = _stage_config(tmp_path, config_path)
+    fallback = StageManifest(
+        stage="convert",
+        config=authored_config,
+        effective_config=None,
+        started_at="2026-08-06T11:00:00+00:00",
+        ended_at="2026-08-06T11:01:00+00:00",
+        status="success",
+    )
+    empty = StageManifest(
+        stage="convert",
+        config=authored_config,
+        effective_config={},
+        started_at="2026-08-06T11:02:00+00:00",
+        ended_at="2026-08-06T11:03:00+00:00",
+        status="success",
+    )
+    manifest_path = tmp_path / "manifests" / "convert.json"
+
+    write_stage_manifest(manifest_path, fallback)
+    fallback_path = tmp_path / fallback.execution_record["resolved_config_path"]
+    write_stage_manifest(manifest_path, empty)
+    empty_path = tmp_path / empty.execution_record["resolved_config_path"]
+
+    assert json.loads(fallback_path.read_text())["effective_config"] == authored_config
+    assert json.loads(empty_path.read_text())["effective_config"] == {}
+
+
+def test_artifact_contract_preserves_declared_output_before_it_exists(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    late_output = tmp_path / "ckpts" / "scoring-parent.json"
+    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
+    manifest.complete(outputs={"scoring_parent_artifact": str(late_output)})
+
+    write_stage_manifest(tmp_path / "manifests" / "convert.json", manifest)
+
+    artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
+    artifact_manifest = json.loads(artifact_path.read_text())
+    assert artifact_manifest["artifact_contract"] == "stage-manifest-outputs"
+    assert artifact_manifest["declared_outputs"] == {"scoring_parent_artifact": str(late_output)}
+    assert not late_output.exists()
+
+
+def test_resolved_config_loader_rejects_tampering(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
+    manifest.complete()
+    write_stage_manifest(tmp_path / "manifests" / "convert.json", manifest)
+    resolved_path = tmp_path / manifest.execution_record["resolved_config_path"]
+    resolved = json.loads(resolved_path.read_text())
+    resolved["effective_config"]["model"]["revision"] = "tampered"
+    resolved_path.write_text(json.dumps(resolved))
+
+    with pytest.raises(ValueError, match="identity mismatch"):
+        _pipeline_config_from_path(resolved_path)
+
+
+def test_resume_remains_compatible_with_historical_stage_manifest(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    teacher_config = tmp_path / "ckpts" / "teacher" / "config.json"
+    teacher_config.parent.mkdir(parents=True)
+    teacher_config.write_text("{}\n")
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(stage="convert", config=config)
+    manifest.complete(outputs={"teacher_dir": str(teacher_config.parent)})
+    historical_payload = manifest.to_dict()
+    historical_payload.pop("effective_config")
+    historical_payload.pop("execution_record")
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    manifest_path.parent.mkdir()
+    manifest_path.write_text(json.dumps(historical_payload))
+
+    _mark_completion(config, config_path, "convert")
+
+    assert _completion_is_valid(config, config_path, "convert")
+
+
+def test_resume_requires_execution_record_files(tmp_path: Path) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    teacher_config = tmp_path / "ckpts" / "teacher" / "config.json"
+    teacher_config.parent.mkdir(parents=True)
+    teacher_config.write_text("{}\n")
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(stage="convert", config=config)
+    manifest.complete(outputs={"teacher_dir": str(teacher_config.parent)})
+
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    write_stage_manifest(manifest_path, manifest)
+    _mark_completion(config, config_path, "convert")
+    assert _completion_is_valid(config, config_path, "convert")
+
+    (tmp_path / manifest.execution_record["resolved_config_path"]).unlink()
+    assert not _completion_is_valid(config, config_path, "convert")

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -153,6 +153,33 @@ def test_execution_record_binds_terminal_skip_reason(tmp_path: Path) -> None:
         validate_stage_execution_record(manifest_path, expected_stage="tokenize_data")
 
 
+@pytest.mark.parametrize(
+    "record_key",
+    ["resolved_config_path", "artifact_manifest_path"],
+    ids=["resolved-config", "artifact-manifest"],
+)
+def test_skipped_stage_resume_rejects_missing_immutable_record(
+    tmp_path: Path,
+    record_key: str,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    config = _stage_config(tmp_path, config_path)
+    config["tokenize_data"] = {"enabled": False}
+    manifest = StageManifest(stage="tokenize_data", config=config)
+    manifest.complete(status="skipped", skip_reason="disabled")
+    manifest_path = tmp_path / "manifests" / "tokenize_data.json"
+    write_stage_manifest(manifest_path, manifest)
+    pointer = json.loads(manifest_path.read_text())
+
+    (tmp_path / pointer["execution_record"][record_key]).unlink()
+
+    with pytest.raises(ValueError, match=r"invalid .* record"):
+        _completion_is_valid(config, config_path, "tokenize_data")
+    with pytest.raises(ValueError, match=r"invalid .* record"):
+        _mark_completion(config, config_path, "tokenize_data")
+
+
 def test_artifact_manifest_separates_output_pointer_from_immutable_evidence(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature.

Puzzletron stage manifests currently identify terminal state and declared outputs, but they do not preserve immutable evidence of the exact effective configuration and artifact metadata for each execution attempt.

This change writes paired immutable records for the resolved stage configuration and artifact pointers, captures effective runtime and descriptor configuration at the stage boundary, and validates record checksums, identities, and path safety during resume. Historical manifests without execution records remain readable, while manifests using the new schema fail closed if their records are missing or tampered with. Skipped stages also validate their referenced records before resume acceptance.

### Testing

The dedicated Puzzletron v2 CPU lane covers execution-record creation and validation, tamper resistance, historical resume compatibility, skipped-stage handling, and cross-model effective-configuration capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added immutable per-stage execution records with resolved settings, provenance, execution identity, artifact references, and integrity evidence.
  - Stage manifests now include effective runtime configuration details for clearer execution tracking.
  - Resume and skipped-stage handling now verify required execution records before continuing.

- **Bug Fixes**
  - Added fail-closed validation for missing, malformed, tampered, unsafe, or mismatched execution records.
  - Preserved compatibility with existing manifests that do not contain execution records.

- **Documentation**
  - Documented execution-record behavior, output pointers, immutability boundaries, and acceptance requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->