### PR TITLE
Fix Puzzletron MBridge schema conversion

### DIFF
--- a/modelopt/torch/puzzletron/plugins/mbridge/base.py
+++ b/modelopt/torch/puzzletron/plugins/mbridge/base.py
@@ -38,6 +38,8 @@ from megatron.core.models.gpt.heterogeneous.heterogeneous_layer_specs import (
 )
 from megatron.core.transformer.spec_utils import ModuleSpec
 
+from ..mbridge_schema import build_mcore_heterogeneous_config
+
 # Monkey-patch: add get_config_for_layer to TransformerConfig if missing
 # (needed for non-heterogeneous teacher models in this container version)
 if not hasattr(TransformerConfig, "get_config_for_layer"):
@@ -103,7 +105,7 @@ class HeterogeneousBridgeMixin:
         parent_provider = super().provider_bridge(hf_pretrained)  # type: ignore[misc]
 
         # If no block_configs, fall back to standard (non-heterogeneous) provider.
-        if not (hasattr(hf_pretrained.config, "block_configs")):
+        if not getattr(hf_pretrained.config, "block_configs", None):
             return parent_provider
 
         provider_kwargs = dataclasses.asdict(parent_provider)
@@ -132,27 +134,8 @@ class HeterogeneousBridgeMixin:
         """Build heterogeneous layers config JSON from HF config."""
 
         hf_config_dict = json.loads(hf_config.to_json_string())
-
-        mcore_block_configs = [
-            self._convert_block_config(block) for block in hf_config_dict["block_configs"]
-        ]
-        return json.dumps({"block_configs": mcore_block_configs}, ensure_ascii=False)
-
-    def _convert_block_config(self, block: dict) -> dict:
-        """Convert a single block config from HF format to MCore format."""
-        return {
-            "attention": self._convert_attention_config(block["attention"]),
-            "ffn": self._convert_ffn_config(block["ffn"]),
-        }
-
-    def _convert_attention_config(self, attention_config: dict) -> dict:
-        """Convert attention config from HF format to MCore format."""
-        attention_config = attention_config.copy()
-        attention_config["num_query_groups"] = attention_config.pop("num_key_value_heads")
-        return attention_config
-
-    def _convert_ffn_config(self, ffn_config: dict) -> dict:
-        """Convert FFN/MLP config from HF format to MCore format."""
-        ffn_config = ffn_config.copy()
-        ffn_config["ffn_hidden_size"] = ffn_config.pop("intermediate_size")
-        return ffn_config
+        mcore_config = build_mcore_heterogeneous_config(
+            hf_config_dict["block_configs"],
+            num_attention_heads=hf_config_dict["num_attention_heads"],
+        )
+        return json.dumps(mcore_config, ensure_ascii=False)

