### PR TITLE
Fix resolved configuration edge cases

### DIFF
--- a/puzzletron_setup/v2/bundle.py
+++ b/puzzletron_setup/v2/bundle.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import yaml
+import yaml  # type: ignore[import-untyped, unused-ignore]
 
 from puzzletron_setup import SetupError
 from puzzletron_setup.bundle import (
@@ -235,8 +235,15 @@ def _render_experiment_v2(
     if config.post_mip_flows_configured:
         rendered["post_mip"] = {"flows": deepcopy(flows)}
 
+    batch_mirrors = {
+        "pruning.micro_batch_size": "data.calibration.micro_batch_size",
+        "replacement_scoring.micro_batch_size": "data.replacement_scoring.micro_batch_size",
+    }
     for dotted, value in config.stage_batches.items():
         _set_dotted(rendered, str(dotted), value)
+        mirrored = batch_mirrors.get(str(dotted))
+        if mirrored is not None:
+            _set_dotted(rendered, mirrored, value)
     parallel_paths = {
         "depth_importance": "depth_importance.automodel.parallel",
         "width_importance": "pruning.automodel.parallel",

--- a/puzzletron_setup/v2/defaults.py
+++ b/puzzletron_setup/v2/defaults.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped, unused-ignore]
 
 from puzzletron_setup import WORKER_REPOSITORY_PLACEHOLDER, WORKER_VENV_PLACEHOLDER, SetupError
 

--- a/puzzletron_setup/v2/resolved.py
+++ b/puzzletron_setup/v2/resolved.py
@@ -603,13 +603,7 @@ def resolve_campaign_config(state: WizardState) -> ResolvedCampaignConfig:
     payload = deepcopy(state.payload)
     collections = _mapping(payload.get("collections"))
     field_records = {
-        str(path): {
-            "value": deepcopy(record.value),
-            "source": str(record.source),
-            "requested": deepcopy(record.requested),
-            "effective": deepcopy(record.effective),
-        }
-        for path, record in state.records().items()
+        str(path): record.to_dict() for path, record in state.records().items()
     }
 
     def effective(path: str, default: Any = _USE_BUILTIN_DEFAULT) -> Any:

--- a/puzzletron_setup/v2/resolved.py
+++ b/puzzletron_setup/v2/resolved.py
@@ -602,9 +602,7 @@ def resolve_campaign_config(state: WizardState) -> ResolvedCampaignConfig:
     """Resolve one mutable wizard state into an immutable campaign snapshot."""
     payload = deepcopy(state.payload)
     collections = _mapping(payload.get("collections"))
-    field_records = {
-        str(path): record.to_dict() for path, record in state.records().items()
-    }
+    field_records = {str(path): record.to_dict() for path, record in state.records().items()}
 
     def effective(path: str, default: Any = _USE_BUILTIN_DEFAULT) -> Any:
         record = field_records.get(path)

--- a/puzzletron_setup/v2/wizard.py
+++ b/puzzletron_setup/v2/wizard.py
@@ -588,11 +588,10 @@ def data_section(
                 "from the completed stage configuration."
             )
         else:
-            if not selected_subsets or subset_selection is None or acquisition is None:
+            if not selected_subsets or subset_selection is None:
                 raise SetupError(
                     "Nemotron-VLM v2 requires at least one selectable hosted-media subset."
                 )
-            assert subset_selection is not None
             subset_media_shards = {
                 record["name"]: record["num_media_shards"]
                 for record in subset_selection["subsets"]

--- a/tests/unit/torch/puzzletron/test_setup_v2_resolved_config.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_resolved_config.py
@@ -26,6 +26,7 @@ import pytest
 import yaml
 
 import puzzletron_setup.v2.bundle as bundle_module
+from puzzletron_setup.bundle import BundleValidation
 from puzzletron_setup.v2.bundle import (
     build_bundles_v2,
     render_execution_v2,
@@ -345,6 +346,22 @@ def test_resolved_sections_take_precedence_over_compatibility_overrides(tmp_path
     assert experiment["pruning"]["automodel"]["parallel"]["tp"] == 2
 
 
+def test_stage_batches_update_shared_data_sections(tmp_path: Path) -> None:
+    state = _campaign_state(tmp_path)
+    state.set_collection(
+        "stage_batches",
+        {
+            "pruning.micro_batch_size": 7,
+            "replacement_scoring.micro_batch_size": 5,
+        },
+    )
+
+    experiment = render_experiment_v2(state, "production")
+
+    assert experiment["data"]["calibration"]["micro_batch_size"] == 7
+    assert experiment["data"]["replacement_scoring"]["micro_batch_size"] == 5
+
+
 def test_runner_compatibility_override_is_applied_to_resolved_runner(tmp_path: Path) -> None:
     state = _campaign_state(tmp_path)
 
@@ -452,10 +469,9 @@ def test_build_freezes_one_snapshot_before_rendering_both_budgets(
     monkeypatch,
 ) -> None:
     state = _campaign_state(tmp_path)
-
     real_validate_bundle = bundle_module.validate_bundle
 
-    def mutate_state_after_smoke(path: Path):
+    def mutate_state_after_smoke(path: Path) -> BundleValidation:
         if path.name == "smoke":
             state.set_field("stages.width_importance.batch", 99, source="user")
             state.set_collection("stage_batches", {"pruning.micro_batch_size": 99})

--- a/tests/unit/torch/puzzletron/test_setup_v2_resolved_config.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_resolved_config.py
@@ -21,12 +21,12 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import FrozenInstanceError
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 
 import puzzletron_setup.v2.bundle as bundle_module
-from puzzletron_setup.bundle import BundleValidation
 from puzzletron_setup.v2.bundle import (
     build_bundles_v2,
     render_execution_v2,
@@ -35,6 +35,9 @@ from puzzletron_setup.v2.bundle import (
 )
 from puzzletron_setup.v2.resolved import resolve_campaign_config
 from puzzletron_setup.v2.state import WizardState
+
+if TYPE_CHECKING:
+    from puzzletron_setup.bundle import BundleValidation
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

This is a focused follow-up to [#2163](https://github.com/NVIDIA/Model-Optimizer/pull/2163), which consolidated Puzzletron's resolved configuration. It fixes edge cases in the compatibility renderer: stage-owned pruning and replacement-scoring batch sizes now update the shared data sections consumed by existing runtime paths. Resolved field records reuse their normalized serialization, and redundant validation branches are removed.

The PyYAML imports also carry the annotations required by the repository's type-checking configuration.

### Testing

Adds focused unit coverage for mirroring stage batch sizes into the shared data configuration. Existing resolved-configuration tests cover snapshot serialization, compatibility rendering, and bundle validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Experiment configuration rendering now correctly applies stage batch settings to calibration and replacement-scoring sections.
  * Configuration resolution more reliably preserves complete state information when determining effective values.
  * Improved dataset validation for Nemotron-VLM configurations by accepting valid subset selections without requiring unrelated acquisition details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->