### PR TITLE
Fix Qwen runtime width-slice equivalence

### DIFF
--- a/modelopt/torch/puzzletron/diagnostics/width_slice_equivalence.py
+++ b/modelopt/torch/puzzletron/diagnostics/width_slice_equivalence.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Content-addressed physical-versus-runtime width-slice equivalence."""
 
@@ -25,6 +37,11 @@ from ..candidates import _AXIS_TO_TARGET, _apply_axis_edits, _axis_base_value
 from ..dataset import DataLayout, PuzzletronBatch, batch_from_automodel
 from ..identity import canonicalize, stable_hash
 from ..plugins.automodel.batch_adapter import canonicalize_position_ids, validated_forward_kwargs
+from ..pruning.compact_runtime import (
+    compact_gated_delta_net_forward,
+    compact_grouped_attention_forward,
+    resolve_compact_grouped_attention_target,
+)
 from ..pruning.materialize import materialize_hidden_width_checkpoint, materialize_model_from_sorted
 from ..pruning.runtime_hidden_width import hidden_width_layer_context
 from ..pruning.runtime_ple import ple_layer_context
@@ -198,6 +215,10 @@ def _implementation_provenance(axis: Any, descriptor: Any) -> dict[str, Any]:
         _prune_target,
         recipe.prune_block_context,
         recipe.architecture_context,
+        recipe._typed_subblock_runtime_hooks,
+        resolve_compact_grouped_attention_target,
+        compact_grouped_attention_forward,
+        compact_gated_delta_net_forward,
         hidden_width_layer_context,
         ple_layer_context,
         _runtime_context,
@@ -815,6 +836,24 @@ def _changed_shapes(
     }
 
 
+def _gdn_projection_width(block_config: BlockConfig | None) -> int | None:
+    if block_config is None:
+        return None
+    mamba = block_config.get_subblock("mamba")
+    if mamba is None:
+        return None
+    values = (
+        getattr(mamba, "num_groups", None),
+        getattr(mamba, "state_dim", None),
+        getattr(mamba, "num_heads", None),
+        getattr(mamba, "head_dim", None),
+    )
+    if any(value is None for value in values):
+        return None
+    num_groups, state_dim, num_heads, head_dim = (int(value) for value in values)
+    return 2 * num_groups * state_dim + num_heads * head_dim
+
+
 def _axis_specific_changed_shapes(
     before: Mapping[str, list[int]],
     after: Mapping[str, list[int]],
@@ -823,7 +862,7 @@ def _axis_specific_changed_shapes(
     case: WidthSliceCase,
     num_layers: int,
 ) -> dict[str, dict[str, list[int] | None]]:
-    """Return only descriptor-owned tensor changes with the requested axis ratio."""
+    """Return descriptor-owned changes with the requested ratio or coupled geometry."""
 
     changed = _changed_shapes(before, after)
     pattern = None
@@ -832,22 +871,37 @@ def _axis_specific_changed_shapes(
         pattern = descriptor.layer_name_predicates(num_layers).get(
             f"block_{case.layers[0]}_{category}"
         )
+    gdn_projection_widths = (
+        _gdn_projection_width(case.source_block_config),
+        _gdn_projection_width(case.target_block_config),
+    )
 
-    def has_target_ratio(item: Mapping[str, list[int] | None]) -> bool:
+    def has_expected_geometry(item: Mapping[str, list[int] | None]) -> bool:
         source_shape = item.get("before")
         target_shape = item.get("after")
         if source_shape is None or target_shape is None:
             return True
-        return any(
+        if any(
             int(source_dim) * case.target_value == int(target_dim) * case.source_value
             for source_dim, target_dim in zip(source_shape, target_shape)
             if int(source_dim) > 0 and int(target_dim) > 0 and source_dim != target_dim
+        ):
+            return True
+        source_projection, target_projection = gdn_projection_widths
+        return (
+            case.axis_id == "gdn_key_head_dim"
+            and source_projection is not None
+            and target_projection is not None
+            and any(
+                int(source_dim) == source_projection and int(target_dim) == target_projection
+                for source_dim, target_dim in zip(source_shape, target_shape)
+            )
         )
 
     return {
         key: value
         for key, value in changed.items()
-        if (pattern is None or pattern.fullmatch(key)) and has_target_ratio(value)
+        if (pattern is None or pattern.fullmatch(key)) and has_expected_geometry(value)
     }
 
 

--- a/modelopt/torch/puzzletron/diagnostics/width_slice_equivalence.py
+++ b/modelopt/torch/puzzletron/diagnostics/width_slice_equivalence.py
@@ -889,11 +889,13 @@ def _axis_specific_changed_shapes(
             return True
         source_projection, target_projection = gdn_projection_widths
         return (
-            case.axis_id == "gdn_key_head_dim"
+            case.axis_id in {"gdn_key_head_dim", "gdn_value_head_dim", "gdn_value_heads_per_group"}
             and source_projection is not None
             and target_projection is not None
             and any(
-                int(source_dim) == source_projection and int(target_dim) == target_projection
+                source_dim != target_dim
+                and int(source_dim) == source_projection
+                and int(target_dim) == target_projection
                 for source_dim, target_dim in zip(source_shape, target_shape)
             )
         )

--- a/modelopt/torch/puzzletron/plugins/automodel/solution_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/solution_recipe.py
@@ -39,6 +39,12 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from ...pruning.compact_runtime import (
+    compact_gated_delta_net_forward,
+    compact_grouped_attention_forward,
+    resolve_compact_grouped_attention_target,
+)
+from ...pruning.gated_delta_net import GDNShape
 from ...pruning.mamba2_surgery import Mamba2TensorLayout, mamba2_projected_prefix_mask
 from .scoring_recipe import ActivationScoringRecipe
 
@@ -73,6 +79,10 @@ def _zero_like_output(output):
 
 def _module_output_zero_hook(module, args, output):
     return _zero_like_output(output)
+
+
+def _module_output_identity_hook(module, args, output):
+    return output
 
 
 @contextmanager
@@ -267,8 +277,7 @@ def _load_split_expert_overlay_tensor(
         value = torch.stack(values, dim=0)
 
     local_slices = tuple(
-        slice(offset, offset + size)
-        for offset, size in zip(global_offset[1:], local_shape[1:])
+        slice(offset, offset + size) for offset, size in zip(global_offset[1:], local_shape[1:])
     )
     value = value[(slice(None), *local_slices)].contiguous()
     if tuple(value.shape) != local_shape:
@@ -371,9 +380,7 @@ def _temporary_parameter_multiplier(
                 "DTensor local parameter shape disagrees with its placement geometry: "
                 f"actual={tuple(local_parameter.shape)} expected={tuple(local_shape)}"
             )
-        full_view = multiplier.reshape((-1,) + (1,) * (len(global_shape) - 1)).expand(
-            global_shape
-        )
+        full_view = multiplier.reshape((-1,) + (1,) * (len(global_shape) - 1)).expand(global_shape)
         local_slices = tuple(
             slice(int(offset), int(offset) + int(size))
             for offset, size in zip(global_offset, local_shape)
@@ -450,9 +457,7 @@ def _masked_native_gate_forward(
         score_func = getattr(self, "score_func", "softmax")
         top_k = int(target_top_k or getattr(self, "topk", 1))
         effective_count = (
-            len(kept_expert_indices)
-            if kept_expert_indices is not None
-            else target_num_experts
+            len(kept_expert_indices) if kept_expert_indices is not None else target_num_experts
         )
         if effective_count is not None:
             top_k = min(top_k, int(effective_count))
@@ -471,7 +476,10 @@ def _masked_native_gate_forward(
                         f"num_experts={scores_for_choice.shape[-1]}"
                     )
                 scores_for_choice = scores_for_choice.index_select(-1, keep)
-            elif target_num_experts is not None and int(target_num_experts) < scores_for_choice.shape[-1]:
+            elif (
+                target_num_experts is not None
+                and int(target_num_experts) < scores_for_choice.shape[-1]
+            ):
                 keep = torch.arange(int(target_num_experts), device=scores_for_choice.device)
                 scores_for_choice = scores_for_choice[..., : int(target_num_experts)]
             else:
@@ -501,7 +509,9 @@ def _masked_native_gate_forward(
             if n_groups > 1:
                 grouped = scores_for_choice.view(x.size(0), n_groups, -1)
                 group_scores = grouped.topk(min(2, grouped.shape[-1]), dim=-1).values.sum(dim=-1)
-                group_idx = group_scores.topk(min(topk_groups, group_scores.shape[-1]), dim=-1).indices
+                group_idx = group_scores.topk(
+                    min(topk_groups, group_scores.shape[-1]), dim=-1
+                ).indices
                 mask = torch.zeros_like(grouped[..., 0]).scatter_(1, group_idx, True)
                 scores_for_choice = (grouped * mask.unsqueeze(-1)).flatten(1)
             compact_indices = torch.topk(scores_for_choice, k=top_k, dim=-1).indices
@@ -541,8 +551,12 @@ def _masked_native_gate_forward(
                 if correction is None:
                     group_scores = grouped.amax(dim=-1)
                 else:
-                    group_scores = grouped.topk(min(2, grouped.shape[-1]), dim=-1).values.sum(dim=-1)
-                group_idx = group_scores.topk(min(topk_groups, group_scores.shape[-1]), dim=-1).indices
+                    group_scores = grouped.topk(min(2, grouped.shape[-1]), dim=-1).values.sum(
+                        dim=-1
+                    )
+                group_idx = group_scores.topk(
+                    min(topk_groups, group_scores.shape[-1]), dim=-1
+                ).indices
                 mask = torch.zeros_like(grouped[..., 0]).scatter_(1, group_idx, True)
                 scores_for_choice = (grouped * mask.unsqueeze(-1)).flatten(1)
             compact_indices = torch.topk(scores_for_choice, k=top_k, dim=-1).indices
@@ -628,7 +642,9 @@ def _mask_expert_activation(experts, *, orig_intermediate: int, target_intermedi
 
     def masked_activation(gate_and_up_out, route_weight):
         out = orig(gate_and_up_out, route_weight)
-        return out * keep_mask.to(dtype=out.dtype, device=out.device).reshape((1,) * (out.ndim - 1) + (-1,))
+        return out * keep_mask.to(dtype=out.dtype, device=out.device).reshape(
+            (1,) * (out.ndim - 1) + (-1,)
+        )
 
     experts.expert_activation_grouped = masked_activation
     try:
@@ -690,8 +706,7 @@ def _supports_compact_fused_mamba(mamba_module) -> bool:
     """Return whether the module uses the native no-cache fused Mamba path."""
 
     return getattr(mamba_module, "cp", object()) is None and all(
-        hasattr(mamba_module, name)
-        for name in ("in_proj", "conv1d", "norm", "out_proj")
+        hasattr(mamba_module, name) for name in ("in_proj", "conv1d", "norm", "out_proj")
     )
 
 
@@ -768,36 +783,6 @@ def _compact_fused_mamba_forward(
         mamba_module.forward = original_forward
 
 
-def _gdn_prefix_masks(
-    *,
-    orig_groups: int,
-    orig_heads: int,
-    orig_key_dim: int,
-    orig_value_dim: int,
-    target_groups: int,
-    target_heads: int,
-    target_key_dim: int,
-    target_value_dim: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    orig_ratio = orig_heads // orig_groups
-    if target_heads % target_groups:
-        raise ValueError(
-            f"GDN target heads={target_heads} must be divisible by groups={target_groups}"
-        )
-    target_ratio = target_heads // target_groups
-    if target_ratio > orig_ratio:
-        raise ValueError(f"GDN target ratio={target_ratio} exceeds teacher ratio={orig_ratio}")
-    qkeep = torch.zeros(orig_groups, orig_key_dim, dtype=torch.bool)
-    qkeep[:target_groups, :target_key_dim] = True
-    vkeep = torch.zeros(orig_heads, orig_value_dim, dtype=torch.bool)
-    for group in range(target_groups):
-        start = group * orig_ratio
-        vkeep[start : start + target_ratio, :target_value_dim] = True
-    qflat = qkeep.reshape(-1)
-    vflat = vkeep.reshape(-1)
-    return torch.cat((qflat, qflat, vflat)), vflat
-
-
 def _mask_last_dim_forward_hook(mask: torch.Tensor):
     def hook(module, args, output):
         if not torch.is_tensor(output):
@@ -809,80 +794,9 @@ def _mask_last_dim_forward_hook(mask: torch.Tensor):
     return hook
 
 
-def _gdn_norm_dim_prehook(mask: torch.Tensor, scale: float):
-    """Zero tail value-head-dim channels entering the GDN norm and compensate energy.
-
-    Matches the ``_norm_prefix_prehook`` convention in elastic_supernet: the first
-    arg (x, the signal) is zeroed and rescaled; subsequent args (z, gate) are zeroed
-    only, so the norm sees the same per-channel energy as a physically smaller model.
-    """
-    def hook(module, args):
-        out = []
-        for i, a in enumerate(args):
-            if torch.is_tensor(a):
-                m = mask.to(dtype=a.dtype, device=a.device).reshape(
-                    (1,) * (a.ndim - 1) + (-1,)
-                )
-                out.append(a * m * scale if i == 0 else a * m)
-            else:
-                out.append(a)
-        return tuple(out)
-
-    return hook
-
-
-@contextmanager
-def _scale_gdn_kernel_query_output(mamba_module: nn.Module, scale: float):
-    """Match a physically sliced GDN kernel's implicit query scale.
-
-    GDN kernels normalize Q/K internally and derive the query scale from the
-    tensor's last dimension. Runtime masking keeps the teacher tensor shape, so
-    a reduced child key dimension needs an explicit output correction. The
-    recurrent state is independent of the query scale and must remain unchanged.
-    """
-    originals = {}
-
-    def scaled_kernel(kernel):
-        def wrapped(*args, **kwargs):
-            output = kernel(*args, **kwargs)
-            if torch.is_tensor(output):
-                return output * scale
-            if isinstance(output, tuple) and output and torch.is_tensor(output[0]):
-                return (output[0] * scale, *output[1:])
-            if isinstance(output, list) and output and torch.is_tensor(output[0]):
-                return [output[0] * scale, *output[1:]]
-            raise TypeError(
-                f"Unsupported GDN kernel output from {getattr(kernel, '__name__', type(kernel).__name__)}"
-            )
-
-        return wrapped
-
-    for name in ("chunk_gated_delta_rule", "recurrent_gated_delta_rule"):
-        kernel = getattr(mamba_module, name, None)
-        if callable(kernel):
-            originals[name] = kernel
-            setattr(mamba_module, name, scaled_kernel(kernel))
-    try:
-        yield
-    finally:
-        for name, kernel in originals.items():
-            setattr(mamba_module, name, kernel)
-
-
-def _mask_last_dim_forward_hook_scaled(mask: torch.Tensor, scale: float):
-    """Like ``_mask_last_dim_forward_hook`` but multiplies the output by ``scale``."""
-    def hook(module, args, output):
-        if not torch.is_tensor(output):
-            return output
-        return output * mask.to(dtype=output.dtype, device=output.device).reshape(
-            (1,) * (output.ndim - 1) + (-1,)
-        ) * scale
-
-    return hook
-
-
 def _scale_tensor_output_forward_hook(scale: float):
     """Scale a tensor module output without touching any model parameter."""
+
     def hook(module, args, output):
         if not torch.is_tensor(output):
             return output
@@ -1002,8 +916,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                 (
                     part
                     for part in self.model_parts
-                    if getattr(part, "_puzzletron_removed_lm_head_weight", None)
-                    is not None
+                    if getattr(part, "_puzzletron_removed_lm_head_weight", None) is not None
                 ),
                 None,
             )
@@ -1068,11 +981,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
             for name, module in part.named_modules():
                 leaf = name.rsplit(".", 1)[-1]
                 components = set(name.split("."))
-                if (
-                    leaf in final_norm_leafs
-                    and ".layers." not in name
-                    and "mtp" not in components
-                ):
+                if leaf in final_norm_leafs and ".layers." not in name and "mtp" not in components:
                     fallback.append((len(name.split(".")), name, module))
         return min(fallback, default=(None, None, None))[2]
 
@@ -1166,8 +1075,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
             hidden_mask = torch.ones_like(targets, dtype=torch.bool)
         masks = {"ce_mask": ce_mask, "kd_mask": ce_mask, "hidden_mask": hidden_mask}
         return {
-            name: value.to(device) if device is not None else value
-            for name, value in masks.items()
+            name: value.to(device) if device is not None else value for name, value in masks.items()
         }
 
     def current_metric_masks(self) -> dict[str, torch.Tensor | None]:
@@ -1178,8 +1086,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
         hidden = hidden[:valid_rows]
         targets = None if targets is None else targets[:valid_rows]
         masks = {
-            name: None if value is None else value[:valid_rows]
-            for name, value in masks.items()
+            name: None if value is None else value[:valid_rows] for name, value in masks.items()
         }
         return hidden, targets, masks
 
@@ -1206,7 +1113,9 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                 self._captured_hidden = None
                 self._forward_batch(batch)
                 if self.has_outputs:
-                    device = self._captured_hidden.device if self._captured_hidden is not None else None
+                    device = (
+                        self._captured_hidden.device if self._captured_hidden is not None else None
+                    )
                     targets = self._local_targets_for_batch(batch, device=device)
                     self._current_metric_masks = self._metric_masks_for_batch(
                         batch,
@@ -1363,7 +1272,8 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
     ):
         """Make one block behave as pruned for the enclosed forward(s), then restore.
 