--- a/modelopt/torch/puzzletron/plugins/mbridge_schema.py
+++ b/modelopt/torch/puzzletron/plugins/mbridge_schema.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translate typed Puzzletron block configs to Megatron-Core's heterogeneous schema."""
+
+from collections.abc import Iterable
+from typing import Any
+
+from ..block_config import AttentionConfig, BlockConfig, FFNConfig
+
+__all__ = ["build_mcore_heterogeneous_config"]
+
+
+def _coerce_block_config(block_config: BlockConfig | dict[str, Any]) -> BlockConfig:
+    return block_config if isinstance(block_config, BlockConfig) else BlockConfig(**block_config)
+
+
+def _require_dense_subblocks(block_config: BlockConfig) -> tuple[AttentionConfig, FFNConfig]:
+    subblocks: dict[str, Any] = {}
+    for subblock in block_config.subblock_configs:
+        if subblock.kind not in {"attention", "ffn"}:
+            raise ValueError(
+                "Megatron-Bridge heterogeneous configs support only attention and ffn "
+                f"subblocks, got {subblock.kind!r}"
+            )
+        if subblock.kind in subblocks:
+            raise ValueError(
+                "Megatron-Bridge heterogeneous configs require exactly one subblock of each "
+                f"supported kind, got duplicate {subblock.kind!r} subblocks"
+            )
+        subblocks[subblock.kind] = subblock
+
+    missing = {"attention", "ffn"} - subblocks.keys()
+    if missing:
+        raise ValueError(
+            "Megatron-Bridge heterogeneous configs require attention and ffn subblocks, "
+            f"missing {sorted(missing)}"
+        )
+
+    attention = subblocks["attention"]
+    ffn = subblocks["ffn"]
+    if not isinstance(attention, AttentionConfig) or not isinstance(ffn, FFNConfig):
+        raise TypeError("attention and ffn subblocks must use their typed Puzzletron configs")
+    return attention, ffn
+
+
+def _convert_attention_config(
+    attention: AttentionConfig, *, num_attention_heads: int
+) -> dict[str, Any]:
+    unsupported_fields = {
+        field
+        for field in (
+            "qk_head_dim",
+            "v_head_dim",
+            "sliding_window_size",
+            "k_eq_v",
+            "kv_source_layer",
+            "llama4",
+        )
+        if getattr(attention, field) is not None
+    }
+    if unsupported_fields:
+        raise ValueError(
+            "Megatron-Bridge heterogeneous configs cannot represent attention fields "
+            f"{sorted(unsupported_fields)}"
+        )
+    if attention.num_query_heads not in {None, num_attention_heads}:
+        raise ValueError(
+            "Megatron-Bridge heterogeneous configs cannot vary num_query_heads by layer; "
+            f"expected {num_attention_heads}, got {attention.num_query_heads}"
+        )
+    if attention.num_kv_heads is not None and (
+        attention.num_kv_heads <= 0 or num_attention_heads % attention.num_kv_heads
+    ):
+        raise ValueError(
+            f"num_kv_heads ({attention.num_kv_heads}) must be a positive divisor of "
+            f"num_attention_heads ({num_attention_heads})"
+        )
+    return {
+        "no_op": attention.no_op,
+        "num_query_groups": attention.num_kv_heads,
+    }
+
+
+def _convert_ffn_config(ffn: FFNConfig) -> dict[str, Any]:
+    if ffn.intermediate_size is not None and ffn.intermediate_size <= 0:
+        raise ValueError(f"intermediate_size must be positive, got {ffn.intermediate_size}")
+    return {
+        "no_op": ffn.no_op,
+        "ffn_hidden_size": ffn.intermediate_size,
+    }
+
+
+def build_mcore_heterogeneous_config(
+    block_configs: Iterable[BlockConfig | dict[str, Any]], *, num_attention_heads: int
+) -> dict[str, list[dict[str, Any]]]:
+    """Build the JSON-compatible block schema consumed by Megatron-Core.
+
+    Megatron-Core's heterogeneous transformer currently supports per-layer KV
+    groups, FFN width, and no-op attention or FFN blocks. Other Puzzletron axes
+    are rejected here so the bridge never silently drops an admitted axis.
+    """
+
+    if num_attention_heads <= 0:
+        raise ValueError(f"num_attention_heads must be positive, got {num_attention_heads}")
+
+    converted = []
+    for index, raw_block_config in enumerate(block_configs):
+        try:
+            attention, ffn = _require_dense_subblocks(_coerce_block_config(raw_block_config))
+            converted.append(
+                {
+                    "attention": _convert_attention_config(
+                        attention, num_attention_heads=num_attention_heads
+                    ),
+                    "ffn": _convert_ffn_config(ffn),
+                }
+            )
+        except (TypeError, ValueError) as error:
+            raise type(error)(f"block_configs[{index}]: {error}") from error
+
+    if not converted:
+        raise ValueError("block_configs must contain at least one layer")
+    return {"block_configs": converted}

