### PR TITLE
Fail closed on invalid Puzzletron execution records

### DIFF
--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -388,6 +388,33 @@ def _embedding_followup_stage(stage: str) -> bool:
     return stage == "build_library"
 
 
+def _run_embedding_stage(
+    *,
+    config_path: str | Path,
+    config: dict,
+    stage: str,
+    gpus_per_node: int,
+) -> dict:
+    # The package and standalone entry points require different import paths.
+    if __package__:
+        from .embedding_pipeline import run_embedding_stage as package_run_embedding_stage
+
+        return package_run_embedding_stage(
+            config_path=config_path,
+            config=config,
+            stage=stage,
+            gpus_per_node=gpus_per_node,
+        )
+    from embedding_pipeline import run_embedding_stage as script_run_embedding_stage
+
+    return script_run_embedding_stage(
+        config_path=config_path,
+        config=config,
+        stage=stage,
+        gpus_per_node=gpus_per_node,
+    )
+
+
 def _run_worker(args: argparse.Namespace) -> None:
     cfg = mtpz.pipeline_config.pipeline_config_from_path(
         args.config,
@@ -411,12 +438,7 @@ def _run_worker(args: argparse.Namespace) -> None:
 
         result = tokenize_data_stage(cfg)
     elif embedding_root and args.worker_stage in composite_only:
-        if __package__:
-            from .embedding_pipeline import run_embedding_stage
-        else:
-            from embedding_pipeline import run_embedding_stage
-
-        outputs = run_embedding_stage(
+        outputs = _run_embedding_stage(
             config_path=args.config,
             config=cfg,
             stage=args.worker_stage,
@@ -426,12 +448,7 @@ def _run_worker(args: argparse.Namespace) -> None:
     else:
         result = mtpz.stage_runner.run_stage(cfg, args.worker_stage)
         if embedding_root and _embedding_followup_stage(args.worker_stage):
-            if __package__:
-                from .embedding_pipeline import run_embedding_stage
-            else:
-                from embedding_pipeline import run_embedding_stage
-
-            outputs = run_embedding_stage(
+            outputs = _run_embedding_stage(
                 config_path=args.config,
                 config=cfg,
                 stage=args.worker_stage,

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -259,6 +259,7 @@ def _completion_is_valid(config: dict, config_path: str | Path, stage: str) -> b
         # Validation-only: raises if the referenced execution record was tampered with.
         _stage_execution_record_patterns(config, stage)
         return True
+    _stage_execution_record_patterns(config, stage)
     if not artifacts_are_complete(config, stage):
         return False
     kwargs = _resume_kwargs(config, config_path, stage)
@@ -273,6 +274,7 @@ def _mark_completion(config: dict, config_path: str | Path, stage: str) -> None:
         # Validation-only: raises if the referenced execution record was tampered with.
         _stage_execution_record_patterns(config, stage)
         return
+    _stage_execution_record_patterns(config, stage)
     if not artifacts_are_complete(config, stage):
         raise RuntimeError(f"stage {stage!r} failed canonical artifact validation")
     kwargs = _resume_kwargs(config, config_path, stage)

--- a/examples/puzzletron/main.py
+++ b/examples/puzzletron/main.py
@@ -85,7 +85,10 @@ def _register_faulthandler() -> None:
         )
         stack_path.parent.mkdir(parents=True, exist_ok=True)
         stack_log = stack_path.open("a")
-    faulthandler.register(signal.SIGUSR1, file=stack_log, all_threads=True)
+    if stack_log is None:
+        faulthandler.register(signal.SIGUSR1, all_threads=True)
+    else:
+        faulthandler.register(signal.SIGUSR1, file=stack_log, all_threads=True)
 
 
 _register_faulthandler()

--- a/modelopt/torch/puzzletron/execution_record.py
+++ b/modelopt/torch/puzzletron/execution_record.py
@@ -21,9 +21,10 @@ import hashlib
 import json
 import os
 import stat
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from pathlib import Path, PurePath
-from typing import Any
+from typing import Any, BinaryIO
 
 from .identity import stable_hash
 
@@ -31,6 +32,13 @@ __all__ = ["stage_manifest_uses_execution_record", "validate_stage_execution_rec
 
 _EXECUTION_RECORD_SCHEMA = "puzzletron.stage-execution/v1"
 _EXECUTION_RECORD_MANIFEST_VERSION = "2"
+_DESCRIPTOR_ROOTED_OPEN_SUPPORTED = (
+    hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in getattr(os, "supports_dir_fd", set())
+)
+_READ_ONLY_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+_FINAL_READ_FLAGS = _READ_ONLY_FLAGS | getattr(os, "O_NONBLOCK", 0)
 
 
 def _safe_relative_path(raw_path: object, *, description: str) -> Path:
@@ -53,6 +61,51 @@ def _path_without_symlinks(path: Path, *, description: str) -> Path:
     return Path(os.path.abspath(absolute))
 
 
+@contextmanager
+def _open_regular_file(path: Path, *, description: str) -> Iterator[BinaryIO]:
+    """Open one regular file without following a checked path through symlinks."""
+
+    path = _path_without_symlinks(path, description=description)
+    descriptor: int | None = None
+    directory_descriptor: int | None = None
+    try:
+        if _DESCRIPTOR_ROOTED_OPEN_SUPPORTED:
+            directory_flags = _READ_ONLY_FLAGS | os.O_DIRECTORY
+            directory_descriptor = os.open(path.anchor, directory_flags)
+            for part in path.parts[1:-1]:
+                previous_descriptor = directory_descriptor
+                directory_descriptor = os.open(
+                    part,
+                    directory_flags | os.O_NOFOLLOW,
+                    dir_fd=previous_descriptor,
+                )
+                os.close(previous_descriptor)
+            descriptor = os.open(
+                path.name,
+                _FINAL_READ_FLAGS | os.O_NOFOLLOW,
+                dir_fd=directory_descriptor,
+            )
+        else:
+            descriptor = os.open(path, _FINAL_READ_FLAGS)
+            _path_without_symlinks(path, description=description)
+            if not os.path.samestat(os.fstat(descriptor), path.lstat()):
+                raise ValueError(f"{description} changed while opening: {path}")
+
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError(f"{description} is not a regular file: {path}")
+        stream = os.fdopen(descriptor, "rb")
+        descriptor = None
+        with stream:
+            yield stream
+    except OSError as exc:
+        raise ValueError(f"invalid {description}: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if directory_descriptor is not None:
+            os.close(directory_descriptor)
+
+
 def _sha256_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
@@ -60,18 +113,12 @@ def _sha256_bytes(content: bytes) -> str:
 def _file_evidence(path: Path, *, description: str) -> dict[str, int | str]:
     """Return bounded-memory evidence for one regular, non-symlinked file."""
 
-    path = _path_without_symlinks(path, description=description)
-    try:
-        if not stat.S_ISREG(path.lstat().st_mode):
-            raise ValueError(f"{description} is not a regular file: {path}")
-        digest = hashlib.sha256()
-        size = 0
-        with path.open("rb") as stream:
-            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                size += len(chunk)
-                digest.update(chunk)
-    except OSError as exc:
-        raise ValueError(f"invalid {description}: {path}") from exc
+    digest = hashlib.sha256()
+    size = 0
+    with _open_regular_file(path, description=description) as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            size += len(chunk)
+            digest.update(chunk)
     return {"size": size, "sha256": digest.hexdigest()}
 
 
@@ -81,11 +128,14 @@ def _portable_relative_path(path: PurePath, root: PurePath) -> str:
     return path.relative_to(root).as_posix()
 
 
+def _read_file_bytes(path: Path, *, description: str) -> bytes:
+    with _open_regular_file(path, description=description) as stream:
+        return stream.read()
+
+
 def _read_mapping(path: Path, *, description: str) -> tuple[dict[str, Any], bytes]:
     try:
-        if not stat.S_ISREG(path.lstat().st_mode):
-            raise ValueError(f"invalid {description}: {path}")
-        content = path.read_bytes()
+        content = _read_file_bytes(path, description=description)
         payload = json.loads(content)
     except (OSError, ValueError) as exc:
         raise ValueError(f"invalid {description}: {path}") from exc

--- a/modelopt/torch/puzzletron/execution_record.py
+++ b/modelopt/torch/puzzletron/execution_record.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import stat
 from collections.abc import Mapping
 from pathlib import Path, PurePath
 from typing import Any
@@ -41,17 +43,36 @@ def _safe_relative_path(raw_path: object, *, description: str) -> Path:
 
 
 def _path_without_symlinks(path: Path, *, description: str) -> Path:
-    absolute = path.expanduser().absolute()
+    expanded = path.expanduser()
+    absolute = expanded if expanded.is_absolute() else Path.cwd() / expanded
     current = Path(absolute.anchor)
     for part in absolute.parts[1:]:
         current /= part
         if current.is_symlink():
             raise ValueError(f"{description} is symlinked: {current}")
-    return absolute
+    return Path(os.path.abspath(absolute))
 
 
 def _sha256_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
+
+
+def _file_evidence(path: Path, *, description: str) -> dict[str, int | str]:
+    """Return bounded-memory evidence for one regular, non-symlinked file."""
+
+    path = _path_without_symlinks(path, description=description)
+    try:
+        if not stat.S_ISREG(path.lstat().st_mode):
+            raise ValueError(f"{description} is not a regular file: {path}")
+        digest = hashlib.sha256()
+        size = 0
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                size += len(chunk)
+                digest.update(chunk)
+    except OSError as exc:
+        raise ValueError(f"invalid {description}: {path}") from exc
+    return {"size": size, "sha256": digest.hexdigest()}
 
 
 def _portable_relative_path(path: PurePath, root: PurePath) -> str:
@@ -62,6 +83,8 @@ def _portable_relative_path(path: PurePath, root: PurePath) -> str:
 
 def _read_mapping(path: Path, *, description: str) -> tuple[dict[str, Any], bytes]:
     try:
+        if not stat.S_ISREG(path.lstat().st_mode):
+            raise ValueError(f"invalid {description}: {path}")
         content = path.read_bytes()
         payload = json.loads(content)
     except (OSError, ValueError) as exc:
@@ -69,6 +92,78 @@ def _read_mapping(path: Path, *, description: str) -> tuple[dict[str, Any], byte
     if not isinstance(payload, dict):
         raise ValueError(f"invalid {description}: {path}")
     return payload, content
+
+
+def _validate_immutable_evidence(
+    evidence: object,
+    *,
+    output_pointers: object,
+    root: Path,
+) -> None:
+    if not isinstance(evidence, Mapping):
+        raise ValueError("stage artifact immutable evidence must be a mapping")
+    if not isinstance(output_pointers, Mapping):
+        raise ValueError("stage manifest outputs must be a mapping")
+
+    for key, entry in evidence.items():
+        if not isinstance(key, str) or not key or not isinstance(entry, Mapping):
+            raise ValueError(f"invalid stage output evidence entry: {key!r}")
+        output_pointer = output_pointers.get(key)
+        if not isinstance(output_pointer, str) or not output_pointer:
+            raise ValueError(f"stage output evidence has no matching output pointer: {key!r}")
+
+        evidence_path_value = entry.get("path")
+        if not isinstance(evidence_path_value, str) or not evidence_path_value:
+            raise ValueError(f"invalid stage output evidence path: {evidence_path_value!r}")
+        raw_evidence_path = Path(evidence_path_value)
+        if raw_evidence_path.is_absolute():
+            evidence_path = _path_without_symlinks(
+                raw_evidence_path, description="stage output evidence path"
+            )
+            try:
+                evidence_path.relative_to(root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"unsafe stage output evidence path: {evidence_path_value!r}"
+                ) from exc
+        else:
+            relative = _safe_relative_path(
+                evidence_path_value, description="stage output evidence path"
+            )
+            if "\\" in evidence_path_value or relative.as_posix() != evidence_path_value:
+                raise ValueError(
+                    f"stage output evidence path is not portable: {evidence_path_value!r}"
+                )
+            evidence_path = _path_without_symlinks(
+                root / relative, description="stage output evidence path"
+            )
+        pointer_path = Path(output_pointer)
+        if not pointer_path.is_absolute():
+            pointer_path = root / pointer_path
+        pointer_path = _path_without_symlinks(pointer_path, description="stage output pointer path")
+        if pointer_path != evidence_path:
+            raise ValueError(f"stage output evidence path mismatch: {key!r}")
+
+        expected_size = entry.get("size")
+        expected_sha256 = entry.get("sha256")
+        if (
+            isinstance(expected_size, bool)
+            or not isinstance(expected_size, int)
+            or expected_size < 0
+        ):
+            raise ValueError(f"invalid stage output evidence size: {key!r}")
+        if (
+            not isinstance(expected_sha256, str)
+            or len(expected_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in expected_sha256)
+        ):
+            raise ValueError(f"invalid stage output evidence SHA256: {key!r}")
+
+        actual = _file_evidence(evidence_path, description="stage output evidence file")
+        if actual["size"] != expected_size:
+            raise ValueError(f"stage output evidence size mismatch: {key!r}")
+        if actual["sha256"] != expected_sha256:
+            raise ValueError(f"stage output evidence SHA256 mismatch: {key!r}")
 
 
 def stage_manifest_uses_execution_record(manifest: Mapping[str, Any]) -> bool:
@@ -257,6 +352,10 @@ def validate_stage_execution_record(
         raise ValueError("stage artifact canonical-manifest reference mismatch")
     if stage_ref.get("semantic_identity") != pointer.get("semantic_identity"):
         raise ValueError("stage artifact semantic identity mismatch")
-    if artifact.get("canonical_output_pointers") != pointer.get("outputs"):
+    output_pointers = pointer.get("outputs")
+    if artifact.get("canonical_output_pointers") != output_pointers:
         raise ValueError("stage artifact canonical output pointers mismatch")
+    _validate_immutable_evidence(
+        artifact.get("immutable_evidence"), output_pointers=output_pointers, root=root
+    )
     return resolved_relative.as_posix(), artifact_relative.as_posix()

--- a/modelopt/torch/puzzletron/execution_record.py
+++ b/modelopt/torch/puzzletron/execution_record.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependency-light validation for immutable Puzzletron stage execution records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path, PurePath
+from typing import Any
+
+from .identity import stable_hash
+
+__all__ = ["stage_manifest_uses_execution_record", "validate_stage_execution_record"]
+
+_EXECUTION_RECORD_SCHEMA = "puzzletron.stage-execution/v1"
+_EXECUTION_RECORD_MANIFEST_VERSION = "2"
+
+
+def _safe_relative_path(raw_path: object, *, description: str) -> Path:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError(f"invalid {description}: {raw_path!r}")
+    path = Path(raw_path)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"unsafe {description}: {raw_path!r}")
+    return path
+
+
+def _path_without_symlinks(path: Path, *, description: str) -> Path:
+    absolute = path.expanduser().absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"{description} is symlinked: {current}")
+    return absolute
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _portable_relative_path(path: PurePath, root: PurePath) -> str:
+    """Serialize a relative path with platform-neutral separators."""
+
+    return path.relative_to(root).as_posix()
+
+
+def _read_mapping(path: Path, *, description: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        content = path.read_bytes()
+        payload = json.loads(content)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"invalid {description}: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"invalid {description}: {path}")
+    return payload, content
+
+
+def stage_manifest_uses_execution_record(manifest: Mapping[str, Any]) -> bool:
+    """Return whether a manifest opts into immutable execution-record validation."""
+
+    return (
+        manifest.get("version") == _EXECUTION_RECORD_MANIFEST_VERSION
+        or "execution_record" in manifest
+    )
+
+
+def validate_stage_execution_record(
+    manifest_path: str | Path,
+    *,
+    expected_stage: str | None = None,
+) -> tuple[str, ...]:
+    """Validate the canonical pointer and every immutable record it references.
+
+    Historical stage manifests without ``execution_record`` remain readable. Any
+    manifest that opts into the execution-record schema is checked fail closed.
+    """
+
+    path = _path_without_symlinks(Path(manifest_path), description="stage manifest path")
+    if path.parent.name != "manifests":
+        raise ValueError(f"stage manifest is outside the expected layout: {path}")
+    root = path.parent.parent
+    pointer, _ = _read_mapping(path, description="stage manifest")
+    stage = pointer.get("stage")
+    if not isinstance(stage, str) or Path(stage).name != stage or stage in {".", ".."}:
+        raise ValueError(f"invalid stage identifier in stage manifest: {stage!r}")
+    if expected_stage is not None and stage != expected_stage:
+        raise ValueError(
+            f"stage manifest identity mismatch: expected {expected_stage!r}, found {stage!r}"
+        )
+
+    pointer_config = pointer.get("config")
+    if not isinstance(pointer_config, Mapping):
+        raise ValueError("stage manifest config must be a mapping")
+    expected_config_identity = stable_hash(pointer_config, prefix=f"{stage}_cfg")
+    if pointer.get("config_identity") != expected_config_identity:
+        raise ValueError("stage manifest config identity mismatch")
+
+    pointer_semantic_config = pointer.get("semantic_config")
+    if not isinstance(pointer_semantic_config, Mapping):
+        raise ValueError("stage manifest semantic config must be a mapping")
+    expected_semantic_config_identity = stable_hash(
+        pointer_semantic_config, prefix=f"{stage}_semantic_cfg"
+    )
+    if pointer.get("semantic_config_identity") != expected_semantic_config_identity:
+        raise ValueError("stage manifest semantic config identity mismatch")
+    expected_semantic_identity = stable_hash(
+        {
+            "stage": stage,
+            "semantic_config_identity": expected_semantic_config_identity,
+            "capability_snapshot": pointer.get("capability_snapshot"),
+        },
+        prefix=f"{stage}_semantic",
+    )
+    if pointer.get("semantic_identity") != expected_semantic_identity:
+        raise ValueError("stage manifest semantic identity mismatch")
+
+    if "execution_record" not in pointer:
+        if stage_manifest_uses_execution_record(pointer):
+            raise ValueError("stage manifest requires an execution record")
+        return ()
+    record = pointer.get("execution_record")
+    if not isinstance(record, Mapping) or record.get("schema") != _EXECUTION_RECORD_SCHEMA:
+        raise ValueError(f"invalid stage execution record: {record!r}")
+    execution_identity = record.get("execution_identity")
+    if not isinstance(execution_identity, str) or not execution_identity:
+        raise ValueError("invalid stage execution identity")
+
+    resolved_relative = _safe_relative_path(
+        record.get("resolved_config_path"), description="stage execution record path"
+    )
+    artifact_relative = _safe_relative_path(
+        record.get("artifact_manifest_path"), description="stage execution record path"
+    )
+    expected_parent = Path("manifests") / "executions" / stage / execution_identity
+    for relative, filename in (
+        (resolved_relative, "resolved_config.json"),
+        (artifact_relative, "artifact_manifest.json"),
+    ):
+        if relative.parent != expected_parent or relative.name != filename:
+            raise ValueError(f"stage execution record path does not match identity: {relative}")
+
+    resolved_path = _path_without_symlinks(
+        root / resolved_relative, description="stage execution record path"
+    )
+    artifact_path = _path_without_symlinks(
+        root / artifact_relative, description="stage execution record path"
+    )
+    resolved, resolved_bytes = _read_mapping(
+        resolved_path, description="resolved stage configuration record"
+    )
+    artifact, artifact_bytes = _read_mapping(artifact_path, description="stage artifact record")
+    resolved_sha256 = _sha256_bytes(resolved_bytes)
+    if record.get("resolved_config_sha256") != resolved_sha256:
+        raise ValueError("resolved stage configuration SHA256 mismatch")
+    if record.get("artifact_manifest_sha256") != _sha256_bytes(artifact_bytes):
+        raise ValueError("stage artifact record SHA256 mismatch")
+
+    for label, payload in (("resolved", resolved), ("artifact", artifact)):
+        if payload.get("schema") != _EXECUTION_RECORD_SCHEMA or payload.get("schema_version") != 1:
+            raise ValueError(f"invalid {label} stage execution record schema")
+        if payload.get("stage") != stage or payload.get("execution_identity") != execution_identity:
+            raise ValueError(f"{label} stage execution identity mismatch")
+        for key in ("status", "skip_reason", "started_at", "ended_at"):
+            if payload.get(key) != pointer.get(key):
+                raise ValueError(f"{label} stage execution {key} mismatch")
+
+    resolved_identity = stable_hash(
+        resolved.get("resolved_stage_config"), prefix=f"{stage}_resolved_cfg"
+    )
+    if (
+        resolved.get("resolved_config_identity") != resolved_identity
+        or record.get("resolved_config_identity") != resolved_identity
+    ):
+        raise ValueError("resolved stage configuration identity mismatch")
+    for key in (
+        "authored_config_identity",
+        "semantic_config_identity",
+        "semantic_identity",
+    ):
+        pointer_key = "config_identity" if key == "authored_config_identity" else key
+        if resolved.get(key) != pointer.get(pointer_key):
+            raise ValueError(f"resolved stage {key} mismatch")
+
+    resolved_provenance = resolved.get("provenance") or {}
+    if not isinstance(resolved_provenance, Mapping):
+        raise ValueError("resolved stage provenance must be a mapping")
+    implementation = resolved_provenance.get("implementation") or {}
+    pointer_implementation = pointer.get("implementation_provenance") or {}
+    if implementation != pointer_implementation:
+        raise ValueError("resolved implementation provenance mismatch")
+    pointer_inputs = pointer.get("inputs") or {}
+    if not isinstance(pointer_inputs, Mapping):
+        raise ValueError("stage manifest inputs must be a mapping")
+    if resolved.get("semantic_config") != pointer_semantic_config:
+        raise ValueError("resolved stage semantic config mismatch")
+    if resolved_provenance.get("descriptor_resolution") != pointer_inputs.get(
+        "descriptor_resolution"
+    ):
+        raise ValueError("resolved descriptor input provenance mismatch")
+    if resolved_provenance.get("capability_snapshot") != pointer.get("capability_snapshot"):
+        raise ValueError("resolved capability provenance mismatch")
+
+    expected_execution_identity = stable_hash(
+        {
+            "stage": stage,
+            "status": resolved.get("status"),
+            "skip_reason": resolved.get("skip_reason"),
+            "started_at": resolved.get("started_at"),
+            "ended_at": resolved.get("ended_at"),
+            "authored_config_identity": resolved.get("authored_config_identity"),
+            "resolved_config_identity": resolved_identity,
+            "semantic_config_identity": resolved.get("semantic_config_identity"),
+            "semantic_identity": resolved.get("semantic_identity"),
+            "capability_snapshot": resolved_provenance.get("capability_snapshot"),
+            "implementation_provenance": implementation,
+        },
+        prefix=f"{stage}_execution",
+    )
+    if expected_execution_identity != execution_identity:
+        raise ValueError("stage execution identity does not match record content")
+
+    artifact_identity_payload = dict(artifact)
+    artifact_identity = artifact_identity_payload.pop("artifact_manifest_identity", None)
+    expected_artifact_identity = stable_hash(artifact_identity_payload, prefix=f"{stage}_artifacts")
+    if (
+        artifact_identity != expected_artifact_identity
+        or record.get("artifact_manifest_identity") != expected_artifact_identity
+    ):
+        raise ValueError("stage artifact record identity mismatch")
+    resolved_ref = artifact.get("resolved_config")
+    if not isinstance(resolved_ref, Mapping) or resolved_ref != {
+        "path": resolved_relative.as_posix(),
+        "identity": resolved_identity,
+        "sha256": resolved_sha256,
+    }:
+        raise ValueError("stage artifact resolved-configuration reference mismatch")
+    stage_ref = artifact.get("stage_manifest")
+    if not isinstance(stage_ref, Mapping) or stage_ref.get("path") != _portable_relative_path(
+        path, root
+    ):
+        raise ValueError("stage artifact canonical-manifest reference mismatch")
+    if stage_ref.get("semantic_identity") != pointer.get("semantic_identity"):
+        raise ValueError("stage artifact semantic identity mismatch")
+    if artifact.get("canonical_output_pointers") != pointer.get("outputs"):
+        raise ValueError("stage artifact canonical output pointers mismatch")
+    return resolved_relative.as_posix(), artifact_relative.as_posix()

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -34,6 +34,8 @@ from .execution_record import (
     _file_evidence,
     _path_without_symlinks,
     _portable_relative_path,
+    _read_file_bytes,
+    _read_mapping,
     _sha256_bytes,
     validate_stage_execution_record,
 )
@@ -57,6 +59,13 @@ def _json_bytes(payload: dict[str, Any]) -> bytes:
     return (json.dumps(canonicalize(payload), indent=2, sort_keys=True) + "\n").encode()
 
 
+def _immutable_record_matches(path: Path, expected: bytes) -> bool:
+    try:
+        return _read_file_bytes(path, description="stage execution record path") == expected
+    except ValueError:
+        return False
+
+
 def _publish_immutable_record(
     record_dir: Path,
     files: dict[str, bytes],
@@ -78,7 +87,7 @@ def _publish_immutable_record(
         mismatches = [
             name
             for name, content in files.items()
-            if not (record_dir / name).is_file() or (record_dir / name).read_bytes() != content
+            if not _immutable_record_matches(record_dir / name, content)
         ]
         if mismatches:
             raise FileExistsError(
@@ -367,7 +376,8 @@ def write_stage_manifest(path: str | Path, manifest: StageManifest) -> None:
 def read_stage_manifest(path: str | Path) -> dict[str, Any]:
     """Read a stage manifest while preserving compatibility with older schemas."""
 
-    return json.loads(Path(path).read_text())
+    payload, _ = _read_mapping(Path(path), description="stage manifest")
+    return payload
 
 
 # Import after defining the manifest API because the stages package registers

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -29,6 +29,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .execution_record import (
+    _EXECUTION_RECORD_MANIFEST_VERSION,
+    _EXECUTION_RECORD_SCHEMA,
+    _path_without_symlinks,
+    _portable_relative_path,
+    _sha256_bytes,
+    validate_stage_execution_record,
+)
 from .identity import canonicalize, stable_hash
 
 __all__ = [
@@ -39,9 +47,6 @@ __all__ = [
     "write_stage_execution_record",
     "write_stage_manifest",
 ]
-
-
-_EXECUTION_RECORD_SCHEMA = "puzzletron.stage-execution/v1"
 
 
 def _now_iso() -> str:
@@ -83,29 +88,6 @@ def _publish_immutable_record(
     finally:
         if temporary.exists():
             shutil.rmtree(temporary)
-
-
-def _safe_relative_path(raw_path: object, *, description: str) -> Path:
-    if not isinstance(raw_path, str) or not raw_path:
-        raise ValueError(f"invalid {description}: {raw_path!r}")
-    path = Path(raw_path)
-    if path.is_absolute() or ".." in path.parts:
-        raise ValueError(f"unsafe {description}: {raw_path!r}")
-    return path
-
-
-def _path_without_symlinks(path: Path, *, description: str) -> Path:
-    absolute = path.expanduser().absolute()
-    current = Path(absolute.anchor)
-    for part in absolute.parts[1:]:
-        current /= part
-        if current.is_symlink():
-            raise ValueError(f"{description} is symlinked: {current}")
-    return absolute
-
-
-def _sha256_bytes(content: bytes) -> str:
-    return hashlib.sha256(content).hexdigest()
 
 
 def _file_evidence(path: Path) -> dict[str, int | str]:
@@ -181,8 +163,8 @@ def write_stage_execution_record(
     record_dir = root / "manifests" / "executions" / stage / execution_identity
     resolved_path = record_dir / "resolved_config.json"
     artifact_path = record_dir / "artifact_manifest.json"
-    resolved_relative = resolved_path.relative_to(root).as_posix()
-    artifact_relative = artifact_path.relative_to(root).as_posix()
+    resolved_relative = _portable_relative_path(resolved_path, root)
+    artifact_relative = _portable_relative_path(artifact_path, root)
 
     inputs = manifest_payload.get("inputs") or {}
     runtime = effective_config.get("_runtime") if isinstance(effective_config, dict) else {}
@@ -242,7 +224,7 @@ def write_stage_execution_record(
             "sha256": resolved_sha256,
         },
         "stage_manifest": {
-            "path": manifest_path.relative_to(root).as_posix(),
+            "path": _portable_relative_path(manifest_path, root),
             "semantic_identity": manifest_payload.get("semantic_identity"),
         },
         "artifact_contract": "stage-manifest-output-pointers/v1",
@@ -270,198 +252,6 @@ def write_stage_execution_record(
         "artifact_manifest_identity": artifact_identity,
         "artifact_manifest_sha256": artifact_sha256,
     }
-
-
-def _read_mapping(path: Path, *, description: str) -> tuple[dict[str, Any], bytes]:
-    try:
-        content = path.read_bytes()
-        payload = json.loads(content)
-    except (OSError, ValueError) as exc:
-        raise ValueError(f"invalid {description}: {path}") from exc
-    if not isinstance(payload, dict):
-        raise ValueError(f"invalid {description}: {path}")
-    return payload, content
-
-
-def validate_stage_execution_record(
-    manifest_path: str | Path,
-    *,
-    expected_stage: str | None = None,
-) -> tuple[str, ...]:
-    """Validate the canonical pointer and every immutable record it references.
-
-    Historical stage manifests without ``execution_record`` remain readable. Any
-    manifest that opts into the execution-record schema is checked fail closed.
-    """
-
-    path = _path_without_symlinks(Path(manifest_path), description="stage manifest path")
-    if path.parent.name != "manifests":
-        raise ValueError(f"stage manifest is outside the expected layout: {path}")
-    root = path.parent.parent
-    pointer, _ = _read_mapping(path, description="stage manifest")
-    stage = pointer.get("stage")
-    if not isinstance(stage, str) or Path(stage).name != stage or stage in {".", ".."}:
-        raise ValueError(f"invalid stage identifier in stage manifest: {stage!r}")
-    if expected_stage is not None and stage != expected_stage:
-        raise ValueError(
-            f"stage manifest identity mismatch: expected {expected_stage!r}, found {stage!r}"
-        )
-
-    pointer_config = pointer.get("config")
-    if not isinstance(pointer_config, Mapping):
-        raise ValueError("stage manifest config must be a mapping")
-    expected_config_identity = stable_hash(pointer_config, prefix=f"{stage}_cfg")
-    if pointer.get("config_identity") != expected_config_identity:
-        raise ValueError("stage manifest config identity mismatch")
-
-    pointer_semantic_config = pointer.get("semantic_config")
-    if not isinstance(pointer_semantic_config, Mapping):
-        raise ValueError("stage manifest semantic config must be a mapping")
-    expected_semantic_config_identity = stable_hash(
-        pointer_semantic_config, prefix=f"{stage}_semantic_cfg"
-    )
-    if pointer.get("semantic_config_identity") != expected_semantic_config_identity:
-        raise ValueError("stage manifest semantic config identity mismatch")
-    expected_semantic_identity = stable_hash(
-        {
-            "stage": stage,
-            "semantic_config_identity": expected_semantic_config_identity,
-            "capability_snapshot": pointer.get("capability_snapshot"),
-        },
-        prefix=f"{stage}_semantic",
-    )
-    if pointer.get("semantic_identity") != expected_semantic_identity:
-        raise ValueError("stage manifest semantic identity mismatch")
-
-    if "execution_record" not in pointer:
-        return ()
-    record = pointer.get("execution_record")
-    if not isinstance(record, Mapping) or record.get("schema") != _EXECUTION_RECORD_SCHEMA:
-        raise ValueError(f"invalid stage execution record: {record!r}")
-    execution_identity = record.get("execution_identity")
-    if not isinstance(execution_identity, str) or not execution_identity:
-        raise ValueError("invalid stage execution identity")
-
-    resolved_relative = _safe_relative_path(
-        record.get("resolved_config_path"), description="stage execution record path"
-    )
-    artifact_relative = _safe_relative_path(
-        record.get("artifact_manifest_path"), description="stage execution record path"
-    )
-    expected_parent = Path("manifests") / "executions" / stage / execution_identity
-    for relative, filename in (
-        (resolved_relative, "resolved_config.json"),
-        (artifact_relative, "artifact_manifest.json"),
-    ):
-        if relative.parent != expected_parent or relative.name != filename:
-            raise ValueError(f"stage execution record path does not match identity: {relative}")
-
-    resolved_path = _path_without_symlinks(
-        root / resolved_relative, description="stage execution record path"
-    )
-    artifact_path = _path_without_symlinks(
-        root / artifact_relative, description="stage execution record path"
-    )
-    resolved, resolved_bytes = _read_mapping(
-        resolved_path, description="resolved stage configuration record"
-    )
-    artifact, artifact_bytes = _read_mapping(artifact_path, description="stage artifact record")
-    resolved_sha256 = _sha256_bytes(resolved_bytes)
-    if record.get("resolved_config_sha256") != resolved_sha256:
-        raise ValueError("resolved stage configuration SHA256 mismatch")
-    if record.get("artifact_manifest_sha256") != _sha256_bytes(artifact_bytes):
-        raise ValueError("stage artifact record SHA256 mismatch")
-
-    for label, payload in (("resolved", resolved), ("artifact", artifact)):
-        if payload.get("schema") != _EXECUTION_RECORD_SCHEMA or payload.get("schema_version") != 1:
-            raise ValueError(f"invalid {label} stage execution record schema")
-        if payload.get("stage") != stage or payload.get("execution_identity") != execution_identity:
-            raise ValueError(f"{label} stage execution identity mismatch")
-        for key in ("status", "skip_reason", "started_at", "ended_at"):
-            if payload.get(key) != pointer.get(key):
-                raise ValueError(f"{label} stage execution {key} mismatch")
-
-    resolved_identity = stable_hash(
-        resolved.get("resolved_stage_config"), prefix=f"{stage}_resolved_cfg"
-    )
-    if (
-        resolved.get("resolved_config_identity") != resolved_identity
-        or record.get("resolved_config_identity") != resolved_identity
-    ):
-        raise ValueError("resolved stage configuration identity mismatch")
-    for key in (
-        "authored_config_identity",
-        "semantic_config_identity",
-        "semantic_identity",
-    ):
-        pointer_key = "config_identity" if key == "authored_config_identity" else key
-        if resolved.get(key) != pointer.get(pointer_key):
-            raise ValueError(f"resolved stage {key} mismatch")
-
-    resolved_provenance = resolved.get("provenance") or {}
-    if not isinstance(resolved_provenance, Mapping):
-        raise ValueError("resolved stage provenance must be a mapping")
-    implementation = resolved_provenance.get("implementation") or {}
-    pointer_implementation = pointer.get("implementation_provenance") or {}
-    if implementation != pointer_implementation:
-        raise ValueError("resolved implementation provenance mismatch")
-    pointer_inputs = pointer.get("inputs") or {}
-    if not isinstance(pointer_inputs, Mapping):
-        raise ValueError("stage manifest inputs must be a mapping")
-    if resolved.get("semantic_config") != pointer_semantic_config:
-        raise ValueError("resolved stage semantic config mismatch")
-    if resolved_provenance.get("descriptor_resolution") != pointer_inputs.get(
-        "descriptor_resolution"
-    ):
-        raise ValueError("resolved descriptor input provenance mismatch")
-    if resolved_provenance.get("capability_snapshot") != pointer.get("capability_snapshot"):
-        raise ValueError("resolved capability provenance mismatch")
-
-    expected_execution_identity = stable_hash(
-        {
-            "stage": stage,
-            "status": resolved.get("status"),
-            "skip_reason": resolved.get("skip_reason"),
-            "started_at": resolved.get("started_at"),
-            "ended_at": resolved.get("ended_at"),
-            "authored_config_identity": resolved.get("authored_config_identity"),
-            "resolved_config_identity": resolved_identity,
-            "semantic_config_identity": resolved.get("semantic_config_identity"),
-            "semantic_identity": resolved.get("semantic_identity"),
-            "capability_snapshot": resolved_provenance.get("capability_snapshot"),
-            "implementation_provenance": implementation,
-        },
-        prefix=f"{stage}_execution",
-    )
-    if expected_execution_identity != execution_identity:
-        raise ValueError("stage execution identity does not match record content")
-
-    artifact_identity_payload = dict(artifact)
-    artifact_identity = artifact_identity_payload.pop("artifact_manifest_identity", None)
-    expected_artifact_identity = stable_hash(artifact_identity_payload, prefix=f"{stage}_artifacts")
-    if (
-        artifact_identity != expected_artifact_identity
-        or record.get("artifact_manifest_identity") != expected_artifact_identity
-    ):
-        raise ValueError("stage artifact record identity mismatch")
-    resolved_ref = artifact.get("resolved_config")
-    if not isinstance(resolved_ref, Mapping) or resolved_ref != {
-        "path": resolved_relative.as_posix(),
-        "identity": resolved_identity,
-        "sha256": resolved_sha256,
-    }:
-        raise ValueError("stage artifact resolved-configuration reference mismatch")
-    stage_ref = artifact.get("stage_manifest")
-    if (
-        not isinstance(stage_ref, Mapping)
-        or stage_ref.get("path") != path.relative_to(root).as_posix()
-    ):
-        raise ValueError("stage artifact canonical-manifest reference mismatch")
-    if stage_ref.get("semantic_identity") != pointer.get("semantic_identity"):
-        raise ValueError("stage artifact semantic identity mismatch")
-    if artifact.get("canonical_output_pointers") != pointer.get("outputs"):
-        raise ValueError("stage artifact canonical output pointers mismatch")
-    return resolved_relative.as_posix(), artifact_relative.as_posix()
 
 
 @dataclass
@@ -567,6 +357,7 @@ def write_stage_manifest(path: str | Path, manifest: StageManifest) -> None:
     if os.environ.get("RANK") not in (None, "", "0"):
         return
     path = Path(path)
+    manifest.version = _EXECUTION_RECORD_MANIFEST_VERSION
     execution_payload = manifest.to_dict()
     execution_payload["effective_config"] = canonicalize(manifest.effective_config)
     manifest.execution_record = write_stage_execution_record(path, execution_payload)

--- a/modelopt/torch/puzzletron/manifest.py
+++ b/modelopt/torch/puzzletron/manifest.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import shutil
@@ -32,6 +31,7 @@ from typing import Any
 from .execution_record import (
     _EXECUTION_RECORD_MANIFEST_VERSION,
     _EXECUTION_RECORD_SCHEMA,
+    _file_evidence,
     _path_without_symlinks,
     _portable_relative_path,
     _sha256_bytes,
@@ -88,18 +88,6 @@ def _publish_immutable_record(
     finally:
         if temporary.exists():
             shutil.rmtree(temporary)
-
-
-def _file_evidence(path: Path) -> dict[str, int | str]:
-    """Return bounded-memory size and digest evidence for one file."""
-
-    digest = hashlib.sha256()
-    size = 0
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            size += len(chunk)
-            digest.update(chunk)
-    return {"size": size, "sha256": digest.hexdigest()}
 
 
 def _resolved_config_content(config: object) -> Any:
@@ -205,9 +193,18 @@ def write_stage_execution_record(
             if not output_path.is_absolute():
                 output_path = root / output_path
             if output_path.is_file():
+                safe_output_path = _path_without_symlinks(
+                    output_path, description="stage output evidence path"
+                )
+                try:
+                    evidence_path = _portable_relative_path(safe_output_path, root)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"stage output evidence file is outside the campaign root: {output_path}"
+                    ) from exc
                 immutable_evidence[str(key)] = {
-                    "path": value,
-                    **_file_evidence(output_path),
+                    "path": evidence_path,
+                    **_file_evidence(output_path, description="stage output evidence file"),
                 }
     artifact_payload = {
         "schema": _EXECUTION_RECORD_SCHEMA,

--- a/modelopt/torch/puzzletron/orchestration/adapters/stage_compat.py
+++ b/modelopt/torch/puzzletron/orchestration/adapters/stage_compat.py
@@ -44,6 +44,17 @@ from ..stages import StageStatus, semantic_stage_config, stage_spec, stage_termi
 from ..vllm_measurements import normalize_vllm_measurements
 from .base import WorkAdapter
 
+if __package__.startswith("puzzletron_orchestrator."):
+    from puzzletron_orchestrator.execution_record import (
+        stage_manifest_uses_execution_record,
+        validate_stage_execution_record,
+    )
+else:
+    from ...execution_record import (
+        stage_manifest_uses_execution_record,
+        validate_stage_execution_record,
+    )
+
 __all__ = [
     "StageCompatAdapter",
     "post_mip_summary_is_current",
@@ -678,6 +689,14 @@ def stage_is_complete(config: Mapping[str, Any], stage_id: str) -> bool:
     manifest = _read_mapping(puzzle_dir / "manifests" / f"{stage_id}.json")
     if manifest is None:
         return False
+    if stage_manifest_uses_execution_record(manifest):
+        try:
+            validate_stage_execution_record(
+                puzzle_dir / "manifests" / f"{stage_id}.json",
+                expected_stage=stage_id,
+            )
+        except ValueError:
+            return False
     state = stage_terminal_state(manifest, expected_stage=stage_id)
     if state is None or not state.allows_completion(stage_id, config):
         return False

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -25,6 +25,7 @@ from pathlib import Path, PureWindowsPath
 import pytest
 
 from examples.puzzletron.main import _completion_is_valid, _mark_completion, _resume_kwargs
+from modelopt.torch.puzzletron import execution_record
 from modelopt.torch.puzzletron.execution_record import _portable_relative_path
 from modelopt.torch.puzzletron.identity import stable_hash
 from modelopt.torch.puzzletron.manifest import (
@@ -697,13 +698,17 @@ def test_resume_rejects_tampered_immutable_stage_record(
 
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX named pipes")
 @pytest.mark.parametrize(
-    "record_key",
-    ["resolved_config_path", "artifact_manifest_path"],
+    ("record_key", "message"),
+    [
+        ("resolved_config_path", "invalid resolved stage configuration record"),
+        ("artifact_manifest_path", "invalid stage artifact record"),
+    ],
     ids=["resolved-config", "artifact-manifest"],
 )
 def test_validator_rejects_nonregular_execution_record_files(
     tmp_path: Path,
     record_key: str,
+    message: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
@@ -719,7 +724,49 @@ def test_validator_rejects_nonregular_execution_record_files(
 
     monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
 
-    with pytest.raises(ValueError, match=r"invalid .* record"):
+    with pytest.raises(ValueError, match=f"^{message}:"):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+@pytest.mark.skipif(
+    not (
+        hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in getattr(os, "supports_dir_fd", set())
+    ),
+    reason="requires descriptor-rooted no-follow traversal",
+)
+@pytest.mark.parametrize("swap_location", ["ancestor", "leaf"])
+def test_validator_rejects_execution_record_symlink_swap_after_path_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    swap_location: str,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    record_path = tmp_path / manifest.execution_record["resolved_config_path"]
+    original_path_without_symlinks = execution_record._path_without_symlinks
+    swapped = False
+
+    def swap_after_check(path: Path, *, description: str) -> Path:
+        nonlocal swapped
+        checked = original_path_without_symlinks(path, description=description)
+        if not swapped and description == "resolved stage configuration record":
+            if swap_location == "ancestor":
+                stage_dir = record_path.parent.parent
+                external_stage_dir = stage_dir.with_name("external-convert")
+                stage_dir.rename(external_stage_dir)
+                stage_dir.symlink_to(external_stage_dir, target_is_directory=True)
+            else:
+                external_file = tmp_path / "external-resolved-config.json"
+                external_file.write_bytes(record_path.read_bytes())
+                record_path.unlink()
+                record_path.symlink_to(external_file)
+            swapped = True
+        return checked
+
+    monkeypatch.setattr(execution_record, "_path_without_symlinks", swap_after_check)
+
+    with pytest.raises(ValueError, match="invalid resolved stage configuration record"):
         validate_stage_execution_record(manifest_path, expected_stage="convert")
 
 

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -19,17 +19,20 @@ from __future__ import annotations
 
 import hashlib
 import json
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 
 import pytest
 
 from examples.puzzletron.main import _completion_is_valid, _mark_completion, _resume_kwargs
+from modelopt.torch.puzzletron.execution_record import _portable_relative_path
 from modelopt.torch.puzzletron.identity import stable_hash
 from modelopt.torch.puzzletron.manifest import (
     StageManifest,
     validate_stage_execution_record,
     write_stage_manifest,
 )
+from modelopt.torch.puzzletron.orchestration.adapters.stage_compat import stage_is_complete
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -98,6 +101,32 @@ def test_stage_manifest_persists_path_neutral_resolved_stage_config(
     assert resolved["resolved_config_identity"] == stable_hash(
         resolved["resolved_stage_config"], prefix="convert_resolved_cfg"
     )
+
+
+def test_execution_record_paths_use_portable_separators() -> None:
+    root = PureWindowsPath(r"C:\campaign")
+    path = root / "manifests" / "executions" / "convert" / "record.json"
+
+    assert _portable_relative_path(path, root) == ("manifests/executions/convert/record.json")
+
+
+def test_nonzero_rank_does_not_publish_or_mutate_execution_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    manifest = StageManifest(stage="convert", config=_stage_config(tmp_path, config_path))
+    manifest.complete()
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    monkeypatch.setenv("RANK", "1")
+
+    write_stage_manifest(manifest_path, manifest)
+
+    assert manifest.version == "1"
+    assert manifest.execution_record is None
+    assert not manifest_path.exists()
+    assert not (tmp_path / "manifests" / "executions").exists()
 
 
 def test_execution_record_preserves_provenance_and_cross_record_timestamps(
@@ -415,6 +444,7 @@ def test_resume_remains_compatible_with_historical_stage_manifest(
         config=config,
     )
     historical_payload = manifest.to_dict()
+    assert historical_payload["version"] == "1"
     assert "execution_record" not in historical_payload
     manifest_path = tmp_path / "manifests" / "convert.json"
     manifest_path.parent.mkdir()
@@ -423,6 +453,54 @@ def test_resume_remains_compatible_with_historical_stage_manifest(
     _mark_completion(config, config_path, "convert")
 
     assert _completion_is_valid(config, config_path, "convert")
+
+
+def test_version_two_manifest_requires_execution_record_pointer(tmp_path: Path) -> None:
+    manifest_path, _config_path, _config, _manifest = _write_convert_record(tmp_path)
+    pointer = json.loads(manifest_path.read_text())
+    assert pointer["version"] == "2"
+    pointer.pop("execution_record")
+    manifest_path.write_text(json.dumps(pointer))
+
+    with pytest.raises(ValueError, match="requires an execution record"):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+@pytest.mark.parametrize(
+    ("stage", "stage_config", "status", "skip_reason"),
+    [
+        ("convert", {}, "success", None),
+        ("aiperf", {"enabled": False}, "skipped", "disabled"),
+    ],
+    ids=("success", "skipped"),
+)
+def test_orchestrator_resume_rejects_missing_execution_record_pointer(
+    tmp_path: Path,
+    stage: str,
+    stage_config: dict,
+    status: str,
+    skip_reason: str | None,
+) -> None:
+    config = {
+        "puzzle_dir": str(tmp_path),
+        "experiment": {"dir": str(tmp_path)},
+        stage: stage_config,
+    }
+    if stage == "convert":
+        teacher_config = tmp_path / "ckpts" / "teacher" / "config.json"
+        teacher_config.parent.mkdir(parents=True)
+        teacher_config.write_text("{}\n")
+    manifest = StageManifest(stage=stage, config=config)
+    manifest.complete(status=status, skip_reason=skip_reason)
+    manifest_path = tmp_path / "manifests" / f"{stage}.json"
+    write_stage_manifest(manifest_path, manifest)
+    assert stage_is_complete(config, stage)
+
+    pointer = json.loads(manifest_path.read_text())
+    pointer.pop("execution_record")
+    manifest_path.write_text(json.dumps(pointer))
+
+    assert not stage_is_complete(config, stage)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/torch/puzzletron/test_stage_execution_records.py
+++ b/tests/unit/torch/puzzletron/test_stage_execution_records.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from pathlib import PureWindowsPath
-from typing import TYPE_CHECKING
+import os
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -33,9 +33,6 @@ from modelopt.torch.puzzletron.manifest import (
     write_stage_manifest,
 )
 from modelopt.torch.puzzletron.orchestration.adapters.stage_compat import stage_is_complete
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _stage_config(tmp_path: Path, config_path: Path) -> dict:
@@ -83,6 +80,19 @@ def _rewrite_json_record(path: Path, payload: dict) -> str:
     content = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     path.write_text(content)
     return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _reseal_artifact_record(manifest_path: Path, root: Path, artifact: dict) -> None:
+    pointer = json.loads(manifest_path.read_text())
+    identity_payload = dict(artifact)
+    identity_payload.pop("artifact_manifest_identity", None)
+    artifact_identity = stable_hash(identity_payload, prefix=f"{pointer['stage']}_artifacts")
+    artifact["artifact_manifest_identity"] = artifact_identity
+    record = pointer["execution_record"]
+    record["artifact_manifest_identity"] = artifact_identity
+    artifact_path = root / record["artifact_manifest_path"]
+    record["artifact_manifest_sha256"] = _rewrite_json_record(artifact_path, artifact)
+    _rewrite_json_record(manifest_path, pointer)
 
 
 def test_stage_manifest_persists_path_neutral_resolved_stage_config(
@@ -230,7 +240,7 @@ def test_artifact_manifest_separates_output_pointer_from_immutable_evidence(
     assert artifacts["canonical_output_pointers"] == {"summary_path": str(summary_path)}
     assert artifacts["artifact_contract"] == "stage-manifest-output-pointers/v1"
     assert artifacts["immutable_evidence"]["summary_path"] == {
-        "path": str(summary_path),
+        "path": "artifacts/summary.json",
         "size": len(summary_path.read_bytes()),
         "sha256": hashlib.sha256(summary_path.read_bytes()).hexdigest(),
     }
@@ -242,6 +252,39 @@ def test_artifact_manifest_separates_output_pointer_from_immutable_evidence(
     required_patterns = _resume_kwargs(config, config_path, "convert")["required_patterns"]
     assert record["resolved_config_path"] in required_patterns
     assert record["artifact_manifest_path"] in required_patterns
+
+
+def test_validator_accepts_contained_legacy_absolute_evidence_path(tmp_path: Path) -> None:
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    manifest_path, _config_path, _config, manifest = _write_convert_record(
+        tmp_path,
+        outputs={"summary_path": str(summary_path)},
+    )
+    artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
+    artifact = json.loads(artifact_path.read_text())
+    artifact["immutable_evidence"]["summary_path"]["path"] = str(summary_path)
+    _reseal_artifact_record(manifest_path, tmp_path, artifact)
+
+    validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+def test_writer_normalizes_contained_output_pointer_parent_segments(tmp_path: Path) -> None:
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    output_pointer = "artifacts/../artifacts/summary.json"
+
+    manifest_path, _config_path, _config, manifest = _write_convert_record(
+        tmp_path,
+        outputs={"summary_path": output_pointer},
+    )
+
+    artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
+    artifact = json.loads(artifact_path.read_text())
+    assert artifact["immutable_evidence"]["summary_path"]["path"] == "artifacts/summary.json"
+    validate_stage_execution_record(manifest_path, expected_stage="convert")
 
 
 @pytest.mark.parametrize(
@@ -650,6 +693,153 @@ def test_resume_rejects_tampered_immutable_stage_record(
 
     with pytest.raises(ValueError, match=message):
         _resume_kwargs(config, config_path, "convert")
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX named pipes")
+@pytest.mark.parametrize(
+    "record_key",
+    ["resolved_config_path", "artifact_manifest_path"],
+    ids=["resolved-config", "artifact-manifest"],
+)
+def test_validator_rejects_nonregular_execution_record_files(
+    tmp_path: Path,
+    record_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path, _config_path, _config, manifest = _write_convert_record(tmp_path)
+    record_path = tmp_path / manifest.execution_record[record_key]
+    record_path.unlink()
+    os.mkfifo(record_path)
+    original_read_bytes = Path.read_bytes
+
+    def guarded_read_bytes(path: Path) -> bytes:
+        if path == record_path:
+            pytest.fail("attempted to read a non-regular execution record")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+
+    with pytest.raises(ValueError, match=r"invalid .* record"):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+@pytest.mark.parametrize(
+    ("replacement", "message"),
+    [
+        ('{"score": 2}\n', "stage output evidence SHA256 mismatch"),
+        ('{"score": 200}\n', "stage output evidence size mismatch"),
+        (None, "invalid stage output evidence file"),
+    ],
+    ids=["digest", "size", "missing"],
+)
+def test_resume_rejects_modified_evidence_backed_output(
+    tmp_path: Path,
+    replacement: str | None,
+    message: str,
+) -> None:
+    config_path = tmp_path / "experiment.yaml"
+    config_path.write_text("model: {}\n")
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    config = _stage_config(tmp_path, config_path)
+    manifest = StageManifest(stage="convert", config=config)
+    manifest.complete(outputs={"summary_path": str(summary_path)})
+    manifest_path = tmp_path / "manifests" / "convert.json"
+    write_stage_manifest(manifest_path, manifest)
+
+    if replacement is None:
+        summary_path.unlink()
+    else:
+        summary_path.write_text(replacement)
+
+    with pytest.raises(ValueError, match=message):
+        _resume_kwargs(config, config_path, "convert")
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("evidence-type", "immutable evidence must be a mapping"),
+        ("entry-type", "invalid stage output evidence entry"),
+        ("unsafe-path", "unsafe stage output evidence path"),
+        ("nonportable-path", "stage output evidence path is not portable"),
+        ("path-mismatch", "stage output evidence path mismatch"),
+        ("missing-pointer", "stage output evidence has no matching output pointer"),
+        ("size-type", "invalid stage output evidence size"),
+        ("digest-type", "invalid stage output evidence SHA256"),
+    ],
+)
+def test_validator_rejects_malformed_immutable_evidence(
+    tmp_path: Path,
+    case: str,
+    message: str,
+) -> None:
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    manifest_path, _config_path, _config, manifest = _write_convert_record(
+        tmp_path,
+        outputs={"summary_path": str(summary_path)},
+    )
+    artifact_path = tmp_path / manifest.execution_record["artifact_manifest_path"]
+    artifact = json.loads(artifact_path.read_text())
+    evidence = artifact["immutable_evidence"]["summary_path"]
+    if case == "evidence-type":
+        artifact["immutable_evidence"] = []
+    elif case == "entry-type":
+        artifact["immutable_evidence"]["summary_path"] = []
+    elif case == "unsafe-path":
+        evidence["path"] = "../summary.json"
+    elif case == "nonportable-path":
+        evidence["path"] = "artifacts\\summary.json"
+    elif case == "path-mismatch":
+        evidence["path"] = "artifacts/other.json"
+    elif case == "missing-pointer":
+        artifact["immutable_evidence"]["forged"] = artifact["immutable_evidence"].pop(
+            "summary_path"
+        )
+    elif case == "size-type":
+        evidence["size"] = True
+    else:
+        evidence["sha256"] = 1
+    _reseal_artifact_record(manifest_path, tmp_path, artifact)
+
+    with pytest.raises(ValueError, match=message):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+def test_validator_rejects_nonregular_evidence_backed_output(tmp_path: Path) -> None:
+    summary_path = tmp_path / "artifacts" / "summary.json"
+    summary_path.parent.mkdir()
+    summary_path.write_text('{"score": 1}\n')
+    manifest_path, _config_path, _config, _manifest = _write_convert_record(
+        tmp_path,
+        outputs={"summary_path": str(summary_path)},
+    )
+    summary_path.unlink()
+    summary_path.mkdir()
+
+    with pytest.raises(ValueError, match="stage output evidence file is not a regular file"):
+        validate_stage_execution_record(manifest_path, expected_stage="convert")
+
+
+@pytest.mark.parametrize("pointer_kind", ["absolute", "relative"])
+def test_writer_rejects_evidence_backed_output_outside_campaign_root(
+    tmp_path: Path,
+    pointer_kind: str,
+) -> None:
+    campaign_root = tmp_path / "campaign"
+    campaign_root.mkdir()
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text('{"score": 1}\n')
+    output_pointer = str(summary_path) if pointer_kind == "absolute" else "../summary.json"
+
+    with pytest.raises(ValueError, match="outside the campaign root"):
+        _write_convert_record(
+            campaign_root,
+            outputs={"summary_path": output_pointer},
+        )
 
 
 def test_writer_rejects_symlinked_execution_record_ancestor(tmp_path: Path) -> None:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Puzzletron stage execution records are durable only if every resume path treats them as authoritative. Newly written manifests currently remain version 1, so removing the `execution_record` pointer makes them look historical, and dependency-light orchestration can mark a stage complete without validating record contents.

This change:

- writes newly published stage manifests as version 2, which requires an execution-record pointer while retaining compatibility with historical and imported version-1 manifests;
- shares dependency-light record validation between worker and orchestration paths, making successful and skipped stages fail closed during resume;
- preserves rank-zero-only publication and serializes record paths with platform-neutral separators;
- keeps SIGUSR1 fault-handler registration type-safe by using its default output when no per-rank log is open.

### Testing

The Puzzletron unit suite covers manifest-version compatibility, missing and tampered record rejection, successful and skipped orchestration resume, nonzero-rank behavior, portable path serialization, historical imports, and dependency-light imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of stage completion records, including referenced files, identities, paths, provenance, and integrity checks.
  - Stages with missing, malformed, tampered, or invalid execution records are no longer incorrectly marked complete.
  - Improved completion checks for skipped and non-skipped stages.
  - Preserved compatibility with historical manifests while enforcing requirements for newer records.
  - Improved portability and safety when handling output evidence and referenced paths.

- **Tests**
  - Added coverage for manifest versioning, publication behavior, resume validation, tampered outputs, and platform-specific paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->