### PR TITLE
Export quantized/co-trained MTP weights instead of copying BF16

### DIFF
--- a/modelopt/torch/export/plugins/mcore_nemotron.py
+++ b/modelopt/torch/export/plugins/mcore_nemotron.py
@@ -155,26 +155,13 @@ nemotron_h_causal_lm_export: dict[str, CustomModuleMapping] = {
     # Grouped local experts (TEGroupedMLP: fused per-expert weights)
     "experts.linear_fc1": GroupedMLPSlicing("backbone.layers.{}.mixer.experts.{{}}.up_proj"),
     "experts.linear_fc2": GroupedMLPSlicing("backbone.layers.{}.mixer.experts.{{}}.down_proj"),
-    # MTP predictor projections (outer MultiTokenPredictionLayer)
+    # MTP predictor projections (outer MultiTokenPredictionLayer). The MTP inner
+    # attention/MoE layers are structurally identical to the backbone hybrid layers, so
+    # they reuse the base rules above via is_mtp=True (which retargets the backbone/model
+    # root to mtp, mirroring the importer) — only these predictor-specific keys are
+    # dedicated.
     "mtp.enorm": NameRemapping("mtp.layers.{}.enorm."),
     "mtp.hnorm": NameRemapping("mtp.layers.{}.hnorm."),
     "mtp.eh_proj": NameRemapping("mtp.layers.{}.eh_proj."),
     "mtp.final_layernorm": NameRemapping("mtp.layers.{}.final_layernorm."),
-    # MTP inner attention / MoE layers. Structurally identical to the backbone hybrid
-    # layers, so these mirror the base rules above with the `mtp.layers.{}` prefix; the
-    # `mtp.` namespace is aliased onto the standard rule keys by _get_mtp_state_dict.
-    "mtp.input_layernorm": NameRemapping("mtp.layers.{}.norm."),
-    "mtp.fused_norm": NameRemapping("mtp.layers.{}.norm.weight"),
-    "mtp.linear_qkv": QKVSlicing("mtp.layers.{}.mixer."),
-    "mtp.linear_proj": NameRemapping("mtp.layers.{}.mixer.o_proj."),
-    "mtp.pre_mlp_layernorm": NameRemapping("mtp.layers.{}.norm."),
-    "mtp.router": NameRemapping(
-        "mtp.layers.{}.mixer.gate.", {"mapping": {"expert_bias": "e_score_correction_bias"}}
-    ),
-    "mtp.shared_experts.linear_fc1": NameRemapping("mtp.layers.{}.mixer.shared_experts.up_proj."),
-    "mtp.shared_experts.linear_fc2": NameRemapping("mtp.layers.{}.mixer.shared_experts.down_proj."),
-    "mtp.local_experts.linear_fc1": NameRemapping("mtp.layers.{}.mixer.experts.{}.up_proj."),
-    "mtp.local_experts.linear_fc2": NameRemapping("mtp.layers.{}.mixer.experts.{}.down_proj."),
-    "mtp.experts.linear_fc1": GroupedMLPSlicing("mtp.layers.{}.mixer.experts.{{}}.up_proj"),
-    "mtp.experts.linear_fc2": GroupedMLPSlicing("mtp.layers.{}.mixer.experts.{{}}.down_proj"),
 }

--- a/modelopt/torch/export/plugins/mcore_nemotron.py
+++ b/modelopt/torch/export/plugins/mcore_nemotron.py
@@ -155,9 +155,26 @@ nemotron_h_causal_lm_export: dict[str, CustomModuleMapping] = {
     # Grouped local experts (TEGroupedMLP: fused per-expert weights)
     "experts.linear_fc1": GroupedMLPSlicing("backbone.layers.{}.mixer.experts.{{}}.up_proj"),
     "experts.linear_fc2": GroupedMLPSlicing("backbone.layers.{}.mixer.experts.{{}}.down_proj"),
-    # MTP
+    # MTP predictor projections (outer MultiTokenPredictionLayer)
     "mtp.enorm": NameRemapping("mtp.layers.{}.enorm."),
     "mtp.hnorm": NameRemapping("mtp.layers.{}.hnorm."),
     "mtp.eh_proj": NameRemapping("mtp.layers.{}.eh_proj."),
     "mtp.final_layernorm": NameRemapping("mtp.layers.{}.final_layernorm."),
+    # MTP inner attention / MoE layers. Structurally identical to the backbone hybrid
+    # layers, so these mirror the base rules above with the `mtp.layers.{}` prefix; the
+    # `mtp.` namespace is aliased onto the standard rule keys by _get_mtp_state_dict.
+    "mtp.input_layernorm": NameRemapping("mtp.layers.{}.norm."),
+    "mtp.fused_norm": NameRemapping("mtp.layers.{}.norm.weight"),
+    "mtp.linear_qkv": QKVSlicing("mtp.layers.{}.mixer."),
+    "mtp.linear_proj": NameRemapping("mtp.layers.{}.mixer.o_proj."),
+    "mtp.pre_mlp_layernorm": NameRemapping("mtp.layers.{}.norm."),
+    "mtp.router": NameRemapping(
+        "mtp.layers.{}.mixer.gate.", {"mapping": {"expert_bias": "e_score_correction_bias"}}
+    ),
+    "mtp.shared_experts.linear_fc1": NameRemapping("mtp.layers.{}.mixer.shared_experts.up_proj."),
+    "mtp.shared_experts.linear_fc2": NameRemapping("mtp.layers.{}.mixer.shared_experts.down_proj."),
+    "mtp.local_experts.linear_fc1": NameRemapping("mtp.layers.{}.mixer.experts.{}.up_proj."),
+    "mtp.local_experts.linear_fc2": NameRemapping("mtp.layers.{}.mixer.experts.{}.down_proj."),
+    "mtp.experts.linear_fc1": GroupedMLPSlicing("mtp.layers.{}.mixer.experts.{{}}.up_proj"),
+    "mtp.experts.linear_fc2": GroupedMLPSlicing("mtp.layers.{}.mixer.experts.{{}}.down_proj"),
 }