-        On the owning PP stage: masks down_proj (FFN removal) / o_proj (attention removal) inputs.
+        On the owning PP stage: masks ``down_proj`` for FFN removal and either executes
+        compact gated-attention projections or masks ``o_proj`` for attention removal.
         No-op on other stages (the pruned
         activations still propagate through the pipeline to the scoring stage). Sorted-teacher
         targets are prefix slices, so removal masks the prefix.
@@ -1398,11 +1308,26 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
             target_num_kv=target_num_kv if o_proj_name is not None else None,
             head_dim=head_dim,
         )
+        compact_attention = resolve_compact_grouped_attention_target(
+            layer,
+            (
+                teacher_block_config.get_subblock("attention")
+                if teacher_block_config is not None
+                else None
+            ),
+            (
+                child_block_config.get_subblock("attention")
+                if child_block_config is not None
+                else None
+            ),
+        )
 
         handles = []
         try:
             for spec in specs:
                 if isinstance(spec, (FFNRemovalSpec, AttnRemovalSpec)):
+                    if isinstance(spec, AttnRemovalSpec) and compact_attention is not None:
+                        continue
                     module = self._maybe_submodule(layer, spec.module_name)
                     if module is not None:
                         handles.append(register_mask_hook(module, spec.keep_mask))
@@ -1452,8 +1377,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                     f"changed_parameters={changed_parameter_details} changed_hooks={changed_hooks}"
                 )
             print(
-                "[solution/automodel] "
-                f"{_rank_tag()} restore verified layer={layer_idx}",
+                f"[solution/automodel] {_rank_tag()} restore verified layer={layer_idx}",
                 flush=True,
             )
 
@@ -1480,7 +1404,11 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
         if descriptor is None:
             raise ValueError("hidden-width scoring requires an AnyModel descriptor")
         config = next(
-            (getattr(part, "config", None) for part in self.model_parts if getattr(part, "config", None)),
+            (
+                getattr(part, "config", None)
+                for part in self.model_parts
+                if getattr(part, "config", None)
+            ),
             None,
         )
         if config is None:
@@ -1535,8 +1463,8 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
 
         These hooks deliberately operate on generic subblock semantics rather
         than model-family names: MoE expert pruning is gate-prefix masking,
