### PR TITLE
Test PuzzleTron v2 atomic state persistence

### DIFF
--- a/tests/unit/torch/puzzletron/test_setup_v2_state.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_state.py
@@ -28,17 +28,20 @@ def test_failed_atomic_replace_preserves_last_resumable_state(tmp_path, monkeypa
     state = WizardState.start(tmp_path / "campaign", defaults_path=None)
     state.set_field("model.source", "/models/teacher")
     durable_snapshot = state.path.read_bytes()
-    replace_calls = []
+    real_replace = state_module.os.replace
+    replace_targets = []
 
     def fail_replace(source, destination):
-        replace_calls.append((source, destination))
-        raise OSError("injected replace failure")
+        replace_targets.append(destination)
+        if destination == state.path:
+            raise OSError("injected replace failure")
+        return real_replace(source, destination)
 
     monkeypatch.setattr(state_module.os, "replace", fail_replace)
 
     with pytest.raises(SetupError, match="Cannot save v2 setup state"):
         state.set_field("model.source", "/models/candidate")
 
-    assert [destination for _, destination in replace_calls] == [state.path]
+    assert state.path in replace_targets
     assert state.path.read_bytes() == durable_snapshot
     assert WizardState.resume(state.path).get_field("model.source") == "/models/teacher"

--- a/tests/unit/torch/puzzletron/test_setup_v2_state.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_state.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Failure-path tests for atomic PuzzleTron v2 wizard state persistence."""
+
+from __future__ import annotations
+
+import pytest
+
+from puzzletron_setup import SetupError
+from puzzletron_setup.v2 import state as state_module
+from puzzletron_setup.v2.state import WizardState
+
+
+def test_failed_atomic_replace_preserves_last_resumable_state(tmp_path, monkeypatch):
+    state = WizardState.start(tmp_path / "campaign", defaults_path=None)
+    state.set_field("model.source", "/models/teacher")
+    durable_snapshot = state.path.read_bytes()
+
+    def fail_replace(source, destination):
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(state_module.os, "replace", fail_replace)
+
+    with pytest.raises(SetupError, match="Cannot save v2 setup state"):
+        state.set_field("model.source", "/models/candidate")
+
+    assert state.path.read_bytes() == durable_snapshot
+    assert WizardState.resume(state.path).get_field("model.source") == "/models/teacher"

--- a/tests/unit/torch/puzzletron/test_setup_v2_state.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_state.py
@@ -28,8 +28,10 @@ def test_failed_atomic_replace_preserves_last_resumable_state(tmp_path, monkeypa
     state = WizardState.start(tmp_path / "campaign", defaults_path=None)
     state.set_field("model.source", "/models/teacher")
     durable_snapshot = state.path.read_bytes()
+    replace_calls = []
 
     def fail_replace(source, destination):
+        replace_calls.append((source, destination))
         raise OSError("injected replace failure")
 
     monkeypatch.setattr(state_module.os, "replace", fail_replace)
@@ -37,5 +39,6 @@ def test_failed_atomic_replace_preserves_last_resumable_state(tmp_path, monkeypa
     with pytest.raises(SetupError, match="Cannot save v2 setup state"):
         state.set_field("model.source", "/models/candidate")
 
+    assert [destination for _, destination in replace_calls] == [state.path]
     assert state.path.read_bytes() == durable_snapshot
     assert WizardState.resume(state.path).get_field("model.source") == "/models/teacher"


### PR DESCRIPTION
### What does this PR do?

Type of change: new tests

PuzzleTron v2 setup persists interactive wizard progress so an interrupted setup can resume from its last durable state. That save path uses a temporary file followed by `os.replace` to provide the atomicity guarantee.

The existing suite covered successful resume behavior, but it never forced the final replacement boundary to fail. A regression could therefore damage or discard the last durable snapshot while all happy-path resume tests continued to pass. This test injects that failure and verifies both that the durable bytes remain unchanged and that `WizardState.resume` still recovers the prior value.

This is intentionally a focused test-only change so a failure points directly at the atomic state-persistence contract.

### Testing

The PuzzleTron CPU unit-test route now covers failed atomic replacement and recovery from the last durable state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for failed wizard-state saves.
  * Verified that save errors are reported clearly without replacing previously saved progress.
  * Confirmed that users can resume the PuzzleTron v2 setup wizard from the last successfully saved state after a save failure.
  * Tested atomic save behavior to ensure existing progress remains intact when a save operation cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->