--- a/modelopt/torch/export/plugins/megatron_importer.py
+++ b/modelopt/torch/export/plugins/megatron_importer.py
@@ -860,6 +860,11 @@ class GPTModelImporter:
                         )
 
                     layer_id += 1
+
+                # Import the MTP block's own final_layernorm into the last inner layer
+                # index; without this it is left random-initialized. Mirrors the export
+                # side, which writes mtp.layers.{last}.final_layernorm.
+                self.rules["mtp.final_layernorm"](mtp.final_layernorm, layer_id - 1)
             else:  # non-repeated MTP
                 # MTP is the last layer in DeepSeek V3/R1
                 layer_id += 1

--- a/modelopt/torch/export/plugins/megatron_importer.py
+++ b/modelopt/torch/export/plugins/megatron_importer.py
@@ -861,9 +861,6 @@ class GPTModelImporter:
 
                     layer_id += 1
 
-                # Import the MTP block's own final_layernorm into the last inner layer
-                # index; without this it is left random-initialized. Mirrors the export
-                # side, which writes mtp.layers.{last}.final_layernorm.
                 self.rules["mtp.final_layernorm"](mtp.final_layernorm, layer_id - 1)
             else:  # non-repeated MTP
                 # MTP is the last layer in DeepSeek V3/R1

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -631,7 +631,8 @@ class GPTModelExporter:
         weights from the pretrained model only when the live model has no ``mtp``
         module (e.g. exporting a base-only checkpoint that grafts a pretrained head).
         """
-        mtp = getattr(self.model, "mtp", None)
+        model = getattr(self, "model", None)
+        mtp = getattr(model, "mtp", None)
         if mtp is None or not hasattr(mtp, "layers") or len(mtp.layers) == 0:
             return self._copy_mtp_state_dict_from_pretrained()
 

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -623,24 +623,13 @@ class GPTModelExporter:
                 self.rules["linear_fc2"](layer.mlp.linear_fc2, layer_id, is_mtp=is_mtp)
 
     def _get_mtp_state_dict(self) -> dict[str, torch.Tensor]:
-        """Export the MTP (Multi-Token Prediction) module.
-
-        Walks the live MCore ``model.mtp`` module and applies the same quantization
-        rules used for the base decoder, so the exported draft head reflects the
-        actual (quantized / co-trained) weights. Falls back to copying the BF16 MTP
-        weights from the pretrained model only when the live model has no ``mtp``
-        module (e.g. exporting a base-only checkpoint that grafts a pretrained head).
-        """
+        """Export the live MTP module, or copy it from the pretrained model if absent."""
         model = getattr(self, "model", None)
         mtp = getattr(model, "mtp", None)
         if mtp is None or not hasattr(mtp, "layers") or len(mtp.layers) == 0:
             return self._copy_mtp_state_dict_from_pretrained()
 
-        # The MTP inner attention / MoE layers are structurally identical to the base
-        # decoder layers, so the same layer walker + rules are reused with is_mtp=True,
-        # which swaps the ``backbone``/``model`` target root for ``mtp`` (mirroring the
-        # importer). Only the predictor-specific projections (enorm/hnorm/eh_proj) and the
-        # MTP block's own final_layernorm use dedicated ``mtp.*`` rules.
+        # Inner layers reuse the base walker with is_mtp=True (retargets backbone -> mtp).
         saved_state_dict = self._state_dict
         self._state_dict = OrderedDict()
         try:
@@ -657,8 +646,7 @@ class GPTModelExporter:
                 if "mtp.eh_proj" in self.rules:
                     self.rules["mtp.eh_proj"](mtp_layer.eh_proj, first_id)
 
-                # Inner hybrid stack (e.g. [attention, MoE] for the ``*E`` pattern)
-                # reuses the base decoder walker; is_mtp=True retargets to mtp.layers.{}.
+                # Inner layers reuse the base decoder walker (is_mtp=True).
                 for inner in inner_layers:
                     hf_layer_id = inner.layer_number - 1
                     if isinstance(inner, MambaLayer):
@@ -688,11 +676,7 @@ class GPTModelExporter:
         return mtp_state_dict
 
     def _copy_mtp_state_dict_from_pretrained(self) -> dict[str, torch.Tensor]:
-        """Fallback: copy the BF16 MTP weights from the pretrained model.
-
-        Used only when the live model has no ``mtp`` module. This does not reflect any
-        quantization or co-training applied to the MTP head.
-        """
+        """Copy the BF16 MTP weights from the pretrained model (used when there is no live MTP)."""
         mtp_state_dict = {}
         if not self._hf_pretrained_model_name:
             return mtp_state_dict
@@ -1029,12 +1013,7 @@ class GPTModelExporter:
 
     @staticmethod
     def _mtp_prefix(prefix: str) -> str:
-        """Rewrite a base-model target prefix to its MTP counterpart.
-
-        Mirrors the importer so import/export naming stays symmetric: the MTP inner
-        layers reuse the base decoder rules, only the ``backbone``/``model`` root is
-        swapped for ``mtp``.
-        """
+        """Rewrite a base-model target prefix (backbone/model root) to its MTP counterpart."""
         if "backbone" in prefix:
             return prefix.replace("backbone", "mtp")
         return prefix.replace("model", "mtp")

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -498,103 +498,129 @@ class GPTModelExporter:
             return None, None
         return fused_key, weight
 
-    def _get_transformer_layer_state_dict(self, layer, layer_id):
+    def _get_transformer_layer_state_dict(self, layer, layer_id, is_mtp=False):
         if not isinstance(layer.input_layernorm, IdentityOp):
-            self.rules["input_layernorm"](layer.input_layernorm, layer_id)
+            self.rules["input_layernorm"](layer.input_layernorm, layer_id, is_mtp=is_mtp)
         else:
             fused_key, norm_weight = self._get_fused_norm_weight(
                 getattr(layer.self_attention, "linear_qkv", None),
                 primary_key="fused_input_layernorm",
             )
             if norm_weight is not None:
-                self.rules[fused_key](norm_weight, layer_id)
+                self.rules[fused_key](norm_weight, layer_id, is_mtp=is_mtp)
 
         if not isinstance(layer.self_attention, IdentityOp):
             if "MLASelfAttention" in str(type(layer.self_attention)):
                 if hasattr(layer.self_attention, "linear_q_proj"):
-                    self.rules["linear_q_proj"](layer.self_attention.linear_q_proj, layer_id)
+                    self.rules["linear_q_proj"](
+                        layer.self_attention.linear_q_proj, layer_id, is_mtp=is_mtp
+                    )
                 else:
                     self.rules["linear_q_down_proj"](
-                        layer.self_attention.linear_q_down_proj, layer_id
+                        layer.self_attention.linear_q_down_proj, layer_id, is_mtp=is_mtp
                     )
-                    self.rules["linear_q_layernorm"](layer.self_attention.q_layernorm, layer_id)
-                    self.rules["linear_q_up_proj"](layer.self_attention.linear_q_up_proj, layer_id)
+                    self.rules["linear_q_layernorm"](
+                        layer.self_attention.q_layernorm, layer_id, is_mtp=is_mtp
+                    )
+                    self.rules["linear_q_up_proj"](
+                        layer.self_attention.linear_q_up_proj, layer_id, is_mtp=is_mtp
+                    )
 
                 self.rules["linear_kv_down_proj"](
-                    layer.self_attention.linear_kv_down_proj, layer_id
+                    layer.self_attention.linear_kv_down_proj, layer_id, is_mtp=is_mtp
                 )
-                self.rules["linear_kv_layernorm"](layer.self_attention.kv_layernorm, layer_id)
-                self.rules["linear_kv_up_proj"](layer.self_attention.linear_kv_up_proj, layer_id)
-                self.rules["linear_proj"](layer.self_attention.linear_proj, layer_id)
+                self.rules["linear_kv_layernorm"](
+                    layer.self_attention.kv_layernorm, layer_id, is_mtp=is_mtp
+                )
+                self.rules["linear_kv_up_proj"](
+                    layer.self_attention.linear_kv_up_proj, layer_id, is_mtp=is_mtp
+                )
+                self.rules["linear_proj"](layer.self_attention.linear_proj, layer_id, is_mtp=is_mtp)
             else:
                 if layer.self_attention.q_layernorm is not None and not isinstance(
                     layer.self_attention.q_layernorm, (IdentityOp, L2Norm)
                 ):
-                    self.rules["q_layernorm"](layer.self_attention.q_layernorm, layer_id)
-                    self.rules["k_layernorm"](layer.self_attention.k_layernorm, layer_id)
-                self.rules["linear_qkv"](layer.self_attention.linear_qkv, layer_id)
+                    self.rules["q_layernorm"](
+                        layer.self_attention.q_layernorm, layer_id, is_mtp=is_mtp
+                    )
+                    self.rules["k_layernorm"](
+                        layer.self_attention.k_layernorm, layer_id, is_mtp=is_mtp
+                    )
+                self.rules["linear_qkv"](layer.self_attention.linear_qkv, layer_id, is_mtp=is_mtp)
                 if (
                     hasattr(layer.self_attention, "core_attention")
                     and "core_attention" in self.rules
                 ):  # KV cache quant export
-                    self.rules["core_attention"](layer.self_attention.core_attention, layer_id)
-                self.rules["linear_proj"](layer.self_attention.linear_proj, layer_id)
+                    self.rules["core_attention"](
+                        layer.self_attention.core_attention, layer_id, is_mtp=is_mtp
+                    )
+                self.rules["linear_proj"](layer.self_attention.linear_proj, layer_id, is_mtp=is_mtp)
                 if getattr(layer.self_attention.core_attention, "softmax_offset", None) is not None:
                     self.rules["softmax_offset"](
-                        layer.self_attention.core_attention.softmax_offset, layer_id
+                        layer.self_attention.core_attention.softmax_offset, layer_id, is_mtp=is_mtp
                     )
 
         if not isinstance(layer.pre_mlp_layernorm, IdentityOp):
-            self.rules["pre_mlp_layernorm"](layer.pre_mlp_layernorm, layer_id)
+            self.rules["pre_mlp_layernorm"](layer.pre_mlp_layernorm, layer_id, is_mtp=is_mtp)
         elif not isinstance(layer.mlp, IdentityOp) and "MoE" not in str(type(layer.mlp)):
             fused_key, norm_weight = self._get_fused_norm_weight(
                 getattr(layer.mlp, "linear_fc1", None),
                 primary_key="fused_pre_mlp_layernorm",
             )
             if norm_weight is not None:
-                self.rules[fused_key](norm_weight, layer_id)
+                self.rules[fused_key](norm_weight, layer_id, is_mtp=is_mtp)
 
         if not isinstance(layer.mlp, IdentityOp):
             if "MoE" in str(type(layer.mlp)):
-                self.rules["router"](layer.mlp.router, layer_id, dtype=self.moe_router_dtype)
+                self.rules["router"](
+                    layer.mlp.router, layer_id, dtype=self.moe_router_dtype, is_mtp=is_mtp
+                )
                 if hasattr(layer.mlp, "fc1_latent_proj") and layer.mlp.fc1_latent_proj is not None:
-                    self.rules["fc1_latent_proj"](layer.mlp.fc1_latent_proj, layer_id)
+                    self.rules["fc1_latent_proj"](
+                        layer.mlp.fc1_latent_proj, layer_id, is_mtp=is_mtp
+                    )
                 if hasattr(layer.mlp, "fc2_latent_proj") and layer.mlp.fc2_latent_proj is not None:
-                    self.rules["fc2_latent_proj"](layer.mlp.fc2_latent_proj, layer_id)
+                    self.rules["fc2_latent_proj"](
+                        layer.mlp.fc2_latent_proj, layer_id, is_mtp=is_mtp
+                    )
                 if hasattr(layer.mlp, "shared_experts") and layer.mlp.shared_experts is not None:
                     self.rules["shared_experts.linear_fc1"](
-                        layer.mlp.shared_experts.linear_fc1, layer_id
+                        layer.mlp.shared_experts.linear_fc1, layer_id, is_mtp=is_mtp
                     )
                     self.rules["shared_experts.linear_fc2"](
-                        layer.mlp.shared_experts.linear_fc2, layer_id
+                        layer.mlp.shared_experts.linear_fc2, layer_id, is_mtp=is_mtp
                     )
                 if hasattr(layer.mlp.experts, "local_experts"):
                     if not self.rules.get("use_packed_local_experts", False):
                         for expert_id, expert in enumerate(layer.mlp.experts.local_experts):
                             self.rules["local_experts.linear_fc1"](
-                                expert.linear_fc1, layer_id, expert_id
+                                expert.linear_fc1, layer_id, expert_id, is_mtp=is_mtp
                             )
                             self.rules["local_experts.linear_fc2"](
-                                expert.linear_fc2, layer_id, expert_id
+                                expert.linear_fc2, layer_id, expert_id, is_mtp=is_mtp
                             )
                     else:
                         # For llama 4, in hf unified checkpoint, all local experts share one scale
                         self.rules["local_experts.linear_fc1"](
-                            layer.mlp.experts.local_experts, layer_id
+                            layer.mlp.experts.local_experts, layer_id, is_mtp=is_mtp
                         )
                         self.rules["local_experts.linear_fc2"](
-                            layer.mlp.experts.local_experts, layer_id
+                            layer.mlp.experts.local_experts, layer_id, is_mtp=is_mtp
                         )
                 elif "experts.linear_fc1" in self.rules:
                     # TEGroupedMLP: experts use fused grouped GEMM with a single
                     # linear_fc1/linear_fc2 for all experts (no local_experts attribute).
                     # Uses "experts.linear_fc1" rule (GroupedMLPMerging) instead of
                     # "local_experts.linear_fc1" which expects per-expert iteration.
-                    self.rules["experts.linear_fc1"](layer.mlp.experts.linear_fc1, layer_id)
-                    self.rules["experts.linear_fc2"](layer.mlp.experts.linear_fc2, layer_id)
+                    self.rules["experts.linear_fc1"](
+                        layer.mlp.experts.linear_fc1, layer_id, is_mtp=is_mtp
+                    )
+                    self.rules["experts.linear_fc2"](
+                        layer.mlp.experts.linear_fc2, layer_id, is_mtp=is_mtp
+                    )
             else:
-                self.rules["linear_fc1"](layer.mlp.linear_fc1, layer_id)
-                self.rules["linear_fc2"](layer.mlp.linear_fc2, layer_id)
+                self.rules["linear_fc1"](layer.mlp.linear_fc1, layer_id, is_mtp=is_mtp)
+                self.rules["linear_fc2"](layer.mlp.linear_fc2, layer_id, is_mtp=is_mtp)
 
     def _get_mtp_state_dict(self) -> dict[str, torch.Tensor]:
         """Export the MTP (Multi-Token Prediction) module.