-        MoE channel/latent pruning masks intermediate activations, and Mamba
-        head/head-dim pruning masks the sorted inner state before ``out_proj``.
+        MoE channel/latent pruning masks intermediate activations, and native
+        fused Mamba or GDN candidates execute compact geometry when supported.
         """
 
         if teacher_block_config is None or child_block_config is None:
@@ -1584,6 +1512,16 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                 )
             handles.append(attention_module.register_forward_hook(_module_output_zero_hook))
 
+        compact_attention = resolve_compact_grouped_attention_target(
+            layer, teacher_attention, child_attention
+        )
+        if compact_attention is not None:
+            attention_module = compact_attention.pop("module")
+            contexts.append(
+                compact_grouped_attention_forward(attention_module, **compact_attention)
+            )
+            handles.append(attention_module.register_forward_hook(_module_output_identity_hook))
+
         teacher_mla = teacher_block_config.get_subblock("mla")
         child_mla = child_block_config.get_subblock("mla")
         if teacher_mla is not None and child_mla is not None:
@@ -1592,10 +1530,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                 raise RuntimeError(
                     f"MLA candidate requested but no self_attn module was found on {type(layer).__name__}"
                 )
-            if (
-                not getattr(teacher_mla, "no_op", False)
-                and getattr(child_mla, "no_op", False)
-            ):
+            if not getattr(teacher_mla, "no_op", False) and getattr(child_mla, "no_op", False):
                 handles.append(mla_module.register_forward_hook(_module_output_zero_hook))
             else:
                 original_heads = getattr(teacher_mla, "num_heads", None)
@@ -1628,11 +1563,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                 ):
                     original_rank = getattr(teacher_mla, rank_field, None)
                     target_rank = getattr(child_mla, rank_field, None)
-                    if (
-                        original_rank is None
-                        or target_rank is None
-                        or target_rank >= original_rank
-                    ):
+                    if original_rank is None or target_rank is None or target_rank >= original_rank:
                         continue
                     norm = getattr(mla_module, norm_name, None)
                     if norm is None:
@@ -1641,9 +1572,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                             f"{type(mla_module).__name__}"
                         )
                     handles.append(
-                        norm.register_forward_hook(
-                            _prefix_rms_norm_forward_hook(int(target_rank))
-                        )
+                        norm.register_forward_hook(_prefix_rms_norm_forward_hook(int(target_rank)))
                     )
 
         teacher_moe = teacher_block_config.get_subblock("moe")
@@ -1660,18 +1589,22 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                     moe_module = candidate
                     break
             if moe_module is not None:
-                if (
-                    not getattr(teacher_moe, "no_op", False)
-                    and getattr(child_moe, "no_op", False)
-                ):
+                if not getattr(teacher_moe, "no_op", False) and getattr(child_moe, "no_op", False):
                     handles.append(moe_module.register_forward_hook(_module_output_zero_hook))
                 else:
                     orig_experts = getattr(teacher_moe, "num_experts", None)
                     target_experts = getattr(child_moe, "num_experts", None)
                     target_top_k = getattr(child_moe, "top_k", None)
-                    if target_experts is not None and orig_experts is not None and target_experts >= orig_experts:
+                    if (
+                        target_experts is not None
+                        and orig_experts is not None
+                        and target_experts >= orig_experts
+                    ):
                         target_experts = None
-                    if target_top_k is not None and getattr(teacher_moe, "top_k", None) == target_top_k:
+                    if (
+                        target_top_k is not None
+                        and getattr(teacher_moe, "top_k", None) == target_top_k
+                    ):
                         target_top_k = None
                     if target_experts is not None or target_top_k is not None:
                         contexts.append(
@@ -1709,10 +1642,17 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                             for expert in experts:
                                 down = getattr(expert, "down_proj", None)
                                 if down is not None:
-                                    handles.append(down.register_forward_pre_hook(lambda module, args, km=keep_mask: (
-                                        args[0] * km.to(dtype=args[0].dtype, device=args[0].device).reshape((1,) * (args[0].ndim - 1) + (-1,)),
-                                        *args[1:],
-                                    )))
+                                    handles.append(
+                                        down.register_forward_pre_hook(
+                                            lambda module, args, km=keep_mask: (
+                                                args[0]
+                                                * km.to(
+                                                    dtype=args[0].dtype, device=args[0].device
+                                                ).reshape((1,) * (args[0].ndim - 1) + (-1,)),
+                                                *args[1:],
+                                            )
+                                        )
+                                    )
 
                     orig_shared = getattr(teacher_moe, "shared_expert_intermediate_size", None)
                     target_shared = getattr(child_moe, "shared_expert_intermediate_size", None)
@@ -1726,7 +1666,9 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                     ):
                         handles.append(
                             shared_down.register_forward_pre_hook(
-                                lambda module, args, km=_bool_prefix_mask(orig_shared, target_shared): (
+                                lambda module,
+                                args,
+                                km=_bool_prefix_mask(orig_shared, target_shared): (
                                     args[0]
                                     * km.to(dtype=args[0].dtype, device=args[0].device).reshape(
                                         (1,) * (args[0].ndim - 1) + (-1,)
@@ -1774,9 +1716,8 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                 or getattr(layer, "self_attn", None)
             )
             if mamba_module is not None:
-                if (
-                    not getattr(teacher_mamba, "no_op", False)
-                    and getattr(child_mamba, "no_op", False)
+                if not getattr(teacher_mamba, "no_op", False) and getattr(
+                    child_mamba, "no_op", False
                 ):
                     handles.append(mamba_module.register_forward_hook(_module_output_zero_hook))
                 else:
@@ -1791,106 +1732,48 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                         mamba_module, "in_proj_qkv"
                     )
                     if is_gdn:
-                        orig_groups = int(getattr(teacher_mamba, "num_groups"))
-                        orig_key_dim = int(getattr(teacher_mamba, "state_dim"))
-                        target_groups = int(getattr(child_mamba, "num_groups") or orig_groups)
-                        target_key_dim = int(getattr(child_mamba, "state_dim") or orig_key_dim)
-                        qkv_keep, value_keep = _gdn_prefix_masks(
-                            orig_groups=orig_groups,
-                            orig_heads=int(orig_heads),
-                            orig_key_dim=orig_key_dim,
-                            orig_value_dim=int(orig_head_dim),
-                            target_groups=target_groups,
-                            target_heads=int(target_heads),
-                            target_key_dim=target_key_dim,
-                            target_value_dim=int(target_head_dim),
+                        teacher_shape = GDNShape(
+                            num_key_heads=int(orig_groups),
+                            num_value_heads=int(orig_heads),
+                            key_head_dim=int(orig_state_dim),
+                            value_head_dim=int(orig_head_dim),
                         )
-                        if not bool(qkv_keep.all()):
-                            handles.append(
-                                mamba_module.in_proj_qkv.register_forward_hook(
-                                    _mask_last_dim_forward_hook(qkv_keep)
-                                )
-                            )
-                        if target_key_dim < orig_key_dim:
+                        target_shape = GDNShape(
+                            num_key_heads=int(getattr(child_mamba, "num_groups") or orig_groups),
+                            num_value_heads=int(target_heads),
+                            key_head_dim=int(getattr(child_mamba, "state_dim") or orig_state_dim),
+                            value_head_dim=int(target_head_dim),
+                        )
+                        if target_shape != teacher_shape:
                             contexts.append(
-                                _scale_gdn_kernel_query_output(
+                                compact_gated_delta_net_forward(
                                     mamba_module,
-                                    (float(orig_key_dim) / float(target_key_dim)) ** 0.5,
-                                )
-                            )
-                        if not bool(value_keep.all()):
-                            handles.append(
-                                mamba_module.in_proj_z.register_forward_hook(
-                                    _mask_last_dim_forward_hook(value_keep)
+                                    teacher_shape=teacher_shape,
+                                    target_shape=target_shape,
                                 )
                             )
                             handles.append(
-                                mamba_module.out_proj.register_forward_pre_hook(
-                                    lambda module, args, km=value_keep: (
-                                        args[0]
-                                        * km.to(dtype=args[0].dtype, device=args[0].device).reshape(
-                                            (1,) * (args[0].ndim - 1) + (-1,)
-                                        ),
-                                        *args[1:],
-                                    )
-                                )
+                                mamba_module.register_forward_hook(_module_output_identity_hook)
                             )
-                        # in_proj_a / in_proj_b output one scalar per value-head;
-                        # derive the head-level keep mask from the flat value mask.
-                        _head_keep = value_keep.reshape(
-                            int(orig_heads), int(orig_head_dim)
-                        ).any(dim=-1)
-                        if not bool(_head_keep.all()):
-                            for _pn in ("in_proj_a", "in_proj_b"):
-                                _pr = getattr(mamba_module, _pn, None)
-                                if _pr is not None:
-                                    handles.append(
-                                        _pr.register_forward_hook(
-                                            _mask_last_dim_forward_hook(_head_keep)
-                                        )
-                                    )
-                        # norm: compensate energy when the value head-dim is reduced so
-                        # the normalisation sees the same per-channel variance as a
-                        # physically smaller model (matches _apply_gdn_prefix_hooks).
-                        if int(target_head_dim) < int(orig_head_dim):
-                            _norm = getattr(mamba_module, "norm", None)
-                            if _norm is not None:
-                                _vd_mask = (
-                                    torch.arange(int(orig_head_dim)) < int(target_head_dim)
-                                )
-                                _scale_in = (
-                                    float(orig_head_dim) / float(target_head_dim)
-                                ) ** 0.5
-                                _scale_out = (
-                                    float(target_head_dim) / float(orig_head_dim)
-                                ) ** 0.5
-                                handles.append(
-                                    _norm.register_forward_pre_hook(
-                                        _gdn_norm_dim_prehook(_vd_mask, _scale_in)
-                                    )
-                                )
-                                handles.append(
-                                    _norm.register_forward_hook(
-                                        _mask_last_dim_forward_hook_scaled(
-                                            _vd_mask, _scale_out
-                                        )
-                                    )
-                                )
-                    if not is_gdn and all(
-                        value is not None
-                        for value in (
-                            orig_heads,
-                            orig_head_dim,
-                            orig_groups,
-                            orig_state_dim,
-                            target_heads,
-                            target_head_dim,
-                            target_state_dim,
+                    if (
+                        not is_gdn
+                        and all(
+                            value is not None
+                            for value in (
+                                orig_heads,
+                                orig_head_dim,
+                                orig_groups,
+                                orig_state_dim,
+                                target_heads,
+                                target_head_dim,
+                                target_state_dim,
+                            )
                         )
-                    ) and (
-                        target_heads < orig_heads
-                        or target_head_dim < orig_head_dim
-                        or target_state_dim < orig_state_dim
+                        and (
+                            target_heads < orig_heads
+                            or target_head_dim < orig_head_dim
+                            or target_state_dim < orig_state_dim
+                        )
                     ):
                         masks = _mamba_prefix_masks(
                             mamba_module,
@@ -1966,8 +1849,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                                     )
                                 )
                             can_scale_output = (
-                                out_proj is not None
-                                and getattr(out_proj, "bias", None) is None
+                                out_proj is not None and getattr(out_proj, "bias", None) is None
                             )
                             if norm_scale != 1.0 and can_scale_output:
                                 handles.append(
@@ -1993,9 +1875,7 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                                 getattr(conv1d, "bias", None) if conv1d is not None else None
                             )
                             if conv_bias is not None and not bool(conv_keep.all()):
-                                contexts.append(
-                                    _temporary_parameter_mask(conv_bias, conv_keep)
-                                )
+                                contexts.append(_temporary_parameter_mask(conv_bias, conv_keep))
 
         return handles, contexts
 

--- a/modelopt/torch/puzzletron/plugins/automodel/solution_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/solution_recipe.py
@@ -82,6 +82,8 @@ def _module_output_zero_hook(module, args, output):
 
 
 def _module_output_identity_hook(module, args, output):
+    """Bypass generic masking after compact execution produced the reduced geometry."""
+
     return output
 
 
@@ -1731,7 +1733,10 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                     is_gdn = hasattr(mamba_module, "num_k_heads") and hasattr(
                         mamba_module, "in_proj_qkv"
                     )
-                    if is_gdn:
+                    if is_gdn and all(
+                        value is not None
+                        for value in (orig_heads, orig_head_dim, orig_groups, orig_state_dim)
+                    ):
                         teacher_shape = GDNShape(
                             num_key_heads=int(orig_groups),
                             num_value_heads=int(orig_heads),
@@ -1739,9 +1744,13 @@ class ReplaceBlockScoringRecipe(ActivationScoringRecipe):
                             value_head_dim=int(orig_head_dim),
                         )
                         target_shape = GDNShape(
-                            num_key_heads=int(getattr(child_mamba, "num_groups") or orig_groups),
+                            num_key_heads=int(
+                                getattr(child_mamba, "num_groups", None) or orig_groups
+                            ),
                             num_value_heads=int(target_heads),
-                            key_head_dim=int(getattr(child_mamba, "state_dim") or orig_state_dim),
+                            key_head_dim=int(
+                                getattr(child_mamba, "state_dim", None) or orig_state_dim
+                            ),
                             value_head_dim=int(target_head_dim),
                         )
                         if target_shape != teacher_shape:

--- a/modelopt/torch/puzzletron/pruning/compact_runtime.py
+++ b/modelopt/torch/puzzletron/pruning/compact_runtime.py
@@ -1,0 +1,422 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reversible compact forwards for physically sliced attention and GDN candidates."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack, contextmanager
+from types import MethodType
+
+import torch
+import torch.nn.functional as F
+
+from .attention_ffn_surgery import slice_query_rows_by_head, sorted_attention_keep_indices
+from .gated_delta_net import GDNShape, gated_delta_net_prefix_indices
+
+__all__ = [
+    "compact_gated_delta_net_forward",
+    "compact_grouped_attention_forward",
+    "resolve_compact_grouped_attention_target",
+    "supports_compact_grouped_attention",
+]
+
+
+def _indices_on(indices: torch.Tensor, tensor: torch.Tensor) -> torch.Tensor:
+    return indices.to(device=tensor.device)
+
+
+def _index_select(tensor: torch.Tensor | None, dim: int, indices: torch.Tensor):
+    if tensor is None:
+        return None
+    return tensor.index_select(dim, _indices_on(indices, tensor)).contiguous()
+
+
+@contextmanager
+def _indexed_linear_forward(
+    module,
+    *,
+    output_indices: torch.Tensor | None = None,
+    input_indices: torch.Tensor | None = None,
+):
+    """Execute one linear layer through selected rows/columns without resizing parameters."""
+
+    original_forward = module.forward
+
+    def forward(self, inputs):
+        weight = self.weight
+        bias = self.bias
+        if output_indices is not None:
+            weight = _index_select(weight, 0, output_indices)
+            bias = _index_select(bias, 0, output_indices)
+        if input_indices is not None:
+            weight = _index_select(weight, 1, input_indices)
+        return F.linear(inputs, weight, bias)
+
+    module.forward = MethodType(forward, module)
+    try:
+        yield
+    finally:
+        module.forward = original_forward
+
+
+@contextmanager
+def _temporary_attrs(module, updates: dict[str, object]):
+    originals = {name: getattr(module, name) for name in updates}
+    try:
+        for name, value in updates.items():
+            setattr(module, name, value)
+        yield
+    finally:
+        for name, value in originals.items():
+            setattr(module, name, value)
+
+
+def supports_compact_grouped_attention(
+    attention_module,
+    *,
+    orig_num_q: int,
+    orig_num_kv: int,
+    head_dim: int,
+) -> bool:
+    """Return whether a gated grouped-attention module has the expected packed layout."""
+
+    q_proj = getattr(attention_module, "q_proj", None)
+    k_proj = getattr(attention_module, "k_proj", None)
+    v_proj = getattr(attention_module, "v_proj", None)
+    o_proj = getattr(attention_module, "o_proj", None)
+    if any(
+        module is None or not hasattr(module, "weight")
+        for module in (q_proj, k_proj, v_proj, o_proj)
+    ):
+        return False
+    assert q_proj is not None and k_proj is not None and v_proj is not None and o_proj is not None
+    return (
+        int(getattr(attention_module, "head_dim", -1)) == int(head_dim)
+        and hasattr(attention_module, "num_key_value_groups")
+        and int(q_proj.weight.shape[0]) == 2 * int(orig_num_q) * int(head_dim)
+        and int(k_proj.weight.shape[0]) == int(orig_num_kv) * int(head_dim)
+        and int(v_proj.weight.shape[0]) == int(orig_num_kv) * int(head_dim)
+        and int(o_proj.weight.shape[1]) == int(orig_num_q) * int(head_dim)
+    )
+
+
+def resolve_compact_grouped_attention_target(layer, teacher_attention, child_attention):
+    """Resolve one physically compact gated-attention target, if supported."""
+
+    if (
+        teacher_attention is None
+        or child_attention is None
+        or getattr(teacher_attention, "no_op", False)
+        or getattr(child_attention, "no_op", False)
+    ):
+        return None
+    attention_module = getattr(layer, "self_attn", None)
+    if attention_module is None:
+        return None
+    orig_num_q = getattr(teacher_attention, "num_query_heads", None)
+    orig_num_kv = getattr(teacher_attention, "num_kv_heads", None)
+    target_num_q = getattr(child_attention, "num_query_heads", None)
+    target_num_kv = getattr(child_attention, "num_kv_heads", None)
+    head_dim = getattr(teacher_attention, "qk_head_dim", None) or getattr(
+        attention_module, "head_dim", None
+    )
+    if (
+        orig_num_q is None
+        or orig_num_kv is None
+        or target_num_q is None
+        or target_num_kv is None
+        or head_dim is None
+    ):
+        return None
+    if target_num_q >= orig_num_q and target_num_kv >= orig_num_kv:
+        return None
+    if not supports_compact_grouped_attention(
+        attention_module,
+        orig_num_q=int(orig_num_q),
+        orig_num_kv=int(orig_num_kv),
+        head_dim=int(head_dim),
+    ):
+        return None
+    return {
+        "module": attention_module,
+        "orig_num_q": int(orig_num_q),
+        "orig_num_kv": int(orig_num_kv),
+        "target_num_q": int(target_num_q),
+        "target_num_kv": int(target_num_kv),
+        "head_dim": int(head_dim),
+    }
+
+
+@contextmanager
+def compact_grouped_attention_forward(
+    attention_module,
+    *,
+    orig_num_q: int,
+    orig_num_kv: int,
+    target_num_q: int,
+    target_num_kv: int,
+    head_dim: int,
+):
+    """Run gated grouped attention with the exact projection geometry of export."""
+
+    if not supports_compact_grouped_attention(
+        attention_module,
+        orig_num_q=orig_num_q,
+        orig_num_kv=orig_num_kv,
+        head_dim=head_dim,
+    ):
+        raise ValueError(
+            f"Unsupported compact grouped-attention layout on {type(attention_module).__name__}"
+        )
+    if target_num_q % target_num_kv:
+        raise ValueError(
+            f"target query heads={target_num_q} must be divisible by KV heads={target_num_kv}"
+        )
+    orig_ratio = int(orig_num_q) // int(orig_num_kv)
+    target_ratio = int(target_num_q) // int(target_num_kv)
+    if target_ratio > orig_ratio:
+        raise ValueError(
+            f"target query-head ratio={target_ratio} exceeds teacher ratio={orig_ratio}"
+        )
+
+    keep_q, keep_kv = sorted_attention_keep_indices(int(target_num_kv), target_ratio, orig_ratio)
+    q_proj = attention_module.q_proj
+    q_rows = slice_query_rows_by_head(
+        torch.arange(q_proj.weight.shape[0]), keep_q, int(head_dim), int(orig_num_q)
+    )
+    kv_rows = (keep_kv[:, None] * int(head_dim) + torch.arange(int(head_dim))[None, :]).reshape(-1)
+    q_columns = (keep_q[:, None] * int(head_dim) + torch.arange(int(head_dim))[None, :]).reshape(-1)
+
+    with ExitStack() as stack:
+        stack.enter_context(_indexed_linear_forward(q_proj, output_indices=q_rows))
+        stack.enter_context(
+            _indexed_linear_forward(attention_module.k_proj, output_indices=kv_rows)
+        )
+        stack.enter_context(
+            _indexed_linear_forward(attention_module.v_proj, output_indices=kv_rows)
+        )
+        stack.enter_context(
+            _indexed_linear_forward(attention_module.o_proj, input_indices=q_columns)
+        )
+        stack.enter_context(
+            _temporary_attrs(
+                attention_module,
+                {"num_key_value_groups": int(target_num_q) // int(target_num_kv)},
+            )
+        )
+        yield
+
+
+def _compact_gdn_norm(norm, hidden_states, gate, value_dim_indices: torch.Tensor):
+    compact_weight = _index_select(norm.weight, 0, value_dim_indices)
+    return torch.func.functional_call(
+        norm,
+        {"weight": compact_weight},
+        (hidden_states, gate),
+        strict=False,
+    )
+
+
+@contextmanager
+def compact_gated_delta_net_forward(
+    gdn_module,
+    *,
+    teacher_shape: GDNShape,
+    target_shape: GDNShape,
+):
+    """Run Qwen-style GDN with the exact compact geometry used by materialization."""
+
+    live_shape = GDNShape.from_module(gdn_module)
+    if live_shape != teacher_shape:
+        raise ValueError(f"live GDN shape {live_shape} does not match teacher {teacher_shape}")
+    required = (
+        "in_proj_qkv",
+        "in_proj_z",
+        "in_proj_a",
+        "in_proj_b",
+        "conv1d",
+        "norm",
+        "out_proj",
+        "chunk_gated_delta_rule",
+        "recurrent_gated_delta_rule",
+    )
+    missing = [name for name in required if not hasattr(gdn_module, name)]
+    if missing:
+        raise ValueError(
+            f"Unsupported compact GDN layout on {type(gdn_module).__name__}: missing {missing}"
+        )
+
+    indices = gated_delta_net_prefix_indices(teacher_shape, target_shape)
+    cidx = indices["cidx"]
+    hidx = indices["hidx"]
+    vidx = indices["vidx"]
+    value_dim_indices = torch.arange(target_shape.value_head_dim)
+    original_forward = gdn_module.forward
+
+    def compact_forward(
+        self,
+        hidden_states: torch.Tensor,
+        cache_params=None,
+        attention_mask: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        if (
+            attention_mask is not None
+            and attention_mask.shape[1] > 1
+            and attention_mask.shape[0] > 1
+        ):
+            hidden_states = (hidden_states * attention_mask[:, :, None]).to(hidden_states.dtype)
+
+        batch_size, seq_len, _ = hidden_states.shape
+        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(
+            self.layer_idx
+        )
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
+
+        mixed_qkv = F.linear(
+            hidden_states,
+            _index_select(self.in_proj_qkv.weight, 0, cidx),
+            _index_select(self.in_proj_qkv.bias, 0, cidx),
+        ).transpose(1, 2)
+        z = F.linear(
+            hidden_states,
+            _index_select(self.in_proj_z.weight, 0, vidx),
+            _index_select(self.in_proj_z.bias, 0, vidx),
+        ).reshape(batch_size, seq_len, target_shape.num_value_heads, target_shape.value_head_dim)
+        b = F.linear(
+            hidden_states,
+            _index_select(self.in_proj_b.weight, 0, hidx),
+            _index_select(self.in_proj_b.bias, 0, hidx),
+        )
+        a = F.linear(
+            hidden_states,
+            _index_select(self.in_proj_a.weight, 0, hidx),
+            _index_select(self.in_proj_a.bias, 0, hidx),
+        )
+        conv_weight = _index_select(self.conv1d.weight, 0, cidx)
+        conv_bias = _index_select(self.conv1d.bias, 0, cidx)
+
+        if use_precomputed_states and seq_len == 1:
+            mixed_qkv = self.causal_conv1d_update(
+                mixed_qkv,
+                conv_state,
+                conv_weight.squeeze(1),
+                conv_bias,
+                self.activation,
+            )
+        else:
+            if use_precomputed_states:
+                mixed_qkv = torch.cat([conv_state, mixed_qkv], dim=-1)
+            if cache_params is not None:
+                new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
+                cache_params.update_conv_state(new_conv_state, self.layer_idx)
+            if self.causal_conv1d_fn is not None:
+                mixed_qkv = self.causal_conv1d_fn(
+                    x=mixed_qkv,
+                    weight=conv_weight.squeeze(1),
+                    bias=conv_bias,
+                    activation=self.activation,
+                    seq_idx=kwargs.get("seq_idx"),
+                )
+            else:
+                mixed_qkv = F.silu(
+                    F.conv1d(
+                        mixed_qkv,
+                        conv_weight,
+                        conv_bias,
+                        stride=self.conv1d.stride,
+                        padding=self.conv1d.padding,
+                        dilation=self.conv1d.dilation,
+                        groups=target_shape.num_key_heads * target_shape.key_head_dim * 2
+                        + target_shape.num_value_heads * target_shape.value_head_dim,
+                    )[:, :, : mixed_qkv.shape[-1]]
+                )
+            if use_precomputed_states:
+                mixed_qkv = mixed_qkv[:, :, -seq_len:]
+
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+        query, key, value = torch.split(
+            mixed_qkv,
+            [
+                target_shape.num_key_heads * target_shape.key_head_dim,
+                target_shape.num_key_heads * target_shape.key_head_dim,
+                target_shape.num_value_heads * target_shape.value_head_dim,
+            ],
+            dim=-1,
+        )
+        query = query.reshape(
+            batch_size, seq_len, target_shape.num_key_heads, target_shape.key_head_dim
+        )
+        key = key.reshape(
+            batch_size, seq_len, target_shape.num_key_heads, target_shape.key_head_dim
+        )
+        value = value.reshape(
+            batch_size, seq_len, target_shape.num_value_heads, target_shape.value_head_dim
+        )
+
+        beta = b.sigmoid()
+        g = -_index_select(self.A_log, 0, hidx).float().exp() * F.softplus(
+            a.float() + _index_select(self.dt_bias, 0, hidx)
+        )
+        repeats = target_shape.num_value_heads // target_shape.num_key_heads
+        if repeats > 1:
+            query = query.repeat_interleave(repeats, dim=2)
+            key = key.repeat_interleave(repeats, dim=2)
+
+        if use_precomputed_states and seq_len == 1:
+            core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
+            )
+        else:
+            core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state if use_precomputed_states else None,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
+            )
+
+        if cache_params is not None:
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
+
+        core_attn_out = core_attn_out.reshape(-1, target_shape.value_head_dim)
+        z = z.reshape(-1, target_shape.value_head_dim)
+        core_attn_out = _compact_gdn_norm(self.norm, core_attn_out, z, value_dim_indices).reshape(
+            batch_size, seq_len, -1
+        )
+        return F.linear(
+            core_attn_out,
+            _index_select(self.out_proj.weight, 1, vidx),
+            self.out_proj.bias,
+        )
+
+    gdn_module.forward = MethodType(compact_forward, gdn_module)
+    try:
+        yield
+    finally:
+        gdn_module.forward = original_forward

--- a/modelopt/torch/puzzletron/pruning/compact_runtime.py
+++ b/modelopt/torch/puzzletron/pruning/compact_runtime.py
@@ -30,8 +30,22 @@ __all__ = [
     "compact_gated_delta_net_forward",
     "compact_grouped_attention_forward",
     "resolve_compact_grouped_attention_target",
+    "supports_compact_gated_delta_net",
     "supports_compact_grouped_attention",
 ]
+
+
+_SUPPORTED_GROUPED_ATTENTION_TYPES = {
+    ("transformers.models.qwen3_5.modeling_qwen3_5", "Qwen3_5Attention"),
+}
+_SUPPORTED_GDN_TYPES = {
+    ("transformers.models.qwen3_5.modeling_qwen3_5", "Qwen3_5GatedDeltaNet"),
+}
+
+
+def _type_key(module) -> tuple[str, str]:
+    module_type = type(module)
+    return module_type.__module__, module_type.__qualname__
 
 
 def _indices_on(indices: torch.Tensor, tensor: torch.Tensor) -> torch.Tensor:
@@ -53,7 +67,8 @@ def _indexed_linear_forward(
 ):
     """Execute one linear layer through selected rows/columns without resizing parameters."""
 
-    original_forward = module.forward
+    missing = object()
+    original_instance_forward = vars(module).get("forward", missing)
 
     def forward(self, inputs):
         weight = self.weight
@@ -69,7 +84,10 @@ def _indexed_linear_forward(
     try:
         yield
     finally:
-        module.forward = original_forward
+        if original_instance_forward is missing:
+            del module.forward
+        else:
+            module.forward = original_instance_forward
 
 
 @contextmanager
@@ -84,15 +102,13 @@ def _temporary_attrs(module, updates: dict[str, object]):
             setattr(module, name, value)
 
 
-def supports_compact_grouped_attention(
+def _has_compact_grouped_attention_layout(
     attention_module,
     *,
     orig_num_q: int,
     orig_num_kv: int,
     head_dim: int,
 ) -> bool:
-    """Return whether a gated grouped-attention module has the expected packed layout."""
-
     q_proj = getattr(attention_module, "q_proj", None)
     k_proj = getattr(attention_module, "k_proj", None)
     v_proj = getattr(attention_module, "v_proj", None)
@@ -105,11 +121,36 @@ def supports_compact_grouped_attention(
     assert q_proj is not None and k_proj is not None and v_proj is not None and o_proj is not None
     return (
         int(getattr(attention_module, "head_dim", -1)) == int(head_dim)
-        and hasattr(attention_module, "num_key_value_groups")
+        and int(getattr(attention_module, "num_key_value_groups", -1))
+        == int(orig_num_q) // int(orig_num_kv)
         and int(q_proj.weight.shape[0]) == 2 * int(orig_num_q) * int(head_dim)
         and int(k_proj.weight.shape[0]) == int(orig_num_kv) * int(head_dim)
         and int(v_proj.weight.shape[0]) == int(orig_num_kv) * int(head_dim)
         and int(o_proj.weight.shape[1]) == int(orig_num_q) * int(head_dim)
+    )
+
+
+def supports_compact_grouped_attention(
+    attention_module,
+    *,
+    orig_num_q: int,
+    orig_num_kv: int,
+    head_dim: int,
+) -> bool:
+    """Return whether this exact tested Qwen attention layout supports compact execution."""
+
+    return (
+        _type_key(attention_module) in _SUPPORTED_GROUPED_ATTENTION_TYPES
+        and orig_num_q > 0
+        and orig_num_kv > 0
+        and head_dim > 0
+        and orig_num_q % orig_num_kv == 0
+        and _has_compact_grouped_attention_layout(
+            attention_module,
+            orig_num_q=orig_num_q,
+            orig_num_kv=orig_num_kv,
+            head_dim=head_dim,
+        )
     )
 
 
@@ -141,22 +182,47 @@ def resolve_compact_grouped_attention_target(layer, teacher_attention, child_att
         or head_dim is None
     ):
         return None
-    if target_num_q >= orig_num_q and target_num_kv >= orig_num_kv:
+    orig_num_q = int(orig_num_q)
+    orig_num_kv = int(orig_num_kv)
+    target_num_q = int(target_num_q)
+    target_num_kv = int(target_num_kv)
+    head_dim = int(head_dim)
+    if min(orig_num_q, orig_num_kv, target_num_q, target_num_kv, head_dim) <= 0:
+        raise ValueError("grouped-attention head counts and head dimension must be positive")
+    if orig_num_q % orig_num_kv or target_num_q % target_num_kv:
+        raise ValueError("grouped-attention query heads must be divisible by KV heads")
+    if target_num_q > orig_num_q or target_num_kv > orig_num_kv:
+        raise ValueError("grouped-attention target geometry cannot exceed the teacher")
+    if target_num_q == orig_num_q and target_num_kv == orig_num_kv:
         return None
+    if target_num_q // target_num_kv > orig_num_q // orig_num_kv:
+        raise ValueError("grouped-attention target GQA ratio cannot exceed the teacher")
+    has_compact_layout = _has_compact_grouped_attention_layout(
+        attention_module,
+        orig_num_q=orig_num_q,
+        orig_num_kv=orig_num_kv,
+        head_dim=head_dim,
+    )
+    if has_compact_layout and _type_key(attention_module) not in _SUPPORTED_GROUPED_ATTENTION_TYPES:
+        module_name, type_name = _type_key(attention_module)
+        raise RuntimeError(
+            "Compact grouped-attention scoring is unsupported for "
+            f"{module_name}.{type_name}; refusing to score reduced geometry"
+        )
     if not supports_compact_grouped_attention(
         attention_module,
-        orig_num_q=int(orig_num_q),
-        orig_num_kv=int(orig_num_kv),
-        head_dim=int(head_dim),
+        orig_num_q=orig_num_q,
+        orig_num_kv=orig_num_kv,
+        head_dim=head_dim,
     ):
         return None
     return {
         "module": attention_module,
-        "orig_num_q": int(orig_num_q),
-        "orig_num_kv": int(orig_num_kv),
-        "target_num_q": int(target_num_q),
-        "target_num_kv": int(target_num_kv),
-        "head_dim": int(head_dim),
+        "orig_num_q": orig_num_q,
+        "orig_num_kv": orig_num_kv,
+        "target_num_q": target_num_q,
+        "target_num_kv": target_num_kv,
+        "head_dim": head_dim,
     }
 
 
@@ -181,6 +247,10 @@ def compact_grouped_attention_forward(
         raise ValueError(
             f"Unsupported compact grouped-attention layout on {type(attention_module).__name__}"
         )
+    if min(target_num_q, target_num_kv) <= 0:
+        raise ValueError("target query and KV head counts must be positive")
+    if target_num_q > orig_num_q or target_num_kv > orig_num_kv:
+        raise ValueError("target query and KV head counts cannot exceed the teacher")
     if target_num_q % target_num_kv:
         raise ValueError(
             f"target query heads={target_num_q} must be divisible by KV heads={target_num_kv}"
@@ -230,6 +300,47 @@ def _compact_gdn_norm(norm, hidden_states, gate, value_dim_indices: torch.Tensor
     )
 
 
+def supports_compact_gated_delta_net(gdn_module, *, teacher_shape: GDNShape) -> bool:
+    """Return whether this exact tested Qwen GDN layout supports compact execution."""
+
+    if _type_key(gdn_module) not in _SUPPORTED_GDN_TYPES:
+        return False
+    if "_fp32_params" in getattr(gdn_module, "_modules", {}):
+        return False
+    if not {"A_log", "dt_bias"}.issubset(getattr(gdn_module, "_parameters", {})):
+        return False
+    required = (
+        "in_proj_qkv",
+        "in_proj_z",
+        "in_proj_a",
+        "in_proj_b",
+        "conv1d",
+        "norm",
+        "out_proj",
+        "chunk_gated_delta_rule",
+        "recurrent_gated_delta_rule",
+    )
+    if any(not hasattr(gdn_module, name) for name in required):
+        return False
+    projection_width = (
+        2 * teacher_shape.num_key_heads * teacher_shape.key_head_dim
+        + teacher_shape.num_value_heads * teacher_shape.value_head_dim
+    )
+    value_width = teacher_shape.num_value_heads * teacher_shape.value_head_dim
+    return (
+        GDNShape.from_module(gdn_module) == teacher_shape
+        and int(gdn_module.in_proj_qkv.weight.shape[0]) == projection_width
+        and int(gdn_module.in_proj_z.weight.shape[0]) == value_width
+        and int(gdn_module.in_proj_a.weight.shape[0]) == teacher_shape.num_value_heads
+        and int(gdn_module.in_proj_b.weight.shape[0]) == teacher_shape.num_value_heads
+        and int(gdn_module.conv1d.weight.shape[0]) == projection_width
+        and int(gdn_module.norm.weight.shape[0]) == teacher_shape.value_head_dim
+        and int(gdn_module.out_proj.weight.shape[1]) == value_width
+        and int(gdn_module.A_log.shape[0]) == teacher_shape.num_value_heads
+        and int(gdn_module.dt_bias.shape[0]) == teacher_shape.num_value_heads
+    )
+
+
 @contextmanager
 def compact_gated_delta_net_forward(
     gdn_module,
@@ -242,21 +353,11 @@ def compact_gated_delta_net_forward(
     live_shape = GDNShape.from_module(gdn_module)
     if live_shape != teacher_shape:
         raise ValueError(f"live GDN shape {live_shape} does not match teacher {teacher_shape}")
-    required = (
-        "in_proj_qkv",
-        "in_proj_z",
-        "in_proj_a",
-        "in_proj_b",
-        "conv1d",
-        "norm",
-        "out_proj",
-        "chunk_gated_delta_rule",
-        "recurrent_gated_delta_rule",
-    )
-    missing = [name for name in required if not hasattr(gdn_module, name)]
-    if missing:
-        raise ValueError(
-            f"Unsupported compact GDN layout on {type(gdn_module).__name__}: missing {missing}"
+    if not supports_compact_gated_delta_net(gdn_module, teacher_shape=teacher_shape):
+        module_name, type_name = _type_key(gdn_module)
+        raise RuntimeError(
+            "Compact GDN scoring is unsupported for "
+            f"{module_name}.{type_name}; refusing to score reduced geometry"
         )
 
     indices = gated_delta_net_prefix_indices(teacher_shape, target_shape)
@@ -264,15 +365,20 @@ def compact_gated_delta_net_forward(
     hidx = indices["hidx"]
     vidx = indices["vidx"]
     value_dim_indices = torch.arange(target_shape.value_head_dim)
-    original_forward = gdn_module.forward
+    missing = object()
+    original_instance_forward = vars(gdn_module).get("forward", missing)
 
     def compact_forward(
         self,
         hidden_states: torch.Tensor,
         cache_params=None,
+        cache_position=None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx=None,
         **kwargs,
     ):
+        if kwargs:
+            raise TypeError(f"Unsupported compact GDN forward arguments: {sorted(kwargs)}")
         if (
             attention_mask is not None
             and attention_mask.shape[1] > 1
@@ -287,6 +393,23 @@ def compact_gated_delta_net_forward(
         if use_precomputed_states:
             conv_state = cache_params.layers[self.layer_idx].conv_states
             recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
+            compact_projection_width = int(cidx.numel())
+            expected_recurrent_shape = (
+                target_shape.num_value_heads,
+                target_shape.key_head_dim,
+                target_shape.value_head_dim,
+            )
+            if int(conv_state.shape[-2]) != compact_projection_width:
+                raise ValueError(
+                    "Compact GDN cache convolution width does not match the target geometry: "
+                    f"actual={int(conv_state.shape[-2])} expected={compact_projection_width}"
+                )
+            actual_recurrent_shape = tuple(int(size) for size in recurrent_state.shape[-3:])
+            if actual_recurrent_shape != expected_recurrent_shape:
+                raise ValueError(
+                    "Compact GDN recurrent-state shape does not match the target geometry: "
+                    f"actual={actual_recurrent_shape} expected={expected_recurrent_shape}"
+                )
 
         mixed_qkv = F.linear(
             hidden_states,
@@ -331,7 +454,7 @@ def compact_gated_delta_net_forward(
                     weight=conv_weight.squeeze(1),
                     bias=conv_bias,
                     activation=self.activation,
-                    seq_idx=kwargs.get("seq_idx"),
+                    seq_idx=seq_idx,
                 )
             else:
                 mixed_qkv = F.silu(
@@ -419,4 +542,7 @@ def compact_gated_delta_net_forward(
     try:
         yield
     finally:
-        gdn_module.forward = original_forward
+        if original_instance_forward is missing:
+            del gdn_module.forward
+        else:
+            gdn_module.forward = original_instance_forward

--- a/modelopt/torch/puzzletron/pruning/compact_runtime.py
+++ b/modelopt/torch/puzzletron/pruning/compact_runtime.py
@@ -319,6 +319,11 @@ def supports_compact_gated_delta_net(gdn_module, *, teacher_shape: GDNShape) -> 
         "out_proj",
         "chunk_gated_delta_rule",
         "recurrent_gated_delta_rule",
+        "causal_conv1d_fn",
+        "causal_conv1d_update",
+        "conv_kernel_size",
+        "activation",
+        "layer_idx",
     )
     if any(not hasattr(gdn_module, name) for name in required):
         return False

--- a/tests/unit/torch/puzzletron/test_automodel_solution_scoring.py
+++ b/tests/unit/torch/puzzletron/test_automodel_solution_scoring.py
@@ -77,6 +77,8 @@ def test_baseline_only_scoring_does_not_require_candidate_solutions(tmp_path):
 
 
 def test_native_automodel_gdn_rejects_compact_runtime_candidate():
+    # Optional dependency: native AutoModel Qwen modules are not installed in every test env.
+    pytest.importorskip("nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn")
     from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareGatedDeltaNet
     from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
 
@@ -133,6 +135,47 @@ def test_native_automodel_gdn_rejects_compact_runtime_candidate():
     assert gdn.forward.__func__ is original_forward
     assert set(vars(gdn)) == original_state
     assert dict(gdn._forward_hooks) == original_forward_hooks
+
+
+@pytest.mark.parametrize(
+    ("teacher_mamba", "child_mamba"),
+    [
+        pytest.param(
+            SimpleNamespace(no_op=False, num_heads=4, head_dim=8, state_dim=8),
+            SimpleNamespace(no_op=False, num_heads=4, head_dim=8, num_groups=2, state_dim=8),
+            id="missing-teacher-groups",
+        ),
+        pytest.param(
+            SimpleNamespace(
+                no_op=False,
+                num_heads=4,
+                head_dim=8,
+                num_groups=2,
+                state_dim=8,
+            ),
+            SimpleNamespace(no_op=False, num_heads=4, head_dim=8),
+            id="missing-child-fields",
+        ),
+    ],
+)
+def test_gdn_runtime_hooks_skip_incomplete_shape_metadata(teacher_mamba, child_mamba):
+    def block_config(mamba):
+        return SimpleNamespace(
+            get_subblock=lambda kind: mamba if kind == "mamba" else None,
+        )
+
+    layer = SimpleNamespace(
+        linear_attn=SimpleNamespace(num_k_heads=2, in_proj_qkv=object()),
+    )
+
+    handles, contexts = ReplaceBlockScoringRecipe._typed_subblock_runtime_hooks(
+        layer,
+        teacher_block_config=block_config(teacher_mamba),
+        child_block_config=block_config(child_mamba),
+    )
+
+    assert handles == []
+    assert contexts == []
 
 
 def test_parent_sweep_reports_rank_local_exception_before_collective(capsys):

--- a/tests/unit/torch/puzzletron/test_automodel_solution_scoring.py
+++ b/tests/unit/torch/puzzletron/test_automodel_solution_scoring.py
@@ -59,6 +59,7 @@ from modelopt.torch.puzzletron.plugins.automodel.solution_recipe import (
     _temporary_parameter_mask,
 )
 from modelopt.torch.puzzletron.plugins.automodel.teacher_cache import TeacherTargetCache
+from modelopt.torch.puzzletron.pruning.gated_delta_net import GDNShape
 from modelopt.torch.puzzletron.pruning.runtime_candidate import apply_runtime_candidate
 from modelopt.torch.puzzletron.stages.diagnostics import _annotate_solution_selections
 
@@ -73,6 +74,65 @@ def test_baseline_only_scoring_does_not_require_candidate_solutions(tmp_path):
 
     assert solutions == []
     assert pending_ids == []
+
+
+def test_native_automodel_gdn_rejects_compact_runtime_candidate():
+    from nemo_automodel.components.models.qwen3_5_moe.cp_linear_attn import CPAwareGatedDeltaNet
+    from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
+
+    config = Qwen3_5MoeTextConfig(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        num_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=32,
+        layer_types=["linear_attention"],
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_conv_kernel_dim=4,
+    )
+    gdn = CPAwareGatedDeltaNet(config, layer_idx=0)
+    shape = GDNShape.from_module(gdn)
+    layer = SimpleNamespace(linear_attn=gdn)
+    teacher = BlockConfig(
+        subblock_configs=(
+            MambaConfig(
+                num_heads=shape.num_value_heads,
+                head_dim=shape.value_head_dim,
+                num_groups=shape.num_key_heads,
+                state_dim=shape.key_head_dim,
+            ),
+        )
+    )
+    child = BlockConfig(
+        subblock_configs=(
+            MambaConfig(
+                num_heads=shape.num_value_heads,
+                head_dim=shape.value_head_dim,
+                num_groups=shape.num_key_heads // 2,
+                state_dim=shape.key_head_dim,
+            ),
+        )
+    )
+    original_forward = gdn.forward.__func__
+    original_state = set(vars(gdn))
+    original_forward_hooks = dict(gdn._forward_hooks)
+
+    with pytest.raises(RuntimeError, match="refusing to score reduced geometry"):
+        apply_runtime_candidate(layer, teacher, child)
+
+    assert gdn.forward.__func__ is original_forward
+    assert set(vars(gdn)) == original_state
+    assert dict(gdn._forward_hooks) == original_forward_hooks
 
 
 def test_parent_sweep_reports_rank_local_exception_before_collective(capsys):
@@ -97,10 +157,7 @@ def test_parent_sweep_reports_rank_local_exception_before_collective(capsys):
 def test_parent_sweep_resume_recaches_original_teacher(
     role, pending_ids, needs_parent_evaluation, expected
 ):
-    assert (
-        _can_skip_parent_model_load(role, pending_ids, needs_parent_evaluation)
-        is expected
-    )
+    assert _can_skip_parent_model_load(role, pending_ids, needs_parent_evaluation) is expected
 
 
 def test_distributed_config_load_precaches_remote_code_before_import(monkeypatch, tmp_path):
@@ -160,8 +217,12 @@ def test_rpc_executor_scores_cumulative_depth_removals(monkeypatch):
     from modelopt.torch.puzzletron.distributed_eval.schema import EvaluationRequest
 
     teacher_blocks = [
-        BlockConfig(subblock_configs=(MoEConfig(num_experts=4, expert_intermediate_size=8, top_k=2),)),
-        BlockConfig(subblock_configs=(MambaConfig(state_dim=4, num_heads=2, head_dim=2, num_groups=1),)),
+        BlockConfig(
+            subblock_configs=(MoEConfig(num_experts=4, expert_intermediate_size=8, top_k=2),)
+        ),
+        BlockConfig(
+            subblock_configs=(MambaConfig(state_dim=4, num_heads=2, head_dim=2, num_groups=1),)
+        ),
     ]
     children = [
         BlockConfig(subblock_configs=(MoEConfig(no_op=True),)),
@@ -276,10 +337,7 @@ def test_block_checkpoint_overlay_merges_split_hf_experts_and_restores(tmp_path)
 
     with recipe.block_checkpoint_overlay_context(checkpoint, 0):
         expected_up = torch.stack(
-            [
-                tensors[f"backbone.layers.0.mixer.experts.{idx}.up_proj.weight"].T
-                for idx in range(2)
-            ]
+            [tensors[f"backbone.layers.0.mixer.experts.{idx}.up_proj.weight"].T for idx in range(2)]
         )
         expected_down = torch.stack(
             [
@@ -409,12 +467,12 @@ def test_parent_equivalence_still_gates_hidden_metrics_without_basis_permutation
 
     assert summary["passed"] is False
     assert summary["findings"]
-    assert any("cosine_embedding_loss_hidden_states" in item["message"] for item in summary["findings"])
+    assert any(
+        "cosine_embedding_loss_hidden_states" in item["message"] for item in summary["findings"]
+    )
 
 
-def test_unloadable_realization_is_quarantined_after_first_load_failure(
-    tmp_path, monkeypatch
-):
+def test_unloadable_realization_is_quarantined_after_first_load_failure(tmp_path, monkeypatch):
     checkpoint = tmp_path / "checkpoint"
     checkpoint.mkdir()
     (checkpoint / "config.json").write_text("{}\n")
@@ -501,9 +559,7 @@ def test_native_sigmoid_gate_groups_the_compact_expert_prefix():
         target_top_k=2,
     )
 
-    _, indices, _ = gate.forward(
-        torch.tensor([[-10.0, -10.0, 5.0, 6.0, 5.0, -10.0, -10.0, -10.0]])
-    )
+    _, indices, _ = gate.forward(torch.tensor([[-10.0, -10.0, 5.0, 6.0, 5.0, -10.0, -10.0, -10.0]]))
 
     assert set(indices.flatten().tolist()) == {3, 4}
 
@@ -583,20 +639,14 @@ def test_solution_prune_target_uses_prefix_after_parent_experts_are_sorted():
 def test_solution_prune_targets_supports_full_architecture_and_skips_teacher_layers():
     teacher_blocks = [
         BlockConfig(
-            subblock_configs=(
-                MoEConfig(num_experts=4, expert_intermediate_size=8, top_k=2),
-            )
+            subblock_configs=(MoEConfig(num_experts=4, expert_intermediate_size=8, top_k=2),)
         ),
         BlockConfig(
-            subblock_configs=(
-                MambaConfig(state_dim=4, num_heads=2, head_dim=2, num_groups=1),
-            )
+            subblock_configs=(MambaConfig(state_dim=4, num_heads=2, head_dim=2, num_groups=1),)
         ),
     ]
     changed = BlockConfig(
-        subblock_configs=(
-            MoEConfig(num_experts=2, expert_intermediate_size=8, top_k=2),
-        )
+        subblock_configs=(MoEConfig(num_experts=2, expert_intermediate_size=8, top_k=2),)
     )
     solution = {
         "chosen_replacements": [
@@ -671,9 +721,7 @@ def test_diagnostic_annotation_records_ranked_expert_ids(tmp_path):
     child = BlockConfig(
         subblock_configs=(MoEConfig(num_experts=2, expert_intermediate_size=8, top_k=2),)
     )
-    (tmp_path / "sorted_permutations.json").write_text(
-        json.dumps({"moe.experts.0": [3, 1, 0, 2]})
-    )
+    (tmp_path / "sorted_permutations.json").write_text(json.dumps({"moe.experts.0": [3, 1, 0, 2]}))
     diagnostic = {
         "axis": "moe_experts",
         "field": "num_experts",
@@ -721,9 +769,7 @@ def test_score_batch_compares_pruned_student_logits_with_full_width_teacher():
     student_hidden = torch.tensor([[[1.0, 2.0]]])
     student_head = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, -1.0]])
     teacher_hidden = torch.tensor([[[1.0, 2.0, 3.0]]])
-    teacher_head = torch.tensor(
-        [[1.0, 0.0, 1.0], [0.0, 1.0, -1.0], [1.0, -1.0, 0.5]]
-    )
+    teacher_head = torch.tensor([[1.0, 0.0, 1.0], [0.0, 1.0, -1.0], [1.0, -1.0, 0.5]])
     hidden_metric_teacher = teacher_hidden[..., :2]
     targets = torch.tensor([[0]])
 
@@ -878,7 +924,9 @@ class _RMSNorm(nn.Module):
         self.variance_epsilon = 1e-6
 
     def forward(self, x):
-        return x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.variance_epsilon) * self.weight
+        return (
+            x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.variance_epsilon) * self.weight
+        )
 
 
 class _MLAProjection(nn.Module):
@@ -897,7 +945,9 @@ class _MLAProjection(nn.Module):
     def forward(self, x):
         q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
         compressed = self.kv_a_proj_with_mqa(x)
-        kv, rope = compressed.split((self.kv_lora_rank, compressed.shape[-1] - self.kv_lora_rank), -1)
+        kv, rope = compressed.split(
+            (self.kv_lora_rank, compressed.shape[-1] - self.kv_lora_rank), -1
+        )
         kv = self.kv_b_proj(self.kv_a_layernorm(kv))
         return q, kv, rope
 
@@ -912,12 +962,8 @@ def test_runtime_mla_prefix_slice_matches_physical_projection_and_restores() -> 
     torch.manual_seed(9)
     layer = _MLALayer()
     x = torch.randn(5, 6, dtype=torch.float64)
-    teacher = BlockConfig(
-        subblock_configs=(MLAConfig(q_lora_rank=4, kv_lora_rank=3),)
-    )
-    child = BlockConfig(
-        subblock_configs=(MLAConfig(q_lora_rank=2, kv_lora_rank=1),)
-    )
+    teacher = BlockConfig(subblock_configs=(MLAConfig(q_lora_rank=4, kv_lora_rank=3),))
+    child = BlockConfig(subblock_configs=(MLAConfig(q_lora_rank=2, kv_lora_rank=1),))
     original = layer.self_attn(x)
 
     handle = apply_runtime_candidate(layer, teacher, child)
@@ -964,12 +1010,8 @@ def test_runtime_mla_head_slice_masks_sorted_o_proj_prefix_and_restores() -> Non
     torch.manual_seed(10)
     layer = _MLAHeadsLayer()
     head_outputs = torch.randn(7, 12, dtype=torch.float64)
-    teacher = BlockConfig(
-        subblock_configs=(MLAConfig(num_heads=4, q_lora_rank=8, kv_lora_rank=6),)
-    )
-    child = BlockConfig(
-        subblock_configs=(MLAConfig(num_heads=2, q_lora_rank=8, kv_lora_rank=6),)
-    )
+    teacher = BlockConfig(subblock_configs=(MLAConfig(num_heads=4, q_lora_rank=8, kv_lora_rank=6),))
+    child = BlockConfig(subblock_configs=(MLAConfig(num_heads=2, q_lora_rank=8, kv_lora_rank=6),))
     original = layer.self_attn(head_outputs)
 
     handle = apply_runtime_candidate(layer, teacher, child)
@@ -1076,7 +1118,7 @@ class _NativeFusedMambaLayer(nn.Module):
 
 @pytest.mark.parametrize(
     ("target_heads", "target_head_dim", "expected_projection", "expected_conv"),
-    ((2, 2, 14, 8), (4, 1, 16, 8)),
+    [(2, 2, 14, 8), (4, 1, 16, 8)],
 )
 def test_runtime_mamba_native_fused_call_uses_physically_compact_geometry(
     monkeypatch: pytest.MonkeyPatch,
@@ -1092,9 +1134,9 @@ def test_runtime_mamba_native_fused_call_uses_physically_compact_geometry(
         conv_weight,
         conv_bias,
         dt_bias,
-        A,
+        A,  # noqa: N803 - external fused-kernel parameter name
         *,
-        D,
+        D,  # noqa: N803 - external fused-kernel parameter name
         rmsnorm_weight,
         rmsnorm_eps,
         outproj_weight,
@@ -1119,9 +1161,7 @@ def test_runtime_mamba_native_fused_call_uses_physically_compact_geometry(
         gate = projected[..., :inner]
         value = projected[..., inner : 2 * inner]
         grouped = value.reshape(*value.shape[:-1], ngroups, -1)
-        grouped = grouped * torch.rsqrt(
-            grouped.square().mean(dim=-1, keepdim=True) + rmsnorm_eps
-        )
+        grouped = grouped * torch.rsqrt(grouped.square().mean(dim=-1, keepdim=True) + rmsnorm_eps)
         normalized = grouped.reshape_as(value) * rmsnorm_weight
         return torch.nn.functional.linear(
             normalized * torch.nn.functional.silu(gate),
@@ -1172,10 +1212,10 @@ def test_runtime_mamba_native_fused_call_uses_physically_compact_geometry(
 
 @pytest.mark.parametrize(
     ("target_heads", "target_head_dim", "keep_indices"),
-    (
+    [
         (2, 2, (0, 1, 4, 5)),
         (4, 1, (0, 2, 4, 6)),
-    ),
+    ],
 )
 def test_runtime_mamba_head_slice_matches_physically_compact_group_norm_and_restores(
     target_heads: int,
@@ -1186,9 +1226,7 @@ def test_runtime_mamba_head_slice_matches_physically_compact_group_norm_and_rest
     layer = _MambaLayer()
     x = torch.randn(7, 3, dtype=torch.float64)
     teacher = BlockConfig(
-        subblock_configs=(
-            MambaConfig(num_heads=4, head_dim=2, num_groups=2, state_dim=1),
-        )
+        subblock_configs=(MambaConfig(num_heads=4, head_dim=2, num_groups=2, state_dim=1),)
     )
     child = BlockConfig(
         subblock_configs=(
@@ -1278,12 +1316,8 @@ def test_runtime_attention_window_change_is_exact_and_reversible(target, expecte
             self.self_attn = Attention()
 
     layer = Layer()
-    teacher = BlockConfig(
-        subblock_configs=(AttentionConfig(sliding_window_size=512),)
-    )
-    child = BlockConfig(
-        subblock_configs=(AttentionConfig(sliding_window_size=target),)
-    )
+    teacher = BlockConfig(subblock_configs=(AttentionConfig(sliding_window_size=512),))
+    child = BlockConfig(subblock_configs=(AttentionConfig(sliding_window_size=target),))
 
     handle = apply_runtime_candidate(layer, teacher, child)
     assert layer.self_attn.sliding_window == expected

--- a/tests/unit/torch/puzzletron/test_compact_runtime.py
+++ b/tests/unit/torch/puzzletron/test_compact_runtime.py
@@ -40,8 +40,13 @@ from modelopt.torch.puzzletron.pruning.gated_delta_net import (
 )
 
 
+def _qwen_modeling():
+    return pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
+
+
 def _qwen_config(*, layer_type: str):
-    pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
+    _qwen_modeling()
+    # Optional dependency: Qwen3.5 is available only in newer transformers builds.
     from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
 
     return Qwen3_5TextConfig(
@@ -65,10 +70,10 @@ def _qwen_config(*, layer_type: str):
 
 
 def test_compact_grouped_attention_target_requires_reduced_supported_geometry():
-    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Attention
+    qwen_attention_cls = _qwen_modeling().Qwen3_5Attention
 
     config = _qwen_config(layer_type="full_attention")
-    attention = Qwen3_5Attention(config, 0)
+    attention = qwen_attention_cls(config, 0)
     layer = SimpleNamespace(self_attn=attention)
     teacher = SimpleNamespace(
         no_op=False,
@@ -96,6 +101,8 @@ def test_compact_grouped_attention_target_requires_reduced_supported_geometry():
 
 
 def test_compact_grouped_attention_rejects_native_automodel_backend():
+    # Optional dependency: native AutoModel Qwen modules are not installed in every test env.
+    pytest.importorskip("nemo_automodel.components.models.qwen3_next.layers")
     from nemo_automodel.components.models.common import BackendConfig
     from nemo_automodel.components.models.qwen3_next.layers import Qwen3NextAttention
     from transformers.models.qwen3_next.configuration_qwen3_next import Qwen3NextConfig
@@ -157,14 +164,15 @@ def test_compact_grouped_attention_matches_physical_projection_geometry(
     dtype: torch.dtype,
 ):
     from transformers.cache_utils import DynamicCache
-    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Attention
+
+    qwen_attention_cls = _qwen_modeling().Qwen3_5Attention
 
     teacher_config = _qwen_config(layer_type="full_attention")
-    teacher = Qwen3_5Attention(teacher_config, 0).to(dtype=dtype).eval()
+    teacher = qwen_attention_cls(teacher_config, 0).to(dtype=dtype).eval()
     target_config = deepcopy(teacher_config)
     target_config.num_attention_heads = target_num_q
     target_config.num_key_value_heads = target_num_kv
-    physical = Qwen3_5Attention(target_config, 0).to(dtype=dtype).eval()
+    physical = qwen_attention_cls(target_config, 0).to(dtype=dtype).eval()
 
     state = {name: tensor.detach().clone() for name, tensor in teacher.state_dict().items()}
     keep_q, keep_kv = sorted_attention_keep_indices(
@@ -227,6 +235,7 @@ def test_compact_grouped_attention_matches_physical_projection_geometry(
                 attention_mask,
             )[0]
 
+        # DynamicCache configs select attention types, not Q/K/V geometry; both are full attention.
         physical_cache = DynamicCache(config=target_config)
         runtime_cache = DynamicCache(config=teacher_config)
         physical_prefill = physical(
@@ -299,17 +308,18 @@ def test_compact_gdn_matches_physical_projection_and_kernel_geometry(
     dtype: torch.dtype,
 ):
     from transformers.cache_utils import DynamicCache
-    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
+
+    qwen_gdn_cls = _qwen_modeling().Qwen3_5GatedDeltaNet
 
     teacher_config = _qwen_config(layer_type="linear_attention")
-    teacher = Qwen3_5GatedDeltaNet(teacher_config, 0).to(dtype=dtype).eval()
+    teacher = qwen_gdn_cls(teacher_config, 0).to(dtype=dtype).eval()
     teacher_shape = GDNShape.from_module(teacher)
     target_config = deepcopy(teacher_config)
     target_config.linear_num_key_heads = target_shape.num_key_heads
     target_config.linear_num_value_heads = target_shape.num_value_heads
     target_config.linear_key_head_dim = target_shape.key_head_dim
     target_config.linear_value_head_dim = target_shape.value_head_dim
-    physical = Qwen3_5GatedDeltaNet(target_config, 0).to(dtype=dtype).eval()
+    physical = qwen_gdn_cls(target_config, 0).to(dtype=dtype).eval()
 
     state = {
         f"gdn.{name}": tensor.detach().clone() for name, tensor in teacher.state_dict().items()
@@ -369,3 +379,54 @@ def test_compact_gdn_matches_physical_projection_and_kernel_geometry(
     )
     assert GDNShape.from_module(teacher) == teacher_shape
     assert "forward" not in vars(teacher)
+
+
+@pytest.mark.parametrize(
+    "missing_attribute",
+    [
+        "causal_conv1d_fn",
+        "causal_conv1d_update",
+        "conv_kernel_size",
+        "activation",
+        "layer_idx",
+    ],
+)
+def test_compact_gdn_support_requires_every_forward_attribute(monkeypatch, missing_attribute):
+    qwen_gdn_cls = _qwen_modeling().Qwen3_5GatedDeltaNet
+
+    teacher = qwen_gdn_cls(_qwen_config(layer_type="linear_attention"), 0).eval()
+    teacher_shape = GDNShape.from_module(teacher)
+    monkeypatch.delattr(teacher, missing_attribute)
+
+    assert not supports_compact_gated_delta_net(teacher, teacher_shape=teacher_shape)
+
+
+def test_compact_gdn_rejects_cache_with_teacher_geometry():
+    from transformers.cache_utils import DynamicCache
+
+    qwen_gdn_cls = _qwen_modeling().Qwen3_5GatedDeltaNet
+
+    teacher_config = _qwen_config(layer_type="linear_attention")
+    teacher = qwen_gdn_cls(teacher_config, 0).eval()
+    teacher_shape = GDNShape.from_module(teacher)
+    target_shape = GDNShape(
+        num_key_heads=teacher_shape.num_key_heads,
+        num_value_heads=teacher_shape.num_value_heads,
+        key_head_dim=teacher_shape.key_head_dim // 2,
+        value_head_dim=teacher_shape.value_head_dim,
+    )
+    cache = DynamicCache(config=teacher_config)
+    hidden_states = torch.randn(1, 2, teacher_config.hidden_size)
+    next_hidden = torch.randn(1, 1, teacher_config.hidden_size)
+
+    with torch.no_grad():
+        teacher(hidden_states, cache_params=cache)
+        with (
+            compact_gated_delta_net_forward(
+                teacher,
+                teacher_shape=teacher_shape,
+                target_shape=target_shape,
+            ),
+            pytest.raises(ValueError, match="cache convolution width.*target geometry"),
+        ):
+            teacher(next_hidden, cache_params=cache)

--- a/tests/unit/torch/puzzletron/test_compact_runtime.py
+++ b/tests/unit/torch/puzzletron/test_compact_runtime.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for reversible compact Qwen attention and GDN runtime projections."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from modelopt.torch.puzzletron.pruning.attention_ffn_surgery import (
+    slice_attention_weights,
+    sorted_attention_keep_indices,
+)
+from modelopt.torch.puzzletron.pruning.compact_runtime import (
+    compact_gated_delta_net_forward,
+    compact_grouped_attention_forward,
+    resolve_compact_grouped_attention_target,
+)
+from modelopt.torch.puzzletron.pruning.gated_delta_net import (
+    GDNShape,
+    slice_gated_delta_net_state_dict,
+)
+
+
+def _qwen_config(*, layer_type: str):
+    pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+
+    return Qwen3_5TextConfig(
+        dtype=torch.float32,
+        hidden_size=32,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_conv_kernel_dim=4,
+        max_position_embeddings=32,
+        vocab_size=32,
+        layer_types=[layer_type],
+        attn_implementation="eager",
+    )
+
+
+def test_compact_grouped_attention_target_requires_reduced_supported_geometry():
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Attention
+
+    config = _qwen_config(layer_type="full_attention")
+    attention = Qwen3_5Attention(config, 0)
+    layer = SimpleNamespace(self_attn=attention)
+    teacher = SimpleNamespace(
+        no_op=False,
+        num_query_heads=4,
+        num_kv_heads=2,
+        qk_head_dim=8,
+    )
+    child = SimpleNamespace(
+        no_op=False,
+        num_query_heads=2,
+        num_kv_heads=1,
+    )
+
+    target = resolve_compact_grouped_attention_target(layer, teacher, child)
+
+    assert target == {
+        "module": attention,
+        "orig_num_q": 4,
+        "orig_num_kv": 2,
+        "target_num_q": 2,
+        "target_num_kv": 1,
+        "head_dim": 8,
+    }
+    assert resolve_compact_grouped_attention_target(layer, teacher, teacher) is None
+
+
+@pytest.mark.parametrize(("target_num_q", "target_num_kv"), [(2, 1), (2, 2)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["fp32", "bf16"])
+def test_compact_grouped_attention_matches_physical_projection_geometry(
+    target_num_q: int,
+    target_num_kv: int,
+    dtype: torch.dtype,
+):
+    from transformers.cache_utils import DynamicCache
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Attention
+
+    teacher_config = _qwen_config(layer_type="full_attention")
+    teacher = Qwen3_5Attention(teacher_config, 0).to(dtype=dtype).eval()
+    target_config = deepcopy(teacher_config)
+    target_config.num_attention_heads = target_num_q
+    target_config.num_key_value_heads = target_num_kv
+    physical = Qwen3_5Attention(target_config, 0).to(dtype=dtype).eval()
+
+    state = {name: tensor.detach().clone() for name, tensor in teacher.state_dict().items()}
+    keep_q, keep_kv = sorted_attention_keep_indices(
+        target_num_kv,
+        target_num_q // target_num_kv,
+        teacher_config.num_attention_heads // teacher_config.num_key_value_heads,
+    )
+    q, k, v, o = slice_attention_weights(
+        state["q_proj.weight"],
+        state["k_proj.weight"],
+        state["v_proj.weight"],
+        state["o_proj.weight"],
+        keep_q,
+        keep_kv,
+        teacher_config.head_dim,
+    )
+    state.update(
+        {
+            "q_proj.weight": q,
+            "k_proj.weight": k,
+            "v_proj.weight": v,
+            "o_proj.weight": o,
+        }
+    )
+    physical.load_state_dict(state)
+
+    hidden_states = torch.randn(1, 4, teacher_config.hidden_size, dtype=dtype)
+    position_embeddings = (
+        torch.ones(1, 4, teacher_config.head_dim, dtype=dtype),
+        torch.zeros(1, 4, teacher_config.head_dim, dtype=dtype),
+    )
+    attention_mask = torch.zeros(1, 1, 4, 4, dtype=dtype)
+    original_shapes = {name: tuple(tensor.shape) for name, tensor in teacher.state_dict().items()}
+
+    with torch.no_grad():
+        teacher_output = teacher(
+            hidden_states,
+            position_embeddings,
+            attention_mask,
+        )[0]
+        physical_output = physical(
+            hidden_states,
+            position_embeddings,
+            attention_mask,
+        )[0]
+        with compact_grouped_attention_forward(
+            teacher,
+            orig_num_q=4,
+            orig_num_kv=2,
+            target_num_q=target_num_q,
+            target_num_kv=target_num_kv,
+            head_dim=8,
+        ):
+            runtime_output = teacher(
+                hidden_states,
+                position_embeddings,
+                attention_mask,
+            )[0]
+
+        physical_cache = DynamicCache(config=target_config)
+        runtime_cache = DynamicCache(config=teacher_config)
+        physical_prefill = physical(
+            hidden_states,
+            position_embeddings,
+            attention_mask,
+            past_key_values=physical_cache,
+        )[0]
+        with compact_grouped_attention_forward(
+            teacher,
+            orig_num_q=4,
+            orig_num_kv=2,
+            target_num_q=target_num_q,
+            target_num_kv=target_num_kv,
+            head_dim=8,
+        ):
+            runtime_prefill = teacher(
+                hidden_states,
+                position_embeddings,
+                attention_mask,
+                past_key_values=runtime_cache,
+            )[0]
+            next_hidden = torch.randn(1, 1, teacher_config.hidden_size, dtype=dtype)
+            next_position_embeddings = (
+                torch.ones(1, 1, teacher_config.head_dim, dtype=dtype),
+                torch.zeros(1, 1, teacher_config.head_dim, dtype=dtype),
+            )
+            next_attention_mask = torch.zeros(1, 1, 1, 5, dtype=dtype)
+            runtime_decode = teacher(
+                next_hidden,
+                next_position_embeddings,
+                next_attention_mask,
+                past_key_values=runtime_cache,
+            )[0]
+        physical_decode = physical(
+            next_hidden,
+            next_position_embeddings,
+            next_attention_mask,
+            past_key_values=physical_cache,
+        )[0]
+        restored_output = teacher(
+            hidden_states,
+            position_embeddings,
+            attention_mask,
+        )[0]
+
+    assert torch.equal(runtime_output, physical_output)
+    assert torch.equal(runtime_prefill, physical_prefill)
+    assert torch.equal(runtime_decode, physical_decode)
+    assert torch.equal(restored_output, teacher_output)
+    assert {name: tuple(tensor.shape) for name, tensor in teacher.state_dict().items()} == (
+        original_shapes
+    )
+    assert teacher.num_key_value_groups == 2
+
+
+@pytest.mark.parametrize(
+    "target_shape",
+    [
+        GDNShape(num_key_heads=1, num_value_heads=2, key_head_dim=8, value_head_dim=8),
+        GDNShape(num_key_heads=2, num_value_heads=2, key_head_dim=8, value_head_dim=8),
+        GDNShape(num_key_heads=2, num_value_heads=4, key_head_dim=4, value_head_dim=8),
+        GDNShape(num_key_heads=2, num_value_heads=4, key_head_dim=8, value_head_dim=4),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["fp32", "bf16"])
+def test_compact_gdn_matches_physical_projection_and_kernel_geometry(
+    target_shape: GDNShape,
+    dtype: torch.dtype,
+):
+    from transformers.cache_utils import DynamicCache
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
+
+    teacher_config = _qwen_config(layer_type="linear_attention")
+    teacher = Qwen3_5GatedDeltaNet(teacher_config, 0).to(dtype=dtype).eval()
+    teacher_shape = GDNShape.from_module(teacher)
+    target_config = deepcopy(teacher_config)
+    target_config.linear_num_key_heads = target_shape.num_key_heads
+    target_config.linear_num_value_heads = target_shape.num_value_heads
+    target_config.linear_key_head_dim = target_shape.key_head_dim
+    target_config.linear_value_head_dim = target_shape.value_head_dim
+    physical = Qwen3_5GatedDeltaNet(target_config, 0).to(dtype=dtype).eval()
+
+    state = {
+        f"gdn.{name}": tensor.detach().clone() for name, tensor in teacher.state_dict().items()
+    }
+    slice_gated_delta_net_state_dict(
+        state,
+        prefix="gdn",
+        shape=teacher_shape,
+        target=target_shape,
+    )
+    physical.load_state_dict({name.removeprefix("gdn."): tensor for name, tensor in state.items()})
+    hidden_states = torch.randn(2, 4, teacher_config.hidden_size, dtype=dtype)
+    attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 0, 0]])
+    original_shapes = {name: tuple(tensor.shape) for name, tensor in teacher.state_dict().items()}
+
+    with torch.no_grad():
+        teacher_output = teacher(hidden_states, attention_mask=attention_mask)
+        physical_output = physical(hidden_states, attention_mask=attention_mask)
+        with compact_gated_delta_net_forward(
+            teacher,
+            teacher_shape=teacher_shape,
+            target_shape=target_shape,
+        ):
+            runtime_output = teacher(hidden_states, attention_mask=attention_mask)
+
+        physical_cache = DynamicCache(config=target_config)
+        runtime_cache = DynamicCache(config=teacher_config)
+        physical_prefill = physical(
+            hidden_states,
+            cache_params=physical_cache,
+            attention_mask=attention_mask,
+        )
+        with compact_gated_delta_net_forward(
+            teacher,
+            teacher_shape=teacher_shape,
+            target_shape=target_shape,
+        ):
+            runtime_prefill = teacher(
+                hidden_states,
+                cache_params=runtime_cache,
+                attention_mask=attention_mask,
+            )
+            next_hidden = torch.randn(2, 1, teacher_config.hidden_size, dtype=dtype)
+            runtime_decode = teacher(next_hidden, cache_params=runtime_cache)
+        physical_decode = physical(next_hidden, cache_params=physical_cache)
+        restored_output = teacher(hidden_states, attention_mask=attention_mask)
+
+    assert torch.equal(runtime_output, physical_output)
+    assert torch.equal(runtime_prefill, physical_prefill)
+    assert torch.equal(runtime_decode, physical_decode)
+    assert torch.equal(restored_output, teacher_output)
+    assert {name: tuple(tensor.shape) for name, tensor in teacher.state_dict().items()} == (
+        original_shapes
+    )
+    assert GDNShape.from_module(teacher) == teacher_shape

--- a/tests/unit/torch/puzzletron/test_compact_runtime.py
+++ b/tests/unit/torch/puzzletron/test_compact_runtime.py
@@ -31,6 +31,8 @@ from modelopt.torch.puzzletron.pruning.compact_runtime import (
     compact_gated_delta_net_forward,
     compact_grouped_attention_forward,
     resolve_compact_grouped_attention_target,
+    supports_compact_gated_delta_net,
+    supports_compact_grouped_attention,
 )
 from modelopt.torch.puzzletron.pruning.gated_delta_net import (
     GDNShape,
@@ -93,6 +95,60 @@ def test_compact_grouped_attention_target_requires_reduced_supported_geometry():
     assert resolve_compact_grouped_attention_target(layer, teacher, teacher) is None
 
 
+def test_compact_grouped_attention_rejects_native_automodel_backend():
+    from nemo_automodel.components.models.common import BackendConfig
+    from nemo_automodel.components.models.qwen3_next.layers import Qwen3NextAttention
+    from transformers.models.qwen3_next.configuration_qwen3_next import Qwen3NextConfig
+
+    config = Qwen3NextConfig(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+        layer_types=["full_attention"],
+    )
+    config.head_dim = 8
+    backend = BackendConfig(
+        linear="torch",
+        attn="sdpa",
+        rms_norm="torch",
+        rope_fusion=False,
+        experts="torch",
+        dispatcher="torch",
+        enable_hf_state_dict_adapter=False,
+    )
+    attention = Qwen3NextAttention(config, layer_idx=0, backend=backend)
+    layer = SimpleNamespace(self_attn=attention)
+    teacher = SimpleNamespace(
+        no_op=False,
+        num_query_heads=4,
+        num_kv_heads=2,
+        qk_head_dim=8,
+    )
+    child = SimpleNamespace(
+        no_op=False,
+        num_query_heads=2,
+        num_kv_heads=1,
+    )
+    original_forward = attention.forward.__func__
+    original_state = set(vars(attention))
+
+    assert not supports_compact_grouped_attention(
+        attention,
+        orig_num_q=4,
+        orig_num_kv=2,
+        head_dim=8,
+    )
+    with pytest.raises(RuntimeError, match="refusing to score reduced geometry"):
+        resolve_compact_grouped_attention_target(layer, teacher, child)
+
+    assert attention.forward.__func__ is original_forward
+    assert set(vars(attention)) == original_state
+
+
 @pytest.mark.parametrize(("target_num_q", "target_num_kv"), [(2, 1), (2, 2)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["fp32", "bf16"])
 def test_compact_grouped_attention_matches_physical_projection_geometry(
@@ -142,6 +198,8 @@ def test_compact_grouped_attention_matches_physical_projection_geometry(
     )
     attention_mask = torch.zeros(1, 1, 4, 4, dtype=dtype)
     original_shapes = {name: tuple(tensor.shape) for name, tensor in teacher.state_dict().items()}
+    projection_modules = (teacher.q_proj, teacher.k_proj, teacher.v_proj, teacher.o_proj)
+    assert all("forward" not in vars(module) for module in projection_modules)
 
     with torch.no_grad():
         teacher_output = teacher(
@@ -162,6 +220,7 @@ def test_compact_grouped_attention_matches_physical_projection_geometry(
             target_num_kv=target_num_kv,
             head_dim=8,
         ):
+            assert all("forward" in vars(module) for module in projection_modules)
             runtime_output = teacher(
                 hidden_states,
                 position_embeddings,
@@ -222,6 +281,7 @@ def test_compact_grouped_attention_matches_physical_projection_geometry(
         original_shapes
     )
     assert teacher.num_key_value_groups == 2
+    assert all("forward" not in vars(module) for module in projection_modules)
 
 
 @pytest.mark.parametrize(
@@ -264,6 +324,8 @@ def test_compact_gdn_matches_physical_projection_and_kernel_geometry(
     hidden_states = torch.randn(2, 4, teacher_config.hidden_size, dtype=dtype)
     attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 0, 0]])
     original_shapes = {name: tuple(tensor.shape) for name, tensor in teacher.state_dict().items()}
+    assert supports_compact_gated_delta_net(teacher, teacher_shape=teacher_shape)
+    assert "forward" not in vars(teacher)
 
     with torch.no_grad():
         teacher_output = teacher(hidden_states, attention_mask=attention_mask)
@@ -273,6 +335,7 @@ def test_compact_gdn_matches_physical_projection_and_kernel_geometry(
             teacher_shape=teacher_shape,
             target_shape=target_shape,
         ):
+            assert "forward" in vars(teacher)
             runtime_output = teacher(hidden_states, attention_mask=attention_mask)
 
         physical_cache = DynamicCache(config=target_config)
@@ -305,3 +368,4 @@ def test_compact_gdn_matches_physical_projection_and_kernel_geometry(
         original_shapes
     )
     assert GDNShape.from_module(teacher) == teacher_shape
+    assert "forward" not in vars(teacher)

--- a/tests/unit/torch/puzzletron/test_width_slice_equivalence.py
+++ b/tests/unit/torch/puzzletron/test_width_slice_equivalence.py
@@ -31,7 +31,12 @@ from transformers import LlamaForCausalLM
 from modelopt.torch.puzzletron.anymodel.models.llama.llama_model_descriptor import (
     LlamaModelDescriptor,
 )
-from modelopt.torch.puzzletron.block_config import AttentionConfig, BlockConfig, FFNConfig
+from modelopt.torch.puzzletron.block_config import (
+    AttentionConfig,
+    BlockConfig,
+    FFNConfig,
+    MambaConfig,
+)
 from modelopt.torch.puzzletron.dataset import DataLayout, PuzzletronBatch, batch_from_automodel
 from modelopt.torch.puzzletron.diagnostics import width_slice_equivalence as width_slice_module
 from modelopt.torch.puzzletron.diagnostics.width_slice_equivalence import (
@@ -376,7 +381,7 @@ def test_tiny_qwen_checkpoint_executes_compact_attention_and_gdn_axes(tmp_path: 
         descriptor=CompactRuntimeQwenDescriptor,
         sorted_checkpoint_dir=checkpoint,
         batch=batch,
-        artifact_dir=tmp_path / "qwen-artifacts",
+        artifact_dir=tmp_path / "qwen-compact-runtime-artifacts",
     )
 
     assert summary["passed"] is True
@@ -754,6 +759,73 @@ def test_axis_structure_rejects_unrelated_tensor_shape_change():
     )
 
     assert evidence == {}
+
+
+@pytest.mark.parametrize(
+    ("axis_id", "target_mamba", "source_value", "target_value"),
+    [
+        (
+            "gdn_key_head_dim",
+            MambaConfig(num_heads=4, head_dim=8, num_groups=2, state_dim=4),
+            8,
+            4,
+        ),
+        (
+            "gdn_value_head_dim",
+            MambaConfig(num_heads=4, head_dim=4, num_groups=2, state_dim=8),
+            8,
+            4,
+        ),
+        (
+            "gdn_value_heads_per_group",
+            MambaConfig(num_heads=2, head_dim=8, num_groups=2, state_dim=8),
+            2,
+            1,
+        ),
+    ],
+)
+def test_axis_structure_accepts_coupled_gdn_projection_width(
+    axis_id,
+    target_mamba,
+    source_value,
+    target_value,
+):
+    source = BlockConfig(
+        subblock_configs=(MambaConfig(num_heads=4, head_dim=8, num_groups=2, state_dim=8),)
+    )
+    target = BlockConfig(subblock_configs=(target_mamba,))
+    case = WidthSliceCase(
+        case_identity="gdn-shape",
+        axis_id=axis_id,
+        axis_class="block::hook",
+        scope="global",
+        layers=(0,),
+        source_value=source_value,
+        target_value=target_value,
+        subblock_kind="mamba",
+        field="shape",
+        source_block_config=source,
+        target_block_config=target,
+        expected_structure={},
+        implementation_provenance={},
+    )
+    before = {"model.layers.0.linear_attn.in_proj_qkv.weight": [64, 32]}
+    after = {"model.layers.0.linear_attn.in_proj_qkv.weight": [48, 32]}
+
+    evidence = width_slice_module._axis_specific_changed_shapes(
+        before,
+        after,
+        descriptor=LlamaModelDescriptor,
+        case=case,
+        num_layers=1,
+    )
+
+    assert evidence == {
+        "model.layers.0.linear_attn.in_proj_qkv.weight": {
+            "before": [64, 32],
+            "after": [48, 32],
+        }
+    }
 
 
 def test_artifact_validation_detects_deleted_case(tmp_path: Path):

--- a/tests/unit/torch/puzzletron/test_width_slice_equivalence.py
+++ b/tests/unit/torch/puzzletron/test_width_slice_equivalence.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Tests for width-slice equivalence evidence and stage integration."""
 
