### PR TITLE
Harden Puzzletron CI quality checks

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -27,6 +27,7 @@ jobs:
         modelopt/**
         noxfile.py
         pyproject.toml
+        tests/_test_utils/torch/distributed/**
         tests/gpu/**
         tests/gpu_megatron/**
         tests/gpu_trtllm/**

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     outputs:
-      any_changed: ${{ steps.changed.outputs.any_changed || steps.non-pr.outputs.any_changed }}
+      any_changed: ${{ steps.changed.outputs.any_modified || steps.non-pr.outputs.any_changed }}
       puzzletron_changed: >-
         ${{ steps.puzzletron_base.outputs.any_changed ||
           steps.puzzletron_changed.outputs.any_modified ||

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,6 +13,7 @@ on:
       - "pyproject.toml"
       - "puzzletron_orchestrator/**"
       - "puzzletron_setup/**"
+      - "tests/_test_utils/torch/distributed/**"
       - "tests/unit/**"
       - "tools/launcher/**"
       - ".agents/skills/**"
@@ -71,6 +72,7 @@ jobs:
             modelopt/**
             noxfile.py
             pyproject.toml
+            tests/_test_utils/torch/distributed/**
             tests/unit/**
             tools/launcher/**
             .agents/skills/**
@@ -94,6 +96,7 @@ jobs:
             pyproject.toml
             puzzletron_orchestrator/**
             puzzletron_setup/**
+            tests/_test_utils/torch/distributed/**
             tests/unit/torch/puzzletron/**
   puzzletron_v2:
     name: Puzzletron v2 CPU tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -274,6 +274,8 @@ def pre_commit_diff(session):
     if changed_python_files:
         session.run(
             "mypy",
+            "--cache-dir",
+            os.devnull,
             "--follow-imports=skip",
             "--ignore-missing-imports",
             *changed_python_files,

--- a/tests/_test_utils/torch/distributed/utils.py
+++ b/tests/_test_utils/torch/distributed/utils.py
@@ -15,7 +15,9 @@
 
 import os
 import socket
+import time
 import traceback
+from contextlib import contextmanager, nullcontext
 
 import torch
 import torch.distributed as dist
@@ -46,27 +48,89 @@ def init_process(rank, size, job=None, backend="gloo", port=None):
     os.environ["MASTER_PORT"] = port
 
     dist.init_process_group(backend, rank=rank, world_size=size)
-    if backend == "nccl" and torch.cuda.is_available():
-        torch.cuda.set_device(rank)
-    torch.manual_seed(1234)
-    if job is not None:
-        job(rank, size)
+    try:
+        if backend == "nccl" and torch.cuda.is_available():
+            torch.cuda.set_device(rank)
+        torch.manual_seed(1234)
+        if job is not None:
+            job(rank, size)
+    finally:
+        # ``job is None`` is the fixture mode: its caller owns the process
+        # group and tears it down after yielding. Spawned one-shot workers own
+        # their group here and must not leave Gloo/NCCL resources behind.
+        if job is not None and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _reap_processes(processes, timeout=10):
+    """Terminate and reap every started child without masking an active error."""
+
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+    deadline = time.monotonic() + timeout
+    for process in processes:
+        process.join(timeout=max(0, deadline - time.monotonic()))
+    stubborn_processes = [process for process in processes if process.is_alive()]
+    for process in stubborn_processes:
+        process.kill()
+    deadline = time.monotonic() + timeout
+    for process in stubborn_processes:
+        process.join(timeout=max(0, deadline - time.monotonic()))
+
+
+@contextmanager
+def _without_subprocess_coverage():
+    """Keep spawned Gloo workers below the unit timeout while preserving parent coverage."""
+
+    key = "COVERAGE_PROCESS_START"
+    previous = os.environ.pop(key, None)
+    try:
+        yield
+    finally:
+        if previous is not None:
+            os.environ[key] = previous
+        else:
+            os.environ.pop(key, None)
 
 
 def spawn_multiprocess_job(size, job, backend="gloo"):
     port = get_free_port()
     ctx = mp.get_context("spawn")
     processes = []
-    for rank in range(size):
-        p = ctx.Process(target=init_process, args=(rank, size, job, backend, port))
-        p.start()
-        processes.append(p)
+    try:
+        # Coverage auto-start makes these short-lived CPU workers trace their
+        # full import graph and pushes each Gloo test beyond the 60-second unit
+        # cap. The parent remains covered and validates every worker result;
+        # other backends retain their existing child-coverage behavior.
+        coverage_context = _without_subprocess_coverage() if backend == "gloo" else nullcontext()
+        with coverage_context:
+            for rank in range(size):
+                process = ctx.Process(
+                    target=init_process,
+                    args=(rank, size, job, backend, port),
+                )
+                process.start()
+                processes.append(process)
 
-    for p in processes:
-        p.join()
-
-        # Ensure that all processes have exited successfully
-        assert not p.exitcode
+        for process in processes:
+            process.join()
+            if process.exitcode != 0:
+                raise RuntimeError(f"distributed worker exited with code {process.exitcode}")
+    except BaseException as primary_error:
+        # pytest-timeout and worker failures can interrupt ``join``. Always
+        # reap the remaining children so one failed test cannot poison the
+        # rest of the suite with orphaned process groups.
+        try:
+            _reap_processes(processes)
+        except BaseException as cleanup_error:
+            if hasattr(primary_error, "add_note"):
+                primary_error.add_note(f"distributed child cleanup also failed: {cleanup_error!r}")
+            else:
+                primary_error.__cause__ = cleanup_error
+        raise
+    else:
+        _reap_processes(processes)
 
 
 def default_worker_teardown(rank, world_size):

--- a/tests/_test_utils/torch/distributed/utils.py
+++ b/tests/_test_utils/torch/distributed/utils.py
@@ -15,9 +15,9 @@
 
 import os
 import socket
-import time
 import traceback
 from contextlib import contextmanager, nullcontext
+from time import monotonic
 
 import torch
 import torch.distributed as dist
@@ -68,15 +68,15 @@ def _reap_processes(processes, timeout=10):
     for process in processes:
         if process.is_alive():
             process.terminate()
-    deadline = time.monotonic() + timeout
+    deadline = monotonic() + timeout
     for process in processes:
-        process.join(timeout=max(0, deadline - time.monotonic()))
+        process.join(timeout=max(0, deadline - monotonic()))
     stubborn_processes = [process for process in processes if process.is_alive()]
     for process in stubborn_processes:
         process.kill()
-    deadline = time.monotonic() + timeout
+    deadline = monotonic() + timeout
     for process in stubborn_processes:
-        process.join(timeout=max(0, deadline - time.monotonic()))
+        process.join(timeout=max(0, deadline - monotonic()))
 
 
 @contextmanager

--- a/tests/unit/torch/puzzletron/test_import_boundary.py
+++ b/tests/unit/torch/puzzletron/test_import_boundary.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -31,6 +32,11 @@ pytestmark = pytest.mark.skipif(
 
 
 def _run_without_automodel(script: str) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    # These probes validate fresh-interpreter import behavior. Coverage
+    # auto-start traces the entire child import graph and exceeds the unit
+    # suite's 60-second cap before the probe can return.
+    environment.pop("COVERAGE_PROCESS_START", None)
     return subprocess.run(
         [
             sys.executable,
@@ -38,6 +44,7 @@ def _run_without_automodel(script: str) -> subprocess.CompletedProcess[str]:
             "import sys; sys.modules['nemo_automodel'] = None; " + script,
         ],
         cwd=REPOSITORY_ROOT,
+        env=environment,
         capture_output=True,
         text=True,
         check=False,

--- a/tests/unit/torch/puzzletron/test_stage_graph.py
+++ b/tests/unit/torch/puzzletron/test_stage_graph.py
@@ -28,15 +28,21 @@ from modelopt.torch.puzzletron.stages.graph import (
     topological_stage_ids,
 )
 
-# Frozen compatibility oracle copied from the removed semantic-section table.
-_PRIOR_SEMANTIC_CONFIG_SECTIONS = {
+# Frozen compatibility oracle for the reviewed semantic projection contract.
+_EXPECTED_SEMANTIC_CONFIG_SECTIONS = {
     "convert": ("convert",),
     "tokenize_data": (
         "tokenize_data",
         "convert",
+        "data",
         "dataset_path",
+        "train_token_cache_path",
+        "validation_token_cache_path",
         "pruning",
         "replacement_scoring",
+        "depth_importance",
+        "sort_sanity",
+        "width_sanity",
     ),
     "width_importance": ("width_importance", "pruning"),
     "sort": ("sort", "pruning"),
@@ -114,14 +120,14 @@ def test_registry_owns_explicit_semantic_sections_and_preserves_projection() -> 
     sections = set(SHARED_SEMANTIC_CONFIG_SECTIONS)
     sections.update(
         section
-        for stage_sections in _PRIOR_SEMANTIC_CONFIG_SECTIONS.values()
+        for stage_sections in _EXPECTED_SEMANTIC_CONFIG_SECTIONS.values()
         for section in stage_sections
     )
     config = {section: {"value": section} for section in sections}
     config["report"] = {"excluded": True}
 
-    assert set(_PRIOR_SEMANTIC_CONFIG_SECTIONS) == set(STAGE_REGISTRY)
-    for stage_id, expected_sections in _PRIOR_SEMANTIC_CONFIG_SECTIONS.items():
+    assert set(_EXPECTED_SEMANTIC_CONFIG_SECTIONS) == set(STAGE_REGISTRY)
+    for stage_id, expected_sections in _EXPECTED_SEMANTIC_CONFIG_SECTIONS.items():
         spec = STAGE_REGISTRY[stage_id]
         assert spec.semantic_config_sections == expected_sections
         expected_projection = {

--- a/tests/unit/torch/puzzletron/test_stage_terminal_contract.py
+++ b/tests/unit/torch/puzzletron/test_stage_terminal_contract.py
@@ -271,21 +271,16 @@ def test_direct_tokenize_data_stage_runs_when_enabled(tmp_path, monkeypatch, wri
     assert result.skip_reason is None
 
 
-def test_enabled_tokenize_data_stage_rejects_empty_success_manifest(
-    tmp_path, write_terminal_manifest
-):
+def test_enabled_tokenize_data_stage_rejects_empty_success_manifest(tmp_path):
     config = _config(
         tmp_path,
         dataset_path="dataset",
         convert={"teacher_dir": str(tmp_path / "ckpts" / "teacher")},
         tokenize_data={"enabled": True, "caches": []},
     )
-    write_terminal_manifest(
-        tmp_path,
-        "tokenize_data",
-        config=config,
-        outputs={"caches": []},
-    )
+    manifest = StageManifest(stage="tokenize_data", config=config)
+    manifest.complete(outputs={"caches": []})
+    write_stage_manifest(tmp_path / "manifests" / "tokenize_data.json", manifest)
 
     assert not stage_is_complete(config, "tokenize_data")
     assert not _completion_is_valid(config, tmp_path / "config.yaml", "tokenize_data")

--- a/tests/unit/torch/puzzletron/test_stage_terminal_contract.py
+++ b/tests/unit/torch/puzzletron/test_stage_terminal_contract.py
@@ -271,7 +271,8 @@ def test_direct_tokenize_data_stage_runs_when_enabled(tmp_path, monkeypatch, wri
     assert result.skip_reason is None
 
 
-def test_enabled_tokenize_data_stage_rejects_empty_success_manifest(tmp_path):
+def test_enabled_tokenize_data_stage_rejects_empty_success_manifest(tmp_path, monkeypatch):
+    monkeypatch.setenv("RANK", "0")
     config = _config(
         tmp_path,
         dataset_path="dataset",
@@ -280,7 +281,9 @@ def test_enabled_tokenize_data_stage_rejects_empty_success_manifest(tmp_path):
     )
     manifest = StageManifest(stage="tokenize_data", config=config)
     manifest.complete(outputs={"caches": []})
-    write_stage_manifest(tmp_path / "manifests" / "tokenize_data.json", manifest)
+    manifest_path = tmp_path / "manifests" / "tokenize_data.json"
+    write_stage_manifest(manifest_path, manifest)
+    assert manifest_path.exists()
 
     assert not stage_is_complete(config, "tokenize_data")
     assert not _completion_is_valid(config, tmp_path / "config.yaml", "tokenize_data")

--- a/tests/unit/torch/test_distributed_test_utils.py
+++ b/tests/unit/torch/test_distributed_test_utils.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for bounded cleanup in shared distributed test helpers."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+from _test_utils.torch.distributed import utils
+
+
+@pytest.mark.parametrize("raises", [False, True], ids=("success", "failure"))
+def test_init_process_destroys_one_shot_process_group(monkeypatch, raises):
+    events = []
+    initialized = False
+
+    def init_process_group(*_args, **_kwargs):
+        nonlocal initialized
+        initialized = True
+        events.append("initialized")
+
+    def destroy_process_group():
+        nonlocal initialized
+        initialized = False
+        events.append("destroyed")
+
+    def job(_rank, _size):
+        events.append("job")
+        if raises:
+            raise RuntimeError("worker failed")
+
+    for name in (
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "RANK",
+        "LOCAL_RANK",
+        "WORLD_SIZE",
+        "LOCAL_WORLD_SIZE",
+        "WANDB_DISABLED",
+    ):
+        monkeypatch.setenv(name, "")
+    monkeypatch.setattr(utils.dist, "init_process_group", init_process_group)
+    monkeypatch.setattr(utils.dist, "destroy_process_group", destroy_process_group)
+    monkeypatch.setattr(utils.dist, "is_initialized", lambda: initialized)
+    monkeypatch.setattr(utils.torch, "manual_seed", lambda _seed: None)
+
+    if raises:
+        with pytest.raises(RuntimeError, match="worker failed"):
+            utils.init_process(0, 1, job=job)
+    else:
+        utils.init_process(0, 1, job=job)
+
+    assert events == ["initialized", "job", "destroyed"]
+
+
+def test_init_process_leaves_fixture_owned_process_group_initialized(monkeypatch):
+    initialized = False
+
+    def init_process_group(*_args, **_kwargs):
+        nonlocal initialized
+        initialized = True
+
+    for name in (
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "RANK",
+        "LOCAL_RANK",
+        "WORLD_SIZE",
+        "LOCAL_WORLD_SIZE",
+        "WANDB_DISABLED",
+    ):
+        monkeypatch.setenv(name, "")
+    monkeypatch.setattr(utils.dist, "init_process_group", init_process_group)
+    monkeypatch.setattr(utils.dist, "is_initialized", lambda: initialized)
+    monkeypatch.setattr(
+        utils.dist,
+        "destroy_process_group",
+        lambda: pytest.fail("fixture owner must tear down its process group"),
+    )
+    monkeypatch.setattr(utils.torch, "manual_seed", lambda _seed: None)
+
+    utils.init_process(0, 1)
+
+    assert initialized
+
+
+@pytest.mark.parametrize(
+    "terminate_reaps",
+    [True, False],
+    ids=("terminate", "kill"),
+)
+def test_spawn_multiprocess_job_reaps_children_when_join_is_interrupted(
+    monkeypatch,
+    terminate_reaps,
+):
+    class Process:
+        def __init__(self):
+            self.exitcode = None
+            self.join_timeouts = []
+            self.killed = False
+            self.terminated = False
+            self._alive = False
+
+        def start(self):
+            self._alive = True
+
+        def join(self, timeout=None):
+            self.join_timeouts.append(timeout)
+            if timeout is None:
+                raise TimeoutError("join interrupted")
+            if self.killed or (self.terminated and terminate_reaps):
+                self._alive = False
+                self.exitcode = -9 if self.killed else -15
+
+        def is_alive(self):
+            return self._alive
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+            self._alive = False
+
+    processes = []
+
+    def make_process(*, target, args):
+        assert target is utils.init_process
+        assert args[-2:] == ("gloo", 12345)
+        process = Process()
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(utils, "get_free_port", lambda: 12345)
+    monkeypatch.setattr(
+        utils.mp,
+        "get_context",
+        lambda _method: SimpleNamespace(Process=make_process),
+    )
+    monkeypatch.setattr(utils.time, "monotonic", lambda: 0)
+
+    with pytest.raises(TimeoutError, match="join interrupted"):
+        utils.spawn_multiprocess_job(2, lambda *_args: None)
+
+    assert len(processes) == 2
+    assert all(process.terminated for process in processes)
+    assert all(process.killed is not terminate_reaps for process in processes)
+    expected_cleanup_joins = [10] if terminate_reaps else [10, 10]
+    assert processes[0].join_timeouts == [None, *expected_cleanup_joins]
+    assert processes[1].join_timeouts == expected_cleanup_joins
+
+
+@pytest.mark.parametrize("coverage_config", ["/tmp/coverage-config.toml", None])
+def test_spawn_multiprocess_job_disables_child_coverage_and_restores_parent(
+    monkeypatch,
+    coverage_config,
+):
+    inherited_coverage = []
+
+    class Process:
+        exitcode = 0
+
+        def start(self):
+            inherited_coverage.append(os.environ.get("COVERAGE_PROCESS_START"))
+
+        def join(self, timeout=None):
+            assert os.environ.get("COVERAGE_PROCESS_START") == coverage_config
+
+        def is_alive(self):
+            return False
+
+    if coverage_config is None:
+        monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+    else:
+        monkeypatch.setenv("COVERAGE_PROCESS_START", coverage_config)
+    monkeypatch.setattr(utils, "get_free_port", lambda: 12345)
+    monkeypatch.setattr(
+        utils.mp,
+        "get_context",
+        lambda _method: SimpleNamespace(Process=lambda **_kwargs: Process()),
+    )
+
+    utils.spawn_multiprocess_job(2, lambda *_args: None)
+
+    assert inherited_coverage == [None, None]
+    assert os.environ.get("COVERAGE_PROCESS_START") == coverage_config
+
+
+def test_spawn_multiprocess_job_preserves_child_coverage_for_other_backends(monkeypatch):
+    coverage_config = "/tmp/coverage-config.toml"
+    inherited_coverage = []
+
+    class Process:
+        exitcode = 0
+
+        def start(self):
+            inherited_coverage.append(os.environ.get("COVERAGE_PROCESS_START"))
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            return False
+
+    monkeypatch.setenv("COVERAGE_PROCESS_START", coverage_config)
+    monkeypatch.setattr(utils, "get_free_port", lambda: 12345)
+    monkeypatch.setattr(
+        utils.mp,
+        "get_context",
+        lambda _method: SimpleNamespace(Process=lambda **_kwargs: Process()),
+    )
+
+    utils.spawn_multiprocess_job(2, lambda *_args: None, backend="nccl")
+
+    assert inherited_coverage == [coverage_config, coverage_config]
+    assert os.environ["COVERAGE_PROCESS_START"] == coverage_config
+
+
+@pytest.mark.parametrize("coverage_config", ["/tmp/coverage-config.toml", None])
+def test_spawn_multiprocess_job_restores_coverage_after_partial_start(
+    monkeypatch,
+    coverage_config,
+):
+    processes = []
+
+    class Process:
+        def __init__(self, index):
+            self.exitcode = None
+            self.index = index
+            self.terminated = False
+
+        def start(self):
+            assert "COVERAGE_PROCESS_START" not in os.environ
+            if self.index == 1:
+                raise RuntimeError("start failed")
+
+        def join(self, timeout=None):
+            assert os.environ.get("COVERAGE_PROCESS_START") == coverage_config
+            if timeout is not None and self.terminated:
+                self.exitcode = -15
+
+        def is_alive(self):
+            return self.exitcode is None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            pytest.fail("terminated child should not need kill")
+
+    def make_process(**_kwargs):
+        process = Process(len(processes))
+        processes.append(process)
+        return process
+
+    if coverage_config is None:
+        monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+    else:
+        monkeypatch.setenv("COVERAGE_PROCESS_START", coverage_config)
+    monkeypatch.setattr(utils, "get_free_port", lambda: 12345)
+    monkeypatch.setattr(
+        utils.mp,
+        "get_context",
+        lambda _method: SimpleNamespace(Process=make_process),
+    )
+    monkeypatch.setattr(utils.time, "monotonic", lambda: 0)
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        utils.spawn_multiprocess_job(2, lambda *_args: None)
+
+    assert processes[0].terminated
+    assert os.environ.get("COVERAGE_PROCESS_START") == coverage_config
+
+
+def test_spawn_multiprocess_job_reaps_siblings_after_worker_failure(monkeypatch):
+    class Process:
+        def __init__(self, index):
+            self.exitcode = 1 if index == 0 else None
+            self.index = index
+            self.terminated = False
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            if timeout is not None and self.terminated:
+                self.exitcode = -15
+
+        def is_alive(self):
+            return self.exitcode is None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            pytest.fail("terminated sibling should not need kill")
+
+    processes = []
+
+    def make_process(**_kwargs):
+        process = Process(len(processes))
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(utils, "get_free_port", lambda: 12345)
+    monkeypatch.setattr(
+        utils.mp,
+        "get_context",
+        lambda _method: SimpleNamespace(Process=make_process),
+    )
+    monkeypatch.setattr(utils.time, "monotonic", lambda: 0)
+
+    with pytest.raises(RuntimeError, match="distributed worker exited with code 1"):
+        utils.spawn_multiprocess_job(2, lambda *_args: None)
+
+    assert processes[1].terminated
+    assert processes[1].exitcode == -15
+
+
+def test_spawn_multiprocess_job_preserves_primary_error_when_cleanup_fails(monkeypatch):
+    class Process:
+        exitcode = None
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            if timeout is None:
+                raise TimeoutError("primary join failure")
+
+        def is_alive(self):
+            return True
+
+        def terminate(self):
+            raise RuntimeError("cleanup failure")
+
+    monkeypatch.setattr(utils, "get_free_port", lambda: 12345)
+    monkeypatch.setattr(
+        utils.mp,
+        "get_context",
+        lambda _method: SimpleNamespace(Process=lambda **_kwargs: Process()),
+    )
+
+    with pytest.raises(TimeoutError, match="primary join failure") as exc_info:
+        utils.spawn_multiprocess_job(1, lambda *_args: None)
+
+    if hasattr(exc_info.value, "__notes__"):
+        assert exc_info.value.__notes__ == [
+            "distributed child cleanup also failed: RuntimeError('cleanup failure')"
+        ]
+    else:
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "cleanup failure"

--- a/tests/unit/torch/test_distributed_test_utils.py
+++ b/tests/unit/torch/test_distributed_test_utils.py
@@ -150,7 +150,7 @@ def test_spawn_multiprocess_job_reaps_children_when_join_is_interrupted(
         "get_context",
         lambda _method: SimpleNamespace(Process=make_process),
     )
-    monkeypatch.setattr(utils.time, "monotonic", lambda: 0)
+    monkeypatch.setattr(utils, "monotonic", lambda: 0)
 
     with pytest.raises(TimeoutError, match="join interrupted"):
         utils.spawn_multiprocess_job(2, lambda *_args: None)
@@ -276,7 +276,7 @@ def test_spawn_multiprocess_job_restores_coverage_after_partial_start(
         "get_context",
         lambda _method: SimpleNamespace(Process=make_process),
     )
-    monkeypatch.setattr(utils.time, "monotonic", lambda: 0)
+    monkeypatch.setattr(utils, "monotonic", lambda: 0)
 
     with pytest.raises(RuntimeError, match="start failed"):
         utils.spawn_multiprocess_job(2, lambda *_args: None)
@@ -321,7 +321,7 @@ def test_spawn_multiprocess_job_reaps_siblings_after_worker_failure(monkeypatch)
         "get_context",
         lambda _method: SimpleNamespace(Process=make_process),
     )
-    monkeypatch.setattr(utils.time, "monotonic", lambda: 0)
+    monkeypatch.setattr(utils, "monotonic", lambda: 0)
 
     with pytest.raises(RuntimeError, match="distributed worker exited with code 1"):
         utils.spawn_multiprocess_job(2, lambda *_args: None)

--- a/tests/unit/torch/test_distributed_test_utils.py
+++ b/tests/unit/torch/test_distributed_test_utils.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Tests for bounded cleanup in shared distributed test helpers."""
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix and new tests.

Puzzletron's covered CPU suite can exceed the default per-test timeout because coverage auto-start traces the full import graph inside short-lived Gloo workers and import probes. Interrupted distributed tests can also leave child processes and process-group resources alive, affecting later tests.

This change keeps parent-process coverage while disabling coverage auto-start only for Gloo workers and fresh-interpreter import probes. It guarantees process-group teardown, terminates and reaps children after failures or interruptions, reports nonzero worker exits, and restores the parent coverage environment. Regression tests cover cleanup, partial-start failures, environment restoration, and backend-specific coverage behavior. The affected shared-helper paths now route through the unit and GPU CI lanes, and Puzzletron contract tests are aligned with the current stage schema.

### Testing

The dedicated Puzzletron v2 CPU suite covers the import probes and distributed Puzzletron behavior. The general unit and GPU workflows cover the shared distributed helper and its non-Gloo callers.

### Additional Information

Seed behavior is unchanged in this PR: `init_process` retains its historical `torch.manual_seed(1234)`. Future work could make worker seed ownership explicit and strengthen synchronization tests with deterministic, rank-distinct calibration data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of distributed test processes through better cleanup, child termination, and error handling.
  * Prevented coverage settings from leaking into subprocess import checks.
  * Updated compatibility checks for revised stage configuration projections.
  * Corrected terminal manifest test setup.

* **Tests**
  * Added comprehensive coverage for distributed process cleanup, failure recovery, environment handling, and process reaping.
  * Updated continuous integration triggers to include distributed test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->