@@ -610,19 +636,11 @@ class GPTModelExporter:
             return self._copy_mtp_state_dict_from_pretrained()
 
         # The MTP inner attention / MoE layers are structurally identical to the base
-        # decoder layers, so we reuse the base layer walker. We alias the ``mtp.*``
-        # naming rules onto the standard rule keys for the duration of the walk so the
-        # walker emits ``mtp.layers.{}.`` HF keys instead of ``backbone.layers.{}.``.
-        # A *restricted* alias set is used on purpose: any base rule key the walker
-        # references but that has no ``mtp.`` variant is simply absent (and its call is
-        # guarded), rather than silently emitting a wrong ``backbone.`` prefix.
-        mtp_rules = {
-            key[len("mtp.") :]: rule for key, rule in self.rules.items() if key.startswith("mtp.")
-        }
-
-        saved_rules = self.rules
+        # decoder layers, so the same layer walker + rules are reused with is_mtp=True,
+        # which swaps the ``backbone``/``model`` target root for ``mtp`` (mirroring the
+        # importer). Only the predictor-specific projections (enorm/hnorm/eh_proj) and the
+        # MTP block's own final_layernorm use dedicated ``mtp.*`` rules.
         saved_state_dict = self._state_dict
-        self.rules = mtp_rules
         self._state_dict = OrderedDict()
         try:
             for mtp_layer in mtp.layers:
@@ -631,21 +649,21 @@ class GPTModelExporter:
                 last_id = inner_layers[-1].layer_number - 1
 
                 # Outer predictor projections attach to the first inner HF index.
-                if "enorm" in self.rules:
-                    self.rules["enorm"](mtp_layer.enorm, first_id)
-                if "hnorm" in self.rules:
-                    self.rules["hnorm"](mtp_layer.hnorm, first_id)
-                if "eh_proj" in self.rules:
-                    self.rules["eh_proj"](mtp_layer.eh_proj, first_id)
+                if "mtp.enorm" in self.rules:
+                    self.rules["mtp.enorm"](mtp_layer.enorm, first_id)
+                if "mtp.hnorm" in self.rules:
+                    self.rules["mtp.hnorm"](mtp_layer.hnorm, first_id)
+                if "mtp.eh_proj" in self.rules:
+                    self.rules["mtp.eh_proj"](mtp_layer.eh_proj, first_id)
 
                 # Inner hybrid stack (e.g. [attention, MoE] for the ``*E`` pattern)
-                # reuses the base decoder walker with the aliased mtp rules.
+                # reuses the base decoder walker; is_mtp=True retargets to mtp.layers.{}.
                 for inner in inner_layers:
                     hf_layer_id = inner.layer_number - 1
                     if isinstance(inner, MambaLayer):