@@ -294,7 +306,7 @@ def test_tiny_qwen_checkpoint_executes_inherited_materialize_and_runtime_hooks(t
         descriptor=FFNOnlyQwenDescriptor,
         sorted_checkpoint_dir=checkpoint,
         batch=batch,
-        artifact_dir=tmp_path / "qwen-artifacts",
+        artifact_dir=tmp_path / "qwen-ffn-artifacts",
         tolerances={
             "loss_atol": 2.0e-3,
             "loss_rtol": 2.0e-3,
@@ -305,6 +317,70 @@ def test_tiny_qwen_checkpoint_executes_inherited_materialize_and_runtime_hooks(t
 
     assert summary["passed"] is True
     assert len(summary["cases"]) == 2
+    assert all(case["target_applied"] for case in summary["cases"])
+    assert all(case["runtime_hook_executions"] > 0 for case in summary["cases"])
+
+
+def test_tiny_qwen_checkpoint_executes_compact_attention_and_gdn_axes(tmp_path: Path):
+    pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
+    from modelopt.torch.puzzletron.anymodel.models.qwen3_5.qwen3_5_converter import Qwen3P5Converter
+    from modelopt.torch.puzzletron.anymodel.models.qwen3_5.qwen3_5_model_descriptor import (
+        Qwen3P5TextModelDescriptor,
+    )
+
+    checkpoint = create_tiny_qwen3_5_dir(
+        tmp_path,
+        layer_types=["linear_attention", "linear_attention", "full_attention", "full_attention"],
+    )
+    config = load_model_config(checkpoint)
+    Qwen3P5TextModelDescriptor.set_block_configs(
+        config,
+        Qwen3P5Converter.create_block_configs_from_main_config(config),
+    )
+    config.block_configs = [block.to_dict() for block in config.block_configs]
+    config.save_pretrained(checkpoint)
+
+    expected_axes = {
+        "gdn_key_groups",
+        "gdn_key_head_dim",
+        "gdn_value_head_dim",
+        "gdn_value_heads_per_group",
+        "kv_groups",
+        "query_heads",
+    }
+
+    class CompactRuntimeQwenDescriptor(Qwen3P5TextModelDescriptor):
+        @classmethod
+        def puzzletron_capabilities(cls, loaded_config):
+            capabilities = super().puzzletron_capabilities(loaded_config)
+            return replace(
+                capabilities,
+                descriptor_name="qwen-compact-runtime-equivalence-test",
+                axes={axis_id: capabilities.axes[axis_id] for axis_id in expected_axes},
+            )
+
+    batch = normalize_width_slice_batch(
+        {
+            "input_ids": torch.tensor([[1, 2, 3, 4]]),
+            "labels": torch.tensor([[1, 2, 3, 4]]),
+            "attention_mask": torch.ones(1, 4, dtype=torch.long),
+        },
+        descriptor=CompactRuntimeQwenDescriptor,
+        checkpoint_config=config,
+        layout=DataLayout.FIXED,
+        sample_ids=("sample-0",),
+        source_metadata={"dataset": "fixture", "revision": "v1"},
+    )
+
+    summary = evaluate_width_slice_equivalence(
+        descriptor=CompactRuntimeQwenDescriptor,
+        sorted_checkpoint_dir=checkpoint,
+        batch=batch,
+        artifact_dir=tmp_path / "qwen-artifacts",
+    )
+
+    assert summary["passed"] is True
+    assert {case["axis_id"] for case in summary["cases"]} == expected_axes
     assert all(case["target_applied"] for case in summary["cases"])
     assert all(case["runtime_hook_executions"] > 0 for case in summary["cases"])
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Puzzletron scores reduced Qwen grouped-attention and GatedDeltaNet candidates on the sorted teacher, then compares them with physically materialized checkpoints. The runtime path previously kept the teacher projection and kernel geometry and approximated reductions with masks. That is not equivalent to a physically compact model: attention grouping changes the packed projection layout, while GatedDeltaNet head and head-dimension reductions change convolution groups, kernel tensor shapes, normalization width, and recurrent-state geometry. This made candidate scores unreliable and caused the `gdn_key_head_dim` equivalence diagnostic to reject the materialized shape change.

This change executes supported Transformers Qwen attention and GatedDeltaNet candidates with reversible compact projection and kernel geometry, restores teacher modules after scoring, and fails closed for native AutoModel modules whose packed-sequence, context-parallel, FSDP, or attention-backend semantics cannot be preserved by these helpers. It also recognizes the exact coupled GatedDeltaNet projection-width transition in equivalence diagnostics. It adds pinned-runtime coverage for FP32 and BF16, uncached forwards, cache prefill and decode, padded batches, restoration, and every attention and GatedDeltaNet axis owned by this correction, while preserving the existing Qwen FFN integration test.

### Testing

The dedicated Puzzletron v2 CPU CI lane exercises the compact-runtime unit cases and end-to-end Qwen width-slice equivalence coverage in the pinned runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compact runtime support for grouped attention and gated delta-net components.
  - Enabled reduced-width execution across supported configurations, including cached decoding and masking scenarios.
  - Added validation and safe restoration of original runtime behavior.

- **Bug Fixes**
  - Improved width and shape validation for gated delta-net configurations.
  - Prevented unsupported model backends from accepting incompatible compact candidates.

- **Tests**
  - Added coverage for numerical equivalence, data types, cache paths, target geometries, and runtime restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->