--- a/tests/examples/megatron_bridge/test_puzzletron_config.py
+++ b/tests/examples/megatron_bridge/test_puzzletron_config.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Megatron-Bridge integration tests for Puzzletron heterogeneous configs."""
+
+import json
+
+from megatron.bridge.models.transformer_config import HeterogeneousTransformerConfig
+
+from modelopt.torch.puzzletron.block_config import AttentionConfig, BlockConfig, FFNConfig
+from modelopt.torch.puzzletron.plugins.mbridge.base import HeterogeneousBridgeMixin
+
+
+class _HfConfig:
+    num_attention_heads = 8
+
+    def __init__(self, block_configs: list[BlockConfig]) -> None:
+        self.block_configs = block_configs
+
+    def to_json_string(self) -> str:
+        return json.dumps(
+            {
+                "num_attention_heads": self.num_attention_heads,
+                "block_configs": [block.to_dict() for block in self.block_configs],
+            }
+        )
+
+
+def test_puzzletron_block_config_round_trips_through_mbridge() -> None:
+    hf_config = _HfConfig(
+        [
+            BlockConfig(
+                subblock_configs=(
+                    AttentionConfig(num_query_heads=8, num_kv_heads=2),
+                    FFNConfig(intermediate_size=32),
+                )
+            ),
+            BlockConfig(
+                subblock_configs=(
+                    AttentionConfig(no_op=True),
+                    FFNConfig(intermediate_size=16),
+                )
+            ),
+        ]
+    )
+    encoded = HeterogeneousBridgeMixin()._build_heterogeneous_config_json(hf_config)
+
+    config = HeterogeneousTransformerConfig(
+        num_layers=2,
+        hidden_size=16,
+        num_attention_heads=8,
+        num_query_groups=8,
+        ffn_hidden_size=64,
+        heterogeneous_layers_config_encoded_json=encoded,
+    )
+    config.finalize()
+
+    first, second = config.per_block_parameters
+    assert first.attention.num_query_groups == 2
+    assert first.mlp.ffn_hidden_size == 32
+    assert not first.attention.no_op
+    assert not first.mlp.no_op
+    assert second.attention.no_op
+    assert second.mlp.ffn_hidden_size == 16

--- a/tests/examples/megatron_bridge/test_puzzletron_config.py
+++ b/tests/examples/megatron_bridge/test_puzzletron_config.py
@@ -16,7 +16,11 @@
 """Megatron-Bridge integration tests for Puzzletron heterogeneous configs."""
 
 import json
+from types import SimpleNamespace
+from typing import cast
 
+from megatron.bridge.models.gpt_provider import GPTModelProvider
+from megatron.bridge.models.hf_pretrained.causal_lm import PreTrainedCausalLM
 from megatron.bridge.models.transformer_config import HeterogeneousTransformerConfig
 
 from modelopt.torch.puzzletron.block_config import AttentionConfig, BlockConfig, FFNConfig
@@ -36,6 +40,25 @@ class _HfConfig:
                 "block_configs": [block.to_dict() for block in self.block_configs],
             }
         )
+
+
+class _ParentBridge:
+    def __init__(self) -> None:
+        self.parent_provider = cast("GPTModelProvider", object())
+
+    def provider_bridge(self, _hf_pretrained: PreTrainedCausalLM) -> GPTModelProvider:
+        return self.parent_provider
+
+
+class _TestBridge(HeterogeneousBridgeMixin, _ParentBridge):
+    pass
+
+
+def test_empty_block_configs_use_parent_provider() -> None:
+    bridge = _TestBridge()
+    hf_pretrained = cast("PreTrainedCausalLM", SimpleNamespace(config=_HfConfig([])))
+
+    assert bridge.provider_bridge(hf_pretrained) is bridge.parent_provider
 
 
 def test_puzzletron_block_config_round_trips_through_mbridge() -> None:

--- a/tests/unit/torch/puzzletron/test_mbridge_schema.py
+++ b/tests/unit/torch/puzzletron/test_mbridge_schema.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Puzzletron-to-Megatron heterogeneous config contract."""
+
+import pytest
+
+from modelopt.torch.puzzletron.block_config import (
+    AttentionConfig,
+    BlockConfig,
+    FFNConfig,
+    MoEConfig,
+)
+from modelopt.torch.puzzletron.plugins.mbridge_schema import build_mcore_heterogeneous_config
+
+
+def test_build_mcore_config_from_typed_block_config() -> None:
+    block = BlockConfig(
+        subblock_configs=(
+            AttentionConfig(num_query_heads=8, num_kv_heads=2),
+            FFNConfig(intermediate_size=32),
+        )
+    )
+
+    config = build_mcore_heterogeneous_config([block.to_dict()], num_attention_heads=8)
+
+    assert config == {
+        "block_configs": [
+            {
+                "attention": {"no_op": False, "num_query_groups": 2},
+                "ffn": {"no_op": False, "ffn_hidden_size": 32},
+            }
+        ]
+    }
+
+
+def test_build_mcore_config_preserves_no_op_subblocks() -> None:
+    block = BlockConfig(subblock_configs=(AttentionConfig(no_op=True), FFNConfig(no_op=True)))
+
+    config = build_mcore_heterogeneous_config([block], num_attention_heads=8)
+
+    assert config["block_configs"][0] == {
+        "attention": {"no_op": True, "num_query_groups": None},
+        "ffn": {"no_op": True, "ffn_hidden_size": None},
+    }
+
+
+@pytest.mark.parametrize(
+    ("block", "match"),
+    [
+        (
+            BlockConfig(
+                subblock_configs=(
+                    AttentionConfig(num_query_heads=4, num_kv_heads=2),
+                    FFNConfig(intermediate_size=32),
+                )
+            ),
+            "cannot vary num_query_heads by layer",
+        ),
+        (
+            BlockConfig(
+                subblock_configs=(
+                    AttentionConfig(num_query_heads=8, num_kv_heads=2),
+                    MoEConfig(num_experts=4, expert_intermediate_size=16, top_k=2),
+                )
+            ),
+            "support only attention and ffn subblocks",
+        ),
+    ],
+)
+def test_build_mcore_config_rejects_unrepresentable_blocks(block: BlockConfig, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        build_mcore_heterogeneous_config([block], num_attention_heads=8)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("qk_head_dim", 4),
+        ("v_head_dim", 4),
+        ("sliding_window_size", 16),
+        ("k_eq_v", True),
+        ("kv_source_layer", 0),
+        ("llama4", {"attention_chunk_size": 16}),
+    ],
+)
+def test_build_mcore_config_rejects_unrepresentable_attention_fields(
+    field: str, value: object
+) -> None:
+    attention = AttentionConfig(
+        num_query_heads=8,
+        num_kv_heads=2,
+        **{field: value},
+    )
+    block = BlockConfig(subblock_configs=(attention, FFNConfig(intermediate_size=32)))
+
+    with pytest.raises(ValueError, match="cannot represent attention fields"):
+        build_mcore_heterogeneous_config([block], num_attention_heads=8)

--- a/tests/unit/torch/puzzletron/test_mbridge_schema.py
+++ b/tests/unit/torch/puzzletron/test_mbridge_schema.py
@@ -92,6 +92,7 @@ def test_build_mcore_config_rejects_unrepresentable_blocks(block: BlockConfig, m
         ("v_head_dim", 4),
         ("sliding_window_size", 16),
         ("k_eq_v", True),
+        ("k_eq_v", False),
         ("kv_source_layer", 0),
         ("llama4", {"attention_chunk_size": 16}),
     ],


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Puzzletron's original AnyModel checkpoints serialized each transformer layer as top-level `attention` and `ffn` dictionaries, which matched the MBridge adapter. Puzzletron v2 later refactored this representation into typed `subblock_configs` and renamed `num_key_value_heads` to `num_kv_heads`, but the MBridge adapter was not migrated at the same time. This left current Puzzletron checkpoints incompatible with the optional MBridge import path.

The Puzzletron v2 campaign uses AutoModel for pruning and distillation and does not depend on this adapter. This change restores the existing interoperability path for users who load a Puzzletron AnyModel checkpoint through Megatron-Bridge, including the Megatron distillation example. It does not change AutoModel execution.

This change adds a dedicated schema adapter that:

- converts per-layer KV head counts to `num_query_groups` and FFN widths to `ffn_hidden_size`
- preserves no-op attention and FFN subblocks
- validates the required dense attention-plus-FFN structure
- rejects pruning axes that MBridge cannot represent instead of silently dropping them
- keeps empty `block_configs` on the standard non-heterogeneous provider path

### Testing

Adds focused CPU coverage for supported conversion, no-op subblocks, invalid structures, and every currently unsupported attention field. Adds Megatron-Bridge examples that exercise the empty-config fallback and finalize the generated configuration through `HeterogeneousTransformerConfig`. The integration tests require the NeMo/Megatron-Bridge environment and were not run locally; they remain routed through the existing example CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting heterogeneous Puzzletron block configurations into Megatron-Core schemas.
  * Supports attention, FFN, and no-op block settings while validating dimensions and supported options.
* **Bug Fixes**
  * Empty block configurations now correctly retain the parent provider.
  * Improved validation and error reporting for unsupported, duplicate, missing, or invalid block settings.
* **Tests**
  * Added unit and integration coverage for configuration conversion, validation, round-tripping, and provider fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