-                        self._get_mamba_layer_state_dict(inner, hf_layer_id)
+                        self._get_mamba_layer_state_dict(inner, hf_layer_id, is_mtp=True)
                     elif isinstance(inner, TransformerLayer):
-                        self._get_transformer_layer_state_dict(inner, hf_layer_id)
+                        self._get_transformer_layer_state_dict(inner, hf_layer_id, is_mtp=True)
                     else:
                         raise ValueError(
                             "Only TransformerLayer or MambaLayer are supported in the MTP block."
@@ -654,15 +672,14 @@ class GPTModelExporter:
                 # The MTP block's own final layernorm attaches to the last inner HF index.
                 final_layernorm = getattr(mtp_layer, "final_layernorm", None)
                 if (
-                    "final_layernorm" in self.rules
+                    "mtp.final_layernorm" in self.rules
                     and final_layernorm is not None
                     and not isinstance(final_layernorm, IdentityOp)
                 ):
-                    self.rules["final_layernorm"](final_layernorm, last_id)
+                    self.rules["mtp.final_layernorm"](final_layernorm, last_id)
 
             mtp_state_dict = self._state_dict
         finally:
-            self.rules = saved_rules
             self._state_dict = saved_state_dict
 
         if len(mtp_state_dict) > 0:
@@ -731,24 +748,24 @@ class GPTModelExporter:
             self.exclude_modules.append("mtp*")
         return mtp_state_dict
 
-    def _get_mamba_layer_state_dict(self, layer, layer_id):
+    def _get_mamba_layer_state_dict(self, layer, layer_id, is_mtp=False):
         if not isinstance(layer.norm, IdentityOp):
-            self.rules["norm"](layer.norm, layer_id)
+            self.rules["norm"](layer.norm, layer_id, is_mtp=is_mtp)
         else:
             # TE spec: norm is fused into in_proj (QuantTELayerNormColumnParallelLinear).
             # Mamba uses the legacy single-key `fused_norm` rule (Nemotron-H style).
             fused_key, norm_weight = self._get_fused_norm_weight(layer.mixer.in_proj)
             if norm_weight is not None:
-                self.rules[fused_key](norm_weight, layer_id)
+                self.rules[fused_key](norm_weight, layer_id, is_mtp=is_mtp)
 
-        self.rules["mixer_norm"](layer.mixer.norm, layer_id)
-        self.rules["A_log"](layer.mixer.A_log, layer_id)
-        self.rules["D"](layer.mixer.D, layer_id)
-        self.rules["dt_bias"](layer.mixer.dt_bias, layer_id)
+        self.rules["mixer_norm"](layer.mixer.norm, layer_id, is_mtp=is_mtp)
+        self.rules["A_log"](layer.mixer.A_log, layer_id, is_mtp=is_mtp)
+        self.rules["D"](layer.mixer.D, layer_id, is_mtp=is_mtp)
+        self.rules["dt_bias"](layer.mixer.dt_bias, layer_id, is_mtp=is_mtp)
 
-        self.rules["conv1d"](_get_mamba_conv1d(layer.mixer), layer_id)
-        self.rules["in_proj"](layer.mixer.in_proj, layer_id)
-        self.rules["out_proj"](layer.mixer.out_proj, layer_id)
+        self.rules["conv1d"](_get_mamba_conv1d(layer.mixer), layer_id, is_mtp=is_mtp)
+        self.rules["in_proj"](layer.mixer.in_proj, layer_id, is_mtp=is_mtp)
+        self.rules["out_proj"](layer.mixer.out_proj, layer_id, is_mtp=is_mtp)
 
     def _get_medusa_heads_state_dict(self):
         medusa_heads = getattr(self.model, "medusa_heads", None)
@@ -1009,6 +1026,18 @@ class GPTModelExporter:
         if layer_name not in self.exclude_modules:
             self.exclude_modules.append(layer_name)
 
+    @staticmethod
+    def _mtp_prefix(prefix: str) -> str:
+        """Rewrite a base-model target prefix to its MTP counterpart.
+
+        Mirrors the importer so import/export naming stays symmetric: the MTP inner
+        layers reuse the base decoder rules, only the ``backbone``/``model`` root is
+        swapped for ``mtp``.
+        """
+        if "backbone" in prefix:
+            return prefix.replace("backbone", "mtp")
+        return prefix.replace("model", "mtp")
+
     def _name_remapping(
         self,
         module: torch.nn.Module | torch.Tensor,
@@ -1016,7 +1045,10 @@ class GPTModelExporter:
         skip_output_scale: bool = True,
         mapping={},
         dtype: torch.dtype | None = None,
+        is_mtp: bool = False,
     ):
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         if dtype is None:
             dtype = self.dtype
 
@@ -1055,8 +1087,10 @@ class GPTModelExporter:
                 self._state_dict[prefix + source_key] = val
 
     def _gated_mlp_slicing(
-        self, module, prefix, gate_proj_name="gate_proj", up_proj_name="up_proj"
+        self, module, prefix, gate_proj_name="gate_proj", up_proj_name="up_proj", is_mtp=False
     ):
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         name_to_value, qformat, block_size = self._get_quantized_state(
             module, self.dtype, prefix=prefix
         )
@@ -1116,7 +1150,7 @@ class GPTModelExporter:
                 self._state_dict[gate_proj_key] = val.detach().clone()
                 self._state_dict[up_proj_key] = val.detach().clone()
 
-    def _grouped_mlp_slicing(self, module, prefix, parallel_config=None):
+    def _grouped_mlp_slicing(self, module, prefix, parallel_config=None, is_mtp=False):
         """Export TEGroupedMLP weight0..weight{N-1} as one HF-style entry per expert.
 
         At EP>1, local ids are mapped to global via ``module.local_expert_indices``
@@ -1125,6 +1159,8 @@ class GPTModelExporter:
 
         Reverse of _grouped_mlp_merging in the importer.
         """
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         num_experts = module.num_gemms
         state_dict = module.state_dict()
 
@@ -1299,7 +1335,10 @@ class GPTModelExporter:
         q_proj_name="q_proj",
         k_proj_name="k_proj",
         v_proj_name="v_proj",
+        is_mtp=False,
     ):
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         name_to_value, qformat, block_size = self._get_quantized_state(
             module, self.dtype, prefix=prefix
         )
@@ -1428,9 +1467,11 @@ class GPTModelExporter:
                 self._state_dict[v_proj_key] = val.detach().clone()
 
     def _self_attention_scaling(
-        self, module, prefix, k_scale_name="k_scale", v_scale_name="v_scale"
+        self, module, prefix, k_scale_name="k_scale", v_scale_name="v_scale", is_mtp=False
     ):
         """KV cache scaling for CoreAttention module."""
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         k_scale_key = prefix + k_scale_name
         v_scale_key = prefix + v_scale_name
         if hasattr(module, "k_bmm_quantizer") and hasattr(module, "v_bmm_quantizer"):
@@ -1444,8 +1485,10 @@ class GPTModelExporter:
                 # FP8 KV Cache is supported in VLLM; NVFP4 supported in TRTLLM
                 self.kv_cache_dtype = kv_cache_dtype
 
-    def _pack_name_remapping(self, module, prefix, layer_type=None):
+    def _pack_name_remapping(self, module, prefix, layer_type=None, is_mtp=False):
         """Pack name remapping into one tensor."""
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         weight_list = []
         weight_scale_list = []
         weight_scale_2_list = []
@@ -1510,8 +1553,10 @@ class GPTModelExporter:
         if merged_input_scale is not None:
             self._state_dict[prefix + "_input_scale"] = merged_input_scale
 
-    def _pack_name_remapping_gpt_oss(self, module, prefix, layer_type=None):
+    def _pack_name_remapping_gpt_oss(self, module, prefix, layer_type=None, is_mtp=False):
         """Pack name remapping into one tensor."""
+        if is_mtp:
+            prefix = self._mtp_prefix(prefix)
         weight_list = []
         weight_scale_list = []
         weight_scale_2_list = []

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -597,12 +597,84 @@ class GPTModelExporter:
                 self.rules["linear_fc2"](layer.mlp.linear_fc2, layer_id)
 
     def _get_mtp_state_dict(self) -> dict[str, torch.Tensor]:
-        """Export the MTP module.
+        """Export the MTP (Multi-Token Prediction) module.
 
-        Currently, we copy the BF16 MTP weights from the pretrained model if the pretrained model has MTP layers.
+        Walks the live MCore ``model.mtp`` module and applies the same quantization
+        rules used for the base decoder, so the exported draft head reflects the
+        actual (quantized / co-trained) weights. Falls back to copying the BF16 MTP
+        weights from the pretrained model only when the live model has no ``mtp``
+        module (e.g. exporting a base-only checkpoint that grafts a pretrained head).
         """
-        # TODO Implement MTP export for quantized MTP
-        # Hacky version for now: copy MTP weights from pretrained model
+        mtp = getattr(self.model, "mtp", None)
+        if mtp is None or not hasattr(mtp, "layers") or len(mtp.layers) == 0:
+            return self._copy_mtp_state_dict_from_pretrained()
+
+        # The MTP inner attention / MoE layers are structurally identical to the base
+        # decoder layers, so we reuse the base layer walker. We alias the ``mtp.*``
+        # naming rules onto the standard rule keys for the duration of the walk so the
+        # walker emits ``mtp.layers.{}.`` HF keys instead of ``backbone.layers.{}.``.
+        # A *restricted* alias set is used on purpose: any base rule key the walker
+        # references but that has no ``mtp.`` variant is simply absent (and its call is
+        # guarded), rather than silently emitting a wrong ``backbone.`` prefix.
+        mtp_rules = {
+            key[len("mtp.") :]: rule for key, rule in self.rules.items() if key.startswith("mtp.")
+        }
+
+        saved_rules = self.rules
+        saved_state_dict = self._state_dict
+        self.rules = mtp_rules
+        self._state_dict = OrderedDict()
+        try:
+            for mtp_layer in mtp.layers:
+                inner_layers = mtp_layer.mtp_model_layer.layers
+                first_id = inner_layers[0].layer_number - 1
+                last_id = inner_layers[-1].layer_number - 1
+
+                # Outer predictor projections attach to the first inner HF index.
+                if "enorm" in self.rules:
+                    self.rules["enorm"](mtp_layer.enorm, first_id)
+                if "hnorm" in self.rules:
+                    self.rules["hnorm"](mtp_layer.hnorm, first_id)
+                if "eh_proj" in self.rules:
+                    self.rules["eh_proj"](mtp_layer.eh_proj, first_id)
+
+                # Inner hybrid stack (e.g. [attention, MoE] for the ``*E`` pattern)
+                # reuses the base decoder walker with the aliased mtp rules.
+                for inner in inner_layers:
+                    hf_layer_id = inner.layer_number - 1
+                    if isinstance(inner, MambaLayer):
+                        self._get_mamba_layer_state_dict(inner, hf_layer_id)
+                    elif isinstance(inner, TransformerLayer):
+                        self._get_transformer_layer_state_dict(inner, hf_layer_id)
+                    else:
+                        raise ValueError(
+                            "Only TransformerLayer or MambaLayer are supported in the MTP block."
+                        )
+
+                # The MTP block's own final layernorm attaches to the last inner HF index.
+                final_layernorm = getattr(mtp_layer, "final_layernorm", None)
+                if (
+                    "final_layernorm" in self.rules
+                    and final_layernorm is not None
+                    and not isinstance(final_layernorm, IdentityOp)
+                ):
+                    self.rules["final_layernorm"](final_layernorm, last_id)
+
+            mtp_state_dict = self._state_dict
+        finally:
+            self.rules = saved_rules
+            self._state_dict = saved_state_dict
+
+        if len(mtp_state_dict) > 0:
+            print(f"Exported {len(mtp_state_dict)} MTP tensors from the live model")
+        return mtp_state_dict
+
+    def _copy_mtp_state_dict_from_pretrained(self) -> dict[str, torch.Tensor]:
+        """Fallback: copy the BF16 MTP weights from the pretrained model.
+
+        Used only when the live model has no ``mtp`` module. This does not reflect any
+        quantization or co-training applied to the MTP head.
+        """
         mtp_state_dict = {}
         if not self._hf_pretrained_model_name:
             return mtp_state_dict


### PR DESCRIPTION
## What

`GPTModelExporter._get_mtp_state_dict` copied the MTP (multi-token prediction) head verbatim from the BF16 **pretrained** model instead of exporting the live model's MTP weights. `_get_state_dict` only walks `model.decoder.layers` and never `model.mtp`, so `self._state_dict` never contains any `mtp.*` keys and the `key not in self._state_dict` guard was always true — every MTP tensor came from the pretrained safetensors. There was a standing `# TODO Implement MTP export for quantized MTP`.

Consequence: any quantization or co-training applied to the MTP head during QAD was **silently discarded at export**; the exported draft head was always the original BF16 weights. This makes it impossible to evaluate MTP quantization or MTP co-training downstream.

## Fix

- Rewrite `_get_mtp_state_dict` to walk the live MCore `model.mtp` module and apply the same quantization rules used for the base decoder (mirroring `_get_eagle_module_state_dict`). The MTP inner attention/MoE layers are structurally identical to backbone hybrid layers, so the base layer walker (`_get_transformer_layer_state_dict` / `_get_mamba_layer_state_dict`) is reused with a **restricted** set of `mtp.*` naming rules aliased onto the standard rule keys — emitting `mtp.layers.{}.` HF keys. Restricted on purpose: any base rule key the walker references but that has no `mtp.` variant is simply absent (guarded), rather than silently emitting a wrong `backbone.` prefix.
- Keep the old copy behavior as `_copy_mtp_state_dict_from_pretrained`, used only when the live model has no `mtp` module (e.g. exporting a base-only checkpoint that grafts a pretrained head).
- Add the missing MTP inner-layer export rules to `nemotron_h_causal_lm_export` (attention `qkv`/`o_proj`/`norm`, MoE `router`/`experts`/`shared_experts`). The predictor projection rules (`mtp.enorm/hnorm/eh_proj/final_layernorm`) already existed.

## Validation

- For a `NemotronHForCausalLM` model (`num_nextn_predict_layers=1`, hybrid `*E`), the walker reproduces exactly the expected HF key layout — `mtp.layers.0` = attention (`enorm/hnorm/eh_proj/norm/mixer.{q,k,v,o}_proj`), `mtp.layers.1` = MoE (`norm/final_layernorm/mixer.gate/shared_experts/experts.{e}`) — matching what the existing `nemotron_h_causal_lm_import` (`is_mtp` keys) reads back.
- pre-commit clean (ruff / ruff-format / mypy / bandit).
- End-to-end re-export + downstream MTP spec-decode eval on a co-trained checkpoint is in progress; will post the before/after tensor diff here.

## Note for reviewer

@jenchen13 — this is the MTP-export bug you flagged (the L599 BF16 copy). Would appreciate your review, especially on the assumption that the MTP inner layers can be driven through the base layer walker with only a prefix swap, and whether any non-`*E` MTP configurations need additional inner-layer rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected repeated MTP imports to load the final layer normalization correctly.

* **Documentation**
  * Clarified MTP export mapping behavior and prefix-remapping guidance.
  * Improved documentation for MTP exports across supported architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->