### PR TITLE
Normalize Puzzletron Python and YAML formatting

### DIFF
--- a/examples/puzzletron/configs/orchestration/qwen_moe/runner.slurm.yaml
+++ b/examples/puzzletron/configs/orchestration/qwen_moe/runner.slurm.yaml
@@ -11,7 +11,7 @@ runner:
     partition_interactive: interactive
     partition_batch: batch
     # Optional. CPU/IO stages use the regular one-node partition when unset.
-    partition_cpu: null
+    partition_cpu:
     interactive_max_nodes: 2
     max_nodes: 20
     time_limit: "4:00:00"

--- a/examples/puzzletron/configs/orchestration/runner.baremetal.example.yaml
+++ b/examples/puzzletron/configs/orchestration/runner.baremetal.example.yaml
@@ -22,4 +22,4 @@ runner:
     venv: REPLACE_WITH_WORKER_VISIBLE_MODELOPT_VENV
     # Optional script sourced before virtualenv activation on every host.
     # Leave null when the worker login environment needs no additional setup.
-    setup_env: null
+    setup_env:

--- a/examples/puzzletron/configs/orchestration/runner.slurm.example.yaml
+++ b/examples/puzzletron/configs/orchestration/runner.slurm.example.yaml
@@ -13,7 +13,7 @@ runner:
     partition_interactive: interactive
     partition_batch: batch
     # Optional. CPU/IO stages use the regular one-node partition when unset.
-    partition_cpu: null
+    partition_cpu:
     interactive_max_nodes: 2
     time_limit: "4:00:00"
     log_dir: puzzle_runs/logs
@@ -24,10 +24,10 @@ runner:
     venv: REPLACE_WITH_WORKER_VISIBLE_MODELOPT_VENV
     # Optional. Set to an image/path accepted by the cluster's srun container plugin.
     # Leave null to execute directly in the worker environment.
-    container: null
+    container:
     # Optional and used only with a container. Use comma-separated
     # /host/path:/container/path entries, for example /data:/data,/models:/models.
-    container_mounts: null
+    container_mounts:
     # Optional shell commands run in order before virtualenv activation.
     # Example: ["module load cuda", "export HF_HOME=/data/huggingface"]
     prerun_commands: []

--- a/examples/puzzletron/configs/setup/defaults.example.yaml
+++ b/examples/puzzletron/configs/setup/defaults.example.yaml
@@ -7,10 +7,10 @@ infrastructure:
     venv: REPLACE_WITH_WORKER_VISIBLE_MODELOPT_VENV
     # Optional. Set to an image/path accepted by the cluster's srun container plugin.
     # Leave null to execute directly in the worker environment.
-    container: null
+    container:
     # Optional and used only with a container. Use comma-separated
     # /host/path:/container/path entries, for example /data:/data,/models:/models.
-    container_mounts: null
+    container_mounts:
     # Optional shell commands run in order before virtualenv activation.
     # Example: ["module load cuda", "export HF_HOME=/data/huggingface"]
     prerun_commands: []
@@ -20,4 +20,4 @@ infrastructure:
       # Add the required Slurm account for your site before using this file.
       # account: REPLACE_WITH_SLURM_ACCOUNT
       # Optional. CPU/IO stages use the regular partition when unset.
-      partition_cpu: null
+      partition_cpu:

--- a/modelopt/torch/puzzletron/anymodel/registry.py
+++ b/modelopt/torch/puzzletron/anymodel/registry.py
@@ -151,7 +151,9 @@ def infer_descriptor_name(
     text_config = _get(config, "text_config", None)
     text_model_type = _get(text_config, "model_type", None)
     if text_model_type in _MODEL_TYPE_TO_DESCRIPTOR:
-        return _MODEL_TYPE_TO_DESCRIPTOR[text_model_type], f"text_config.model_type is {text_model_type}"
+        return _MODEL_TYPE_TO_DESCRIPTOR[
+            text_model_type
+        ], f"text_config.model_type is {text_model_type}"
 
     # Aliases are metadata discovered by a campaign preflight. They are deliberately
     # consulted only after every built-in architecture/model-type mapping, so a stale

--- a/modelopt/torch/puzzletron/diagnostics/campaign_findings.py
+++ b/modelopt/torch/puzzletron/diagnostics/campaign_findings.py
@@ -216,8 +216,7 @@ def loss_trend_findings(
         finite = [
             row
             for row in sorted(values, key=lambda item: item.get(step_key, 0))
-            if isinstance(row.get(loss_key), (int, float))
-            and math.isfinite(float(row[loss_key]))
+            if isinstance(row.get(loss_key), (int, float)) and math.isfinite(float(row[loss_key]))
         ]
         if len(finite) < 2:
             continue

--- a/modelopt/torch/puzzletron/diagnostics/campaign_progress_report.py
+++ b/modelopt/torch/puzzletron/diagnostics/campaign_progress_report.py
@@ -178,10 +178,7 @@ def _stage_artifact_present(root: Path, spec: StageSpec) -> bool:
 def _pipeline_state(root: Path, spec: StageSpec, config: dict[str, Any]) -> str:
     """Return the report state from the manifest, artifacts, and configuration."""
 
-    if (
-        (config.get("post_mip") or {}).get("flows")
-        and spec.stage_id in LEGACY_POST_MIP_STAGE_IDS
-    ):
+    if (config.get("post_mip") or {}).get("flows") and spec.stage_id in LEGACY_POST_MIP_STAGE_IDS:
         return "disabled"
     if is_correctness_sanity_stage(spec.stage_id):
         manifest = _manifest(root, spec.stage_id)
@@ -287,11 +284,7 @@ def _sort_table(summary: dict[str, Any]) -> str:
             f"{reverse_cell}"
             "</tr>"
         )
-    gate = (
-        "passed"
-        if summary.get("passed") is True
-        else "failed (blocking correctness)"
-    )
+    gate = "passed" if summary.get("passed") is True else "failed (blocking correctness)"
     gate_label = "passed" if summary.get("passed") is True else "failed"
     findings = list(summary.get("findings") or ())
     finding_notes = ""
@@ -301,8 +294,7 @@ def _sort_table(summary: dict[str, Any]) -> str:
             str(item.get("message") or "Measured result needs review.") for item in findings
         )
         gate_attributes = (
-            " warning-value' tabindex='0' "
-            f"data-warning='{html.escape(messages, quote=True)}"
+            f" warning-value' tabindex='0' data-warning='{html.escape(messages, quote=True)}"
         )
         finding_notes = (
             "<p class='note'>"
@@ -414,9 +406,7 @@ def _activation_diagnostic_summary(root: Path) -> dict[str, Any]:
     if not slicing_findings:
         slicing_findings = [
             asdict(finding)
-            for finding in descriptor_realization_findings(
-                slicing.get("axis_summaries") or {}
-            )
+            for finding in descriptor_realization_findings(slicing.get("axis_summaries") or {})
         ]
     return {
         "rows": rows,
@@ -429,7 +419,10 @@ def _activation_diagnostic_summary(root: Path) -> dict[str, Any]:
         ),
         "width_findings": width_findings,
         "slicing_findings": slicing_findings,
-        "sort_findings": list((_load_optional(root / "artifacts" / "sort_sanity" / "summary.json")).get("findings") or ()),
+        "sort_findings": list(
+            (_load_optional(root / "artifacts" / "sort_sanity" / "summary.json")).get("findings")
+            or ()
+        ),
     }
 
 
@@ -455,9 +448,7 @@ def _cell_finding_messages(
         evidence = finding.get("evidence") or {}
         group = evidence.get("group") or {}
         methods = {
-            str(evidence[key])
-            for key in _FINDING_METHOD_KEYS
-            if evidence.get(key) is not None
+            str(evidence[key]) for key in _FINDING_METHOD_KEYS if evidence.get(key) is not None
         }
         if (
             str(group.get("axis")) == str(axis)
@@ -471,9 +462,11 @@ def _cell_finding_messages(
 
 
 def _activation_diagnostic_section(summary: dict[str, Any]) -> str:
-    findings = list(summary.get("width_findings") or ()) + list(
-        summary.get("slicing_findings") or ()
-    ) + list(summary.get("sort_findings") or ())
+    findings = (
+        list(summary.get("width_findings") or ())
+        + list(summary.get("slicing_findings") or ())
+        + list(summary.get("sort_findings") or ())
+    )
     rows = _activation_diagnostic_rows(summary)
     gates = []
     if summary.get("width_present"):
@@ -552,11 +545,7 @@ def _activation_diagnostic_section(summary: dict[str, Any]) -> str:
                 metric=first_metric,
                 method=method,
             )
-            attributes = (
-                " class='warning-cell'"
-                if messages
-                else ""
-            )
+            attributes = " class='warning-cell'" if messages else ""
             formatted = html.escape(_fmt(value)) if value is not None else "N/A"
             if messages:
                 formatted = (
@@ -564,9 +553,7 @@ def _activation_diagnostic_section(summary: dict[str, Any]) -> str:
                     f"data-warning='{html.escape(chr(10).join(messages), quote=True)}'>"
                     f"{formatted}</span>"
                 )
-            cells.append(
-                f"<td{attributes}>{formatted}</td>"
-            )
+            cells.append(f"<td{attributes}>{formatted}</td>")
         body.append(
             "<tr>"
             f"<th>{html.escape(label)}</th><td>{html.escape(_fmt(target))}</td>"
@@ -696,9 +683,7 @@ def _bypass_overfit_data(root: Path) -> dict[str, Any]:
         mode: _bypass_overfit_mode_data(root, mode)
         for mode in ("smallest_fixed", "diverse_resampled")
     }
-    granularities = {
-        data.get("granularity") for data in modes.values() if data.get("records")
-    }
+    granularities = {data.get("granularity") for data in modes.values() if data.get("records")}
     granularity = "subblock" if "subblock" in granularities else "block"
     units = sorted(
         {unit for data in modes.values() for unit in data.get("units", ())},
@@ -740,15 +725,11 @@ def _overfit_summary_card(mode: str, data: dict[str, Any]) -> str:
     findings = list(summary.get("findings") or ())
     warning_attributes = ""
     if findings:
-        warning_attributes = (
-            " warning-value' tabindex='0' data-warning='"
-            + html.escape(
-                "\n".join(
-                    str(item.get("message") or "Measured result needs review.")
-                    for item in findings
-                ),
-                quote=True,
-            )
+        warning_attributes = " warning-value' tabindex='0' data-warning='" + html.escape(
+            "\n".join(
+                str(item.get("message") or "Measured result needs review.") for item in findings
+            ),
+            quote=True,
         )
     return (
         f"<article class='probe-summary {'passed' if passed else 'failed'}{warning_attributes}'>"
@@ -770,8 +751,7 @@ def _bypass_overfit_section(data: dict[str, Any]) -> str:
     if not units or not any(mode.get("records") for mode in modes.values()):
         return "<p class='empty'>Pending bypass overfit.</p>"
     options = "".join(
-        f"<option value='{html.escape(unit)}'>layer_{html.escape(unit)}</option>"
-        for unit in units
+        f"<option value='{html.escape(unit)}'>layer_{html.escape(unit)}</option>" for unit in units
     )
     unit_label = "Subblock" if data.get("granularity") == "subblock" else "Layer"
     cards = "".join(
@@ -830,9 +810,7 @@ def _report_candidate_config(config: Any) -> Any:
         kv_heads = _finite_number(normalized.get("num_kv_heads"))
         if query_heads is not None and kv_heads is not None and kv_heads > 0:
             ratio = query_heads / kv_heads
-            normalized["num_query_heads_per_kv_head"] = (
-                int(ratio) if ratio.is_integer() else ratio
-            )
+            normalized["num_query_heads_per_kv_head"] = int(ratio) if ratio.is_integer() else ratio
     return normalized
 
 
@@ -856,7 +834,12 @@ def _compact_nested_bypass_observations(
                 missing_catalog_entries += 1
         active_params = _finite_number(observation.get("active_params"))
         teacher_params = _finite_number(observation.get("teacher_params"))
-        if active_params is None or active_params < 0 or teacher_params is None or teacher_params <= 0:
+        if (
+            active_params is None
+            or active_params < 0
+            or teacher_params is None
+            or teacher_params <= 0
+        ):
             row["parameter_ratio"] = None
             invalid_parameter_counts += 1
         else:
@@ -919,8 +902,8 @@ def _nested_bypass_data(root: Path) -> dict[str, Any]:
         history_path.with_name("candidate_catalog.json"),
     )
     raw_candidate_catalog = _load_optional(catalog_path)
-    observations, candidate_catalog, observation_diagnostics = (
-        _compact_nested_bypass_observations(observations, raw_candidate_catalog)
+    observations, candidate_catalog, observation_diagnostics = _compact_nested_bypass_observations(
+        observations, raw_candidate_catalog
     )
     layers = sorted(
         {str(layer_idx) for row in records for layer_idx in (row.get("per_layer_loss") or {})},
@@ -1003,7 +986,9 @@ def _nested_bypass_section(data: dict[str, Any]) -> str:
         )
     missing_catalog_entries = int(diagnostics.get("missing_catalog_entries") or 0)
     if missing_catalog_entries:
-        subject = "observation references" if missing_catalog_entries == 1 else "observations reference"
+        subject = (
+            "observation references" if missing_catalog_entries == 1 else "observations reference"
+        )
         warning_messages.append(
             f"{missing_catalog_entries} {subject} a candidate missing from the catalog"
         )
@@ -1164,10 +1149,7 @@ def _mamba_family_hint(root: Path) -> str | None:
 
     for stage in ("build_library", "vllm_stats", "width_importance", "convert"):
         manifest = _load_optional(root / "manifests" / f"{stage}.json")
-        axes = (
-            ((manifest.get("config") or {}).get("search_space") or {}).get("axes")
-            or {}
-        )
+        axes = ((manifest.get("config") or {}).get("search_space") or {}).get("axes") or {}
         names = {str(axis) for axis in axes}
         has_gdn = any(name.startswith("gdn_") for name in names)
         has_mamba = any(name.startswith("mamba_") for name in names)
@@ -1265,10 +1247,7 @@ def _subblock_axes(
         consumed.update({"num_kv_heads", "num_query_heads", "qk_head_dim", "sliding_window_size"})
     elif (
         kind == "mamba"
-        and _semantic_subblock_family(
-            subblock, mamba_family_hint=mamba_family_hint
-        )
-        == "gdn"
+        and _semantic_subblock_family(subblock, mamba_family_hint=mamba_family_hint) == "gdn"
     ):
         groups = subblock.get("num_groups")
         heads = subblock.get("num_heads")
@@ -1311,9 +1290,7 @@ def _subblock_axes(
     return axes
 
 
-def _block_axes(
-    block: dict[str, Any], *, mamba_family_hint: str | None = None
-) -> dict[str, Any]:
+def _block_axes(block: dict[str, Any], *, mamba_family_hint: str | None = None) -> dict[str, Any]:
     axes: dict[str, Any] = {}
     for subblock in _config_subblocks(block):
         axes.update(_subblock_axes(subblock, mamba_family_hint=mamba_family_hint))
@@ -1332,9 +1309,7 @@ def _axis_sort_key(axis: str) -> tuple[int, str]:
     return (_AXIS_ORDER.index(axis) if axis in _AXIS_ORDER else len(_AXIS_ORDER), axis)
 
 
-def _library_scenario(
-    path: Path, *, mamba_family_hint: str | None = None
-) -> dict[str, Any]:
+def _library_scenario(path: Path, *, mamba_family_hint: str | None = None) -> dict[str, Any]:
     payload = _load_optional(path)
     entries = [entry for entry in payload.get("entries", ()) if isinstance(entry, dict)]
     by_signature: dict[tuple[str, ...], dict[int, dict[str, dict[str, Any]]]] = {}
@@ -1352,9 +1327,7 @@ def _library_scenario(
         active = [value for value in subblocks if value.get("no_op") is not True]
         signature = tuple(
             sorted(
-                _semantic_subblock_family(
-                    value, mamba_family_hint=mamba_family_hint
-                )
+                _semantic_subblock_family(value, mamba_family_hint=mamba_family_hint)
                 for value in (active or subblocks)
             )
         )
@@ -1376,9 +1349,7 @@ def _library_scenario(
             axis_values: dict[str, set[str]] = {}
             decoded_values: dict[str, dict[str, Any]] = {}
             for block in configs:
-                for axis, value in _block_axes(
-                    block, mamba_family_hint=mamba_family_hint
-                ).items():
+                for axis, value in _block_axes(block, mamba_family_hint=mamba_family_hint).items():
                     encoded = _canonical_json(value)
                     axis_values.setdefault(axis, set()).add(encoded)
                     decoded_values.setdefault(axis, {})[encoded] = value
@@ -1451,9 +1422,7 @@ def _library_data(root: Path) -> dict[str, Any]:
     if not paths and (root / "replacement_library.json").is_file():
         paths = [root / "replacement_library.json"]
     mamba_family_hint = _mamba_family_hint(root)
-    scenarios = [
-        _library_scenario(path, mamba_family_hint=mamba_family_hint) for path in paths
-    ]
+    scenarios = [_library_scenario(path, mamba_family_hint=mamba_family_hint) for path in paths]
     total_entries = sum(int(scenario["entries"]) for scenario in scenarios)
     unique_runtime_configs = sum(int(row["unique_runtime_configs"]) for row in scenarios)
     formula = "Pending library creation"
@@ -1506,12 +1475,8 @@ def _library_section(data: dict[str, Any]) -> str:
     )
 
 
-def _compact_runtime_config(
-    config: dict[str, Any], *, mamba_family_hint: str | None = None
-) -> str:
-    kind = _semantic_subblock_family(
-        config, mamba_family_hint=mamba_family_hint
-    )
+def _compact_runtime_config(config: dict[str, Any], *, mamba_family_hint: str | None = None) -> str:
+    kind = _semantic_subblock_family(config, mamba_family_hint=mamba_family_hint)
     ignored = {"kind", "name", "no_op", "conv_kernel_size"}
     values = ", ".join(
         f"{key.replace('intermediate_size', 'dim').replace('num_', '')}={value}"
@@ -1562,8 +1527,7 @@ def _vllm_data(root: Path, library: dict[str, Any]) -> dict[str, Any]:
     for scenario in source_scenarios:
         width = scenario.get("hidden_width")
         stats_path = Path(
-            scenario.get("stats_path")
-            or Path(scenario["path"]).with_name("subblock_stats.json")
+            scenario.get("stats_path") or Path(scenario["path"]).with_name("subblock_stats.json")
         )
         if not stats_path.is_file() and (root / "subblock_stats.json").is_file():
             stats_path = root / "subblock_stats.json"
@@ -1572,7 +1536,8 @@ def _vllm_data(root: Path, library: dict[str, Any]) -> dict[str, Any]:
             [
                 row
                 for row in payload
-                if isinstance(row, dict) and (row.get("args") or {}).get("runtime_stats") is True
+                if isinstance(row, dict)
+                and (row.get("args") or {}).get("runtime_stats") is True
                 and (
                     width is None
                     or (row.get("args") or {}).get("n_embd") is None
@@ -1651,9 +1616,7 @@ def _vllm_data(root: Path, library: dict[str, Any]) -> dict[str, Any]:
                         ),
                         "axes": {
                             "hidden_width": width,
-                            **_subblock_axes(
-                                config, mamba_family_hint=mamba_family_hint
-                            ),
+                            **_subblock_axes(config, mamba_family_hint=mamba_family_hint),
                         },
                         "metrics": metrics,
                         "profile": args,
@@ -1664,11 +1627,7 @@ def _vllm_data(root: Path, library: dict[str, Any]) -> dict[str, Any]:
                     }
                 )
         expected = int(scenario.get("unique_runtime_configs", 0))
-        invalid = sum(
-            1
-            for warning in warnings
-            if warning.get("hidden_width") == width
-        )
+        invalid = sum(1 for warning in warnings if warning.get("hidden_width") == width)
         scenarios.append(
             {
                 "hidden_width": width,
@@ -1816,8 +1775,7 @@ def _subblock_replacement_record(
         (
             subblock
             for subblock in _config_subblocks(block)
-            if str(subblock.get("kind")) == kind
-            and str(subblock.get("name", kind)) == name
+            if str(subblock.get("kind")) == kind and str(subblock.get("name", kind)) == name
         ),
         None,
     )
@@ -1869,9 +1827,7 @@ def _replacement_data(root: Path) -> dict[str, Any]:
         manifest = _load_optional(scenario_dir / "scenario_manifest.json")
         width = manifest.get("hidden_width")
         subblock_definitions_path = scenario_dir / "single_subblock_replacement_solutions.json"
-        subblock_result_dir = (
-            scenario_dir / "single_subblock_replacement_solutions--validation"
-        )
+        subblock_result_dir = scenario_dir / "single_subblock_replacement_solutions--validation"
         if subblock_definitions_path.is_file() and subblock_result_dir.is_dir():
             granularity = "subblock"
             definitions = json.loads(subblock_definitions_path.read_text())
@@ -2102,9 +2058,7 @@ _MIP_FAMILY_COLUMNS = {
 }
 
 
-def _mip_supported_columns(
-    names: set[str], *, family_presence: dict[str, bool]
-) -> list[str]:
+def _mip_supported_columns(names: set[str], *, family_presence: dict[str, bool]) -> list[str]:
     def hidden(name: str) -> bool:
         return any(name == base or name.startswith(f"{base}@") for base in _MIP_HIDDEN_COLUMNS)
 
@@ -2212,9 +2166,7 @@ def _mip_data(root: Path) -> dict[str, Any]:
                         "hidden_width": width,
                         "removed_sublayers": depth,
                         "rank": rank,
-                        "outputs": _mip_outputs(
-                            solution, runtime_profile=runtime_profile
-                        ),
+                        "outputs": _mip_outputs(solution, runtime_profile=runtime_profile),
                         "solution_path": scenario.get("solution_path"),
                     }
                 )
@@ -2279,9 +2231,7 @@ def _mip_data(root: Path) -> dict[str, Any]:
         )
     columns = [name for name in _MIP_COLUMN_ORDER if name in available_columns]
     columns.extend(sorted(available_columns - set(columns)))
-    homogeneous_columns = [
-        name for name in _MIP_COLUMN_ORDER if name in homogeneous_output_columns
-    ]
+    homogeneous_columns = [name for name in _MIP_COLUMN_ORDER if name in homogeneous_output_columns]
     homogeneous_columns.extend(sorted(homogeneous_output_columns - set(homogeneous_columns)))
     return {
         "profiles": profiles,
@@ -2446,7 +2396,8 @@ def _evaluation_data(root: Path) -> dict[str, Any]:
                     **raw,
                     "label": style.get("label", raw.get("label", solution_id)),
                     "color": style.get(
-                        "color", raw.get("color", _EVALUATION_PALETTE[index % len(_EVALUATION_PALETTE)])
+                        "color",
+                        raw.get("color", _EVALUATION_PALETTE[index % len(_EVALUATION_PALETTE)]),
                     ),
                     "marker": {
                         "teacher": "star",
@@ -2841,8 +2792,7 @@ def _distillation_overfit_section(data: dict[str, Any]) -> str:
             "<p class='gate warning warning-value' tabindex='0' data-warning='"
             + html.escape(
                 "\n".join(
-                    str(item.get("message") or "Measured result needs review.")
-                    for item in findings
+                    str(item.get("message") or "Measured result needs review.") for item in findings
                 ),
                 quote=True,
             )
@@ -2954,10 +2904,7 @@ def _proper_distillation_section(data: dict[str, Any]) -> str:
     progress = ""
     if run.get("partial"):
         latest_step = max(
-            (
-                int(row.get("step", row.get("global_step", 0)))
-                for row in run.get("records", ())
-            ),
+            (int(row.get("step", row.get("global_step", 0))) for row in run.get("records", ())),
             default=0,
         )
         progress = (
@@ -2965,8 +2912,7 @@ def _proper_distillation_section(data: dict[str, Any]) -> str:
             f"{latest_step} / {html.escape(str(run.get('max_steps', 'N/A')))} optimizer steps.</p>"
         )
     return (
-        progress
-        + "<p class='note'>Fresh shuffled data · "
+        progress + "<p class='note'>Fresh shuffled data · "
         f"{html.escape(str(run.get('max_steps', 'N/A')))} optimizer steps · sequence length "
         f"{html.escape(str(run.get('sequence_length', 'N/A')))} · global batch "
         f"{html.escape(str(run.get('global_batch_size', 'N/A')))}.</p>"
@@ -3183,12 +3129,16 @@ def _experiment_summary_section(data: dict[str, Any]) -> str:
         ("Best models for AIPerf", "aiperf_candidates"),
         ("Best models for distillation", "distillation_candidates"),
     )
-    return "<div class='summary-grid'>" + "".join(
-        "<article><span>{}</span><strong>{}</strong></article>".format(
-            html.escape(label), html.escape(_fmt(data.get(key) or "unknown"))
+    return (
+        "<div class='summary-grid'>"
+        + "".join(
+            "<article><span>{}</span><strong>{}</strong></article>".format(
+                html.escape(label), html.escape(_fmt(data.get(key) or "unknown"))
+            )
+            for label, key in labels
         )
-        for label, key in labels
-    ) + "</div>"
+        + "</div>"
+    )
 
 
 def _stage_dag(
@@ -3206,28 +3156,24 @@ def _stage_dag(
         dynamic_post_mip_stage_ids=dynamic,
     )
     specs_by_id = {spec.stage_id: spec for spec in STAGE_SPECS}
-    specs = {
-        stage_id: specs_by_id[stage_id]
-        for stage_id in configured
-        if stage_id not in dynamic
-    }
-    parents = {
-        stage_id: configured_parent_stage_ids(stage_id, merged_config)
-        for stage_id in specs
-    }
-    parents.update(
-        {stage_id: node.dependency_stage_ids for stage_id, node in dynamic.items()}
-    )
+    specs = {stage_id: specs_by_id[stage_id] for stage_id in configured if stage_id not in dynamic}
+    parents = {stage_id: configured_parent_stage_ids(stage_id, merged_config) for stage_id in specs}
+    parents.update({stage_id: node.dependency_stage_ids for stage_id, node in dynamic.items()})
     levels: dict[str, int] = {}
     pending = set(specs) | set(dynamic)
     while pending:
-        ready = [stage_id for stage_id in pending if all(parent in levels for parent in parents[stage_id])]
+        ready = [
+            stage_id
+            for stage_id in pending
+            if all(parent in levels for parent in parents[stage_id])
+        ]
         if not ready:
             ready = list(pending)
         for stage_id in sorted(
             ready,
             key=lambda value: (
-                specs[value].topology_order if value in specs else len(specs), value
+                specs[value].topology_order if value in specs else len(specs),
+                value,
             ),
         ):
             levels[stage_id] = max((levels[parent] + 1 for parent in parents[stage_id]), default=0)
@@ -3422,9 +3368,7 @@ def _section_source_selector(
     section_id: str,
     stage_ids: tuple[str, ...],
 ) -> Callable[[Path, bool], Iterable[Path]]:
-    return lambda root, completed: _report_source_paths(
-        root, section_id, stage_ids, completed
-    )
+    return lambda root, completed: _report_source_paths(root, section_id, stage_ids, completed)
 
 
 def _report_section_specs() -> tuple[_ReportSectionSpec, ...]:
@@ -3558,9 +3502,7 @@ def _report_section_specs() -> tuple[_ReportSectionSpec, ...]:
     )
 
 
-def _report_campaign_identity(
-    root: Path, model_name: str, merged_config: dict[str, Any]
-) -> str:
+def _report_campaign_identity(root: Path, model_name: str, merged_config: dict[str, Any]) -> str:
     return stable_digest(
         {
             "report_contract": 1,
@@ -3630,9 +3572,7 @@ def generate_campaign_progress_report(
 
     post_mip_nodes = compile_post_mip_flows(merged_config)
     granularity_data = _granularity_data(root, merged_config)
-    statuses = {
-        spec.stage_id: _pipeline_state(root, spec, merged_config) for spec in STAGE_SPECS
-    }
+    statuses = {spec.stage_id: _pipeline_state(root, spec, merged_config) for spec in STAGE_SPECS}
     post_mip_payloads = build_post_mip_report_payloads(root, post_mip_nodes)
     post_mip_report_bodies = {}
     for node in post_mip_nodes:
@@ -3666,8 +3606,7 @@ def generate_campaign_progress_report(
             hash_contents=completed,
         )
         dependencies = {
-            dependency: section_data[dependency]
-            for dependency in section_spec.dependencies
+            dependency: section_data[dependency] for dependency in section_spec.dependencies
         }
         dependency_identities = {
             dependency: section_results[dependency].snapshot.input_digest
@@ -3723,9 +3662,7 @@ def generate_campaign_progress_report(
         stage_id in configured_stages and present[stage_id]
         for stage_id in ("width_sanity", "slicing_sanity")
     )
-    has_bypass_overfit = (
-        "bypass_sanity" in configured_stages and present["bypass_sanity"]
-    )
+    has_bypass_overfit = "bypass_sanity" in configured_stages and present["bypass_sanity"]
     has_nested_bypass = "bypass" in configured_stages and present["bypass"]
     has_depth = "depth_importance" in configured_stages and present["depth_importance"]
     has_library = "build_library" in configured_stages and present["build_library"]
@@ -3734,20 +3671,15 @@ def generate_campaign_progress_report(
         present["replacement_scoring"] or bool(replacement_data.get("records"))
     )
     has_mip = "mip" in configured_stages and present["mip"]
-    has_evaluation = (
-        "zero_shot_evaluation" in configured_stages
-        and present["zero_shot_evaluation"]
-    )
+    has_evaluation = "zero_shot_evaluation" in configured_stages and present["zero_shot_evaluation"]
     has_aiperf = "aiperf" in configured_stages and (
         present["aiperf"] or bool(aiperf_data.get("profiles"))
     )
     has_distillation_overfit = (
-        "global_distillation_sanity" in configured_stages
-        and present["global_distillation_sanity"]
+        "global_distillation_sanity" in configured_stages and present["global_distillation_sanity"]
     )
-    has_proper_distillation = (
-        "global_distillation" in configured_stages
-        and bool(proper_distillation_data.get("runs"))
+    has_proper_distillation = "global_distillation" in configured_stages and bool(
+        proper_distillation_data.get("runs")
     )
     has_post_distillation_evaluation = (
         "post_distillation_evaluation" in configured_stages
@@ -3787,12 +3719,8 @@ def generate_campaign_progress_report(
         stage_targets["post_distillation_evaluation"] = "post-distillation-evaluation"
     for node in post_mip_nodes:
         if node.stage_id in post_mip_report_bodies:
-            stage_targets[node.stage_id] = str(
-                post_mip_payloads[node.stage_id]["section_id"]
-            )
-    dag = _stage_dag(
-        root, merged_config, statuses, stage_targets, post_mip_nodes=post_mip_nodes
-    )
+            stage_targets[node.stage_id] = str(post_mip_payloads[node.stage_id]["section_id"])
+    dag = _stage_dag(root, merged_config, statuses, stage_targets, post_mip_nodes=post_mip_nodes)
     vllm_title = stage_display_name(
         "vllm_stats", granularity=_stage_granularity(root, "vllm_stats", merged_config)
     )

--- a/modelopt/torch/puzzletron/diagnostics/sanity_verdict.py
+++ b/modelopt/torch/puzzletron/diagnostics/sanity_verdict.py
@@ -104,9 +104,7 @@ def complete_sanity_stage(
     )
     fail_on_warnings = bool((config.get("sanity") or {}).get("fail_on_warnings", False))
     status = (
-        "failed"
-        if correctness_failure or (fail_on_warnings and not verdict.passed)
-        else "success"
+        "failed" if correctness_failure or (fail_on_warnings and not verdict.passed) else "success"
     )
     return complete_stage(
         config,

--- a/modelopt/torch/puzzletron/diagnostics/width_sanity.py
+++ b/modelopt/torch/puzzletron/diagnostics/width_sanity.py
@@ -51,18 +51,14 @@ def _normalize_summary(axis: str, summary: Mapping[str, Any]) -> list[dict[str, 
             continue
         metrics = source.get("metrics") if isinstance(source.get("metrics"), Mapping) else {}
         row = {
-            key: value
-            for key, value in source.items()
-            if key not in {"metrics", "method", "role"}
+            key: value for key, value in source.items() if key not in {"metrics", "method", "role"}
         }
         row.update(metrics)
         row.update(
             axis=str(source.get("axis") or axis),
             layer_idx=source.get("layer_idx", "global"),
             target_value=source.get("target_value", source.get("hidden_width")),
-            teacher_value=source.get(
-                "teacher_value", summary.get("teacher_hidden_width")
-            ),
+            teacher_value=source.get("teacher_value", summary.get("teacher_hidden_width")),
             method=method,
         )
         normalized.append(row)
@@ -99,7 +95,11 @@ def descriptor_realization_findings(
                     stage="slicing_sanity",
                     message=(
                         f"sorted and physical failed the descriptor realization gate for {metric}"
-                        + (f": delta {float(delta):.6g}." if isinstance(delta, (int, float)) else ".")
+                        + (
+                            f": delta {float(delta):.6g}."
+                            if isinstance(delta, (int, float))
+                            else "."
+                        )
                     ),
                     evidence={
                         "kind": "descriptor_realization_gate",

--- a/modelopt/torch/puzzletron/orchestration/controller.py
+++ b/modelopt/torch/puzzletron/orchestration/controller.py
@@ -470,9 +470,7 @@ class CampaignController:
                     "and rerun the controller"
                 )
                 return False
-            selected = self.terminal_controls.choose_revisions(
-                request.prompt, request.revision_ids
-            )
+            selected = self.terminal_controls.choose_revisions(request.prompt, request.revision_ids)
             decision_path = (
                 self.plan.puzzle_dir
                 / "artifacts"
@@ -851,9 +849,7 @@ class CampaignController:
         """Generate the canonical campaign report through the configured executor."""
 
         attempt = build_final_report_attempt(self.plan, attempt_id=str(uuid.uuid4()))
-        fallback_logs = (
-            (attempt.command.log_path,) if attempt.command.log_path is not None else ()
-        )
+        fallback_logs = (attempt.command.log_path,) if attempt.command.log_path is not None else ()
         self.logger.stage("generating final campaign report")
         try:
             handle = self.executor.submit(attempt)

--- a/modelopt/torch/puzzletron/orchestration/executors/baremetal.py
+++ b/modelopt/torch/puzzletron/orchestration/executors/baremetal.py
@@ -102,8 +102,7 @@ class GpuLeaseManager:
             slices = [
                 tuple(free[index : index + topology.gpus_per_task])
                 for index in range(0, len(free), topology.gpus_per_task)
-                if len(free[index : index + topology.gpus_per_task])
-                == topology.gpus_per_task
+                if len(free[index : index + topology.gpus_per_task]) == topology.gpus_per_task
             ]
             if not slices:
                 continue
@@ -179,9 +178,7 @@ class BareMetalSSHExecutor(Executor):
         return str(path.with_name(f"{path.stem}.task-{task_index:04d}{path.suffix}"))
 
     @staticmethod
-    def _launcher_argv(
-        attempt: AttemptSpec, topology: ResolvedTaskTopology
-    ) -> tuple[str, ...]:
+    def _launcher_argv(attempt: AttemptSpec, topology: ResolvedTaskTopology) -> tuple[str, ...]:
         payload = attempt.command.argv
         if attempt.command.shell:
             payload = ("bash", "-lc", " ".join(shlex.quote(part) for part in payload))
@@ -224,9 +221,7 @@ class BareMetalSSHExecutor(Executor):
         topology = resolve_task_topology(attempt)
         leases = self.leases.acquire_topology(attempt.attempt_id, topology)
         task_hosts = tuple(dict.fromkeys(lease.hostname for lease in leases))
-        launcher = " ".join(
-            shlex.quote(part) for part in self._launcher_argv(attempt, topology)
-        )
+        launcher = " ".join(shlex.quote(part) for part in self._launcher_argv(attempt, topology))
         contract = self.runner.contract
         hooks: list[str] = []
         if contract.setup_env:
@@ -264,7 +259,7 @@ class BareMetalSSHExecutor(Executor):
                 )
                 payload = (
                     f"{postrun_trap}set +e; {launcher}; status=$?; "
-                    f"printf '%s\\n' \"$status\" > {shlex.quote(exit_path)}; exit \"$status\""
+                    f'printf \'%s\\n\' "$status" > {shlex.quote(exit_path)}; exit "$status"'
                 )
                 remote_command = (
                     f"set -Eeuo pipefail; cd {shlex.quote(working_directory)}; "
@@ -331,7 +326,7 @@ class BareMetalSSHExecutor(Executor):
             exit_path = shlex.quote(str(record["exit_path"]))
             probe_command = (
                 f"if [[ -f {exit_path} ]]; then printf 'DONE '; cat {exit_path}; "
-                f"elif [[ -f {pid_path} ]] && kill -0 \"$(cat {pid_path})\" "
+                f'elif [[ -f {pid_path} ]] && kill -0 "$(cat {pid_path})" '
                 ">/dev/null 2>&1; then echo RUNNING; else echo LOST; fi"
             )
             probe = _run_command(

--- a/modelopt/torch/puzzletron/orchestration/progress.py
+++ b/modelopt/torch/puzzletron/orchestration/progress.py
@@ -40,9 +40,7 @@ _VLLM_TOTAL = re.compile(
     r"\((?P<specs>\d+) unique benchmarks\)"
 )
 _SUBBLOCK_KINDS = ("attention", "mla", "mamba", "ffn", "moe")
-_WIDTH_ITER = re.compile(
-    r"\[activation/automodel\] iter (?P<current>\d+)/(?P<total>\d+)\b"
-)
+_WIDTH_ITER = re.compile(r"\[activation/automodel\] iter (?P<current>\d+)/(?P<total>\d+)\b")
 _WIDTH_TARGET = re.compile(
     r"\[activation/automodel\] entering calibration loop: target (?P<total>\d+) iteration"
 )
@@ -160,9 +158,7 @@ def _depth_progress(puzzle_dir: Path, config: Mapping[str, Any] | None) -> str |
     if max_removals <= 0:
         return None
 
-    iteration_dirs = sorted(
-        path for path in iterative.glob("iteration_*") if path.is_dir()
-    )
+    iteration_dirs = sorted(path for path in iterative.glob("iteration_*") if path.is_dir())
     if selected >= max_removals and iteration_dirs:
         return f"removing layer {max_removals} out of {max_removals}, current progress complete"
 
@@ -188,7 +184,9 @@ def _depth_progress(puzzle_dir: Path, config: Mapping[str, Any] | None) -> str |
     return f"removing layer 1 out of {max_removals}, current progress 0/{available or '?'}"
 
 
-def _width_progress_from_artifacts(puzzle_dir: Path, config: Mapping[str, Any] | None) -> str | None:
+def _width_progress_from_artifacts(
+    puzzle_dir: Path, config: Mapping[str, Any] | None
+) -> str | None:
     root = Path(puzzle_dir)
     candidates: list[Path] = []
     configured = _nested(config, "pruning", "activations_log_dir")
@@ -196,7 +194,13 @@ def _width_progress_from_artifacts(puzzle_dir: Path, config: Mapping[str, Any] |
         candidates.append(Path(str(configured)) / ".native_resume" / "progress.json")
     candidates.extend(
         [
-            root / "pruning" / "pruning_scores" / "automodel" / "all_axes" / ".native_resume" / "progress.json",
+            root
+            / "pruning"
+            / "pruning_scores"
+            / "automodel"
+            / "all_axes"
+            / ".native_resume"
+            / "progress.json",
             root / "activations_log" / ".native_resume" / "progress.json",
             root / "width" / ".native_resume" / "progress.json",
         ]
@@ -235,9 +239,7 @@ def _width_progress_from_logs(log_paths: Sequence[str]) -> str | None:
 
 def _combined_log_text(log_paths: Sequence[str], *, max_bytes: int = 1048576) -> str:
     return "\n".join(
-        text
-        for log_path in log_paths
-        if (text := _tail_text(Path(log_path), max_bytes=max_bytes))
+        text for log_path in log_paths if (text := _tail_text(Path(log_path), max_bytes=max_bytes))
     ).replace("\r", "\n")
 
 
@@ -291,13 +293,9 @@ def _bypass_progress(log_paths: Sequence[str]) -> str | None:
         prefix = ""
         if probes:
             probe = probes[-1]
-            prefix = (
-                f"{probe.group('mode')} probe "
-                f"{probe.group('index')}/{probe.group('count')}: "
-            )
+            prefix = f"{probe.group('mode')} probe {probe.group('index')}/{probe.group('count')}: "
         return (
-            f"{prefix}step {step.group('current')}/{step.group('total')}, "
-            f"loss {step.group('loss')}"
+            f"{prefix}step {step.group('current')}/{step.group('total')}, loss {step.group('loss')}"
         )
     if probes:
         probe = probes[-1]
@@ -343,8 +341,7 @@ def _replacement_progress(
     )
     widths = _nested(config, "embedding_pruning", "widths", default=()) or ()
     scenario_roots = [
-        puzzle_dir / "scenarios" / f"width-{int(width):04d}" / "depth-00"
-        for width in widths
+        puzzle_dir / "scenarios" / f"width-{int(width):04d}" / "depth-00" for width in widths
     ]
     if not scenario_roots:
         scenario_roots = sorted((puzzle_dir / "scenarios").glob("width-*/depth-00"))
@@ -360,8 +357,7 @@ def _replacement_progress(
         expected += len(solutions)
         output_dir = manifest_path.parent / output_name
         completed += sum(
-            (output_dir / f"solution_{index}.json").is_file()
-            for index in range(len(solutions))
+            (output_dir / f"solution_{index}.json").is_file() for index in range(len(solutions))
         )
     if expected:
         return f"scored {completed}/{expected} replacement candidates"
@@ -418,10 +414,7 @@ def _post_mip_progress(
     if not isinstance(current, Mapping) or not current.get("execution_identity"):
         return None
     candidate_set = _read_json(
-        input_root
-        / "executions"
-        / str(current["execution_identity"])
-        / "candidate_set.json"
+        input_root / "executions" / str(current["execution_identity"]) / "candidate_set.json"
     )
     if not isinstance(candidate_set, Mapping):
         return None
@@ -429,9 +422,7 @@ def _post_mip_progress(
     if not isinstance(revision_ids, list) or not revision_ids:
         return None
 
-    executions_root = (
-        puzzle_dir / "artifacts" / "post_mip" / "nodes" / node_id / "executions"
-    )
+    executions_root = puzzle_dir / "artifacts" / "post_mip" / "nodes" / node_id / "executions"
     executions = [path for path in executions_root.glob("post_mip_execution_*") if path.is_dir()]
     rows_by_revision: dict[str, Mapping[str, Any]] = {}
     if executions:
@@ -453,9 +444,7 @@ def _post_mip_progress(
     }
     completed = len(rows_by_revision)
     failed = sum(row.get("status") == "failed" for row in rows_by_revision.values())
-    timed_out = sum(
-        row.get("status") == "timed_out" for row in rows_by_revision.values()
-    )
+    timed_out = sum(row.get("status") == "timed_out" for row in rows_by_revision.values())
     outcomes = []
     if failed:
         outcomes.append(f"{failed} failed")
@@ -463,8 +452,7 @@ def _post_mip_progress(
         outcomes.append(f"{timed_out} timed out")
     suffix = f", {', '.join(outcomes)}" if outcomes else ""
     return (
-        f"{labels.get(node_type, 'processed')} {completed}/{len(revision_ids)} candidates"
-        f"{suffix}"
+        f"{labels.get(node_type, 'processed')} {completed}/{len(revision_ids)} candidates{suffix}"
     )
 
 

--- a/modelopt/torch/puzzletron/post_mip/reporting.py
+++ b/modelopt/torch/puzzletron/post_mip/reporting.py
@@ -144,9 +144,7 @@ def _kd_runs(
     observations: list[dict[str, Any]],
     revisions: Mapping[str, Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
-    by_architecture = {
-        _architecture_id(row, revisions): row for row in observations
-    }
+    by_architecture = {_architecture_id(row, revisions): row for row in observations}
     architecture_ids = set(by_architecture)
     checkpoint_root = execution_root / "checkpoints" if execution_root else None
     if checkpoint_root and checkpoint_root.is_dir():
@@ -164,9 +162,7 @@ def _kd_runs(
             if architecture_root is not None
             else []
         )
-        revision_id = str(
-            row.get("input_revision_id") or row.get("source_revision_id") or ""
-        )
+        revision_id = str(row.get("input_revision_id") or row.get("source_revision_id") or "")
         runs.append(
             {
                 "architecture_id": architecture_id,
@@ -223,9 +219,7 @@ def build_post_mip_report_payloads(
         payload = raw[node.stage_id]
         observations = []
         for row in payload["observations"]:
-            revision_id = str(
-                row.get("input_revision_id") or row.get("source_revision_id") or ""
-            )
+            revision_id = str(row.get("input_revision_id") or row.get("source_revision_id") or "")
             architecture_id = _architecture_id(row, revisions)
             observations.append(
                 {
@@ -245,9 +239,7 @@ def build_post_mip_report_payloads(
             "observations": observations,
             "runs": (
                 _kd_runs(
-                    Path(payload["execution_root"])
-                    if payload["execution_root"]
-                    else None,
+                    Path(payload["execution_root"]) if payload["execution_root"] else None,
                     observations,
                     revisions,
                 )
@@ -278,8 +270,7 @@ def _status_summary(payload: Mapping[str, Any]) -> str:
         status = str(row.get("status") or "pending")
         counts[status] = counts.get(status, 0) + 1
     outcomes = " · ".join(
-        f"{_text(status.replace('_', ' '))}={count}"
-        for status, count in sorted(counts.items())
+        f"{_text(status.replace('_', ' '))}={count}" for status, count in sorted(counts.items())
     )
     status = _text(payload.get("status") or "pending")
     return f"<p>status={status}{f' · {outcomes}' if outcomes else ''}</p>"
@@ -323,11 +314,7 @@ def render_evaluation_report(section_id: str, payload: Mapping[str, Any]) -> str
         if metric_names
         else ""
     )
-    return (
-        "<h3>Candidate evaluation</h3>"
-        f"{_status_summary(payload)}"
-        f"{plot}{table}"
-    )
+    return f"<h3>Candidate evaluation</h3>{_status_summary(payload)}{plot}{table}"
 
 
 def render_aiperf_report(section_id: str, payload: Mapping[str, Any]) -> str:

--- a/puzzletron_setup/v2/post_mip.py
+++ b/puzzletron_setup/v2/post_mip.py
@@ -222,9 +222,7 @@ class PostMIPFlowEditor:
         if dependents:
             return dependents
         flow = self._flows[flow_id]
-        nodes = OrderedDict(
-            (name, value) for name, value in flow.nodes.items() if name != node_id
-        )
+        nodes = OrderedDict((name, value) for name, value in flow.nodes.items() if name != node_id)
         self._flows[flow_id] = replace(flow, nodes=nodes)
         return ()
 
@@ -232,9 +230,7 @@ class PostMIPFlowEditor:
         self.edit_node(flow_id, node_id, input_id=new_input)
 
     def to_config(self) -> OrderedDict[str, Any]:
-        return OrderedDict(
-            (flow_id, flow.to_config()) for flow_id, flow in self._flows.items()
-        )
+        return OrderedDict((flow_id, flow.to_config()) for flow_id, flow in self._flows.items())
 
     def compile(self, mip_runs: Mapping[str, Any] | None = None):
         # Keep the setup package usable without PyTorch until canonical validation.

--- a/puzzletron_setup/v2/validation.py
+++ b/puzzletron_setup/v2/validation.py
@@ -102,9 +102,7 @@ def _dataset_subset_issues(state: WizardState) -> list[ValidationIssue]:
         for item in catalog.get("subsets") or ()
         if isinstance(item, Mapping)
     }
-    records = [
-        item for item in selection.get("subsets") or () if isinstance(item, Mapping)
-    ]
+    records = [item for item in selection.get("subsets") or () if isinstance(item, Mapping)]
     names = [str(item.get("name", "")) for item in records]
     if not records or any(not name for name in names) or len(names) != len(set(names)):
         issues.append(
@@ -163,8 +161,7 @@ def _dataset_subset_issues(state: WizardState) -> list[ValidationIssue]:
                 )
             )
         elif any(
-            record.get(key) != cached.get(key)
-            for key in ("num_rows", "num_bytes_original_files")
+            record.get(key) != cached.get(key) for key in ("num_rows", "num_bytes_original_files")
         ):
             issues.append(
                 ValidationIssue(

--- a/puzzletron_setup/wizard.py
+++ b/puzzletron_setup/wizard.py
@@ -730,9 +730,7 @@ def _ask_aiperf_config(
         },
     }
     if detailed:
-        config["input_tokens"] = prompts.integer(
-            "AIPerf ISL:", default=int(config["input_tokens"])
-        )
+        config["input_tokens"] = prompts.integer("AIPerf ISL:", default=int(config["input_tokens"]))
         config["output_tokens"] = prompts.integer(
             "AIPerf OSL:", default=int(config["output_tokens"])
         )
@@ -757,7 +755,6 @@ def _ask_downstream_evaluation_config(
     defaults: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Ask for lmms-eval task and vLLM settings."""
-
     defaults = defaults or {}
     tasks = prompts.text(
         "lmms-eval tasks (comma-separated):",
@@ -796,10 +793,7 @@ def _ask_downstream_evaluation_config(
         )
         enable_expert_parallel = (
             prompts.confirm(
-                (
-                    "Enable lmms-eval vLLM expert parallelism? "
-                    "vLLM effective EP is TP * DP."
-                ),
+                ("Enable lmms-eval vLLM expert parallelism? vLLM effective EP is TP * DP."),
                 default=bool(
                     topology_defaults.get("enable_expert_parallel")
                     or int(topology_defaults.get("expert_parallel_size", 1)) > 1
@@ -859,7 +853,6 @@ def _ask_downstream_evaluation_config(
 
 def _downstream_evaluation_metric_suggestions(node_id: str, config: Mapping[str, Any]) -> list[str]:
     """Return filter metric names produced by the downstream-evaluation runner."""
-
     suggestions = []
     tasks = config.get("tasks") or ()
     if isinstance(tasks, str):

--- a/tests/unit/torch/puzzletron/test_campaign_progress_report.py
+++ b/tests/unit/torch/puzzletron/test_campaign_progress_report.py
@@ -390,10 +390,7 @@ def test_report_promotes_legacy_descriptor_realization_failure(tmp_path: Path):
     summary = _activation_diagnostic_summary(tmp_path)
 
     assert len(summary["slicing_findings"]) == 1
-    assert (
-        summary["slicing_findings"][0]["evidence"]["kind"]
-        == "descriptor_realization_gate"
-    )
+    assert summary["slicing_findings"][0]["evidence"]["kind"] == "descriptor_realization_gate"
 
 
 def test_library_uses_active_semantic_subblock_family(tmp_path: Path):
@@ -674,7 +671,7 @@ def test_progress_report_renders_axis_selectable_activation_diagnostic_tables(tm
             }
         )
     _write(
-            tmp_path / "artifacts/width_sanity/summary.json",
+        tmp_path / "artifacts/width_sanity/summary.json",
         {"rows": rows, "primary_metric": "normalized_mse_loss_hidden_states"},
     )
 
@@ -812,8 +809,7 @@ def test_progress_report_uses_subblock_losses_for_subblock_bypass_overfit(tmp_pa
         {"status": "complete"},
     )
     _write(
-        tmp_path
-        / "artifacts/bypass/overfit_probe/smallest_fixed/local_kd_loss_history.json",
+        tmp_path / "artifacts/bypass/overfit_probe/smallest_fixed/local_kd_loss_history.json",
         {
             "granularity": "subblock",
             "records": [
@@ -830,12 +826,18 @@ def test_progress_report_uses_subblock_losses_for_subblock_bypass_overfit(tmp_pa
     result = generate_campaign_progress_report(tmp_path, model_name="Qwen3.5-0.8B")
     document = Path(result["html"]).read_text(encoding="utf-8")
 
-    assert '<label class=\'selector-label\' for=\'bypass-overfit-unit-select\'>Subblock</label>' in document
+    assert (
+        "<label class='selector-label' for='bypass-overfit-unit-select'>Subblock</label>"
+        in document
+    )
     assert "layer_0:attention:self_attn" in document
     assert "per_subblock_loss" in document
-    assert "per_layer_loss||" not in document.split("function renderLossChart", maxsplit=1)[1].split(
-        "</script>", maxsplit=1
-    )[0]
+    assert (
+        "per_layer_loss||"
+        not in document.split("function renderLossChart", maxsplit=1)[1].split(
+            "</script>", maxsplit=1
+        )[0]
+    )
 
 
 def test_nested_bypass_report_exposes_ema_and_display_only_outlier_controls(tmp_path: Path):
@@ -1058,13 +1060,9 @@ def test_evaluation_report_adds_teacher_styles_solution_kinds_and_pareto_front(t
 
 
 def test_report_separates_plot_titles_from_horizontal_legends(tmp_path: Path):
-    document = Path(generate_campaign_progress_report(tmp_path)["html"]).read_text(
-        encoding="utf-8"
-    )
+    document = Path(generate_campaign_progress_report(tmp_path)["html"]).read_text(encoding="utf-8")
 
-    assert (
-        "legend:{orientation:'h',x:0,xanchor:'left',y:1.18,yanchor:'bottom'}" in document
-    )
+    assert "legend:{orientation:'h',x:0,xanchor:'left',y:1.18,yanchor:'bottom'}" in document
     assert "margin:{l:62,r:18,t:96,b:55}" in document
     assert "function chartTitle(text,size=15)" in document
     assert "title:chartTitle(" in document
@@ -1177,9 +1175,9 @@ def test_progress_report_renders_proper_distillation_terms_and_before_after_eval
     global_section = document.split('id="global-distillation"', maxsplit=1)[1].split(
         "</details>", maxsplit=1
     )[0]
-    post_section = document.split(
-        'id="post-distillation-evaluation"', maxsplit=1
-    )[1].split("</details>", maxsplit=1)[0]
+    post_section = document.split('id="post-distillation-evaluation"', maxsplit=1)[1].split(
+        "</details>", maxsplit=1
+    )[0]
     assert 'id="proper-distillation-plots"' in global_section
     assert "Before KD" not in global_section and "After KD" not in global_section
     assert 'id="proper-distillation-plots"' not in post_section
@@ -1415,8 +1413,7 @@ def test_mip_report_separates_homogeneous_solutions_and_simplifies_costs(tmp_pat
     assert "stats.num_params: 73–75" in document
     assert (
         "homogeneousHead.innerHTML=`<tr><th>Solution</th><th>Hidden Width</th>"
-        "<th>Removed Sublayers</th>"
-        not in document
+        "<th>Removed Sublayers</th>" not in document
     )
 
 

--- a/tests/unit/torch/puzzletron/test_diagnostic_scoring_config.py
+++ b/tests/unit/torch/puzzletron/test_diagnostic_scoring_config.py
@@ -56,7 +56,9 @@ def test_diagnostic_scoring_config_uses_explicit_checkpoint_roles(tmp_path: Path
     assert cfg.scoring.target_teacher_dir == str(teacher)
 
 
-def test_diagnostic_sorted_parent_runs_the_distributed_sort_on_every_rank(monkeypatch, tmp_path: Path):
+def test_diagnostic_sorted_parent_runs_the_distributed_sort_on_every_rank(
+    monkeypatch, tmp_path: Path
+):
     calls = []
     monkeypatch.setattr(diagnostics.dist, "is_master", lambda: False)
     monkeypatch.setattr(diagnostics.dist, "barrier", lambda: calls.append("barrier"))
@@ -142,9 +144,7 @@ def test_sort_equivalence_summary_records_blocking_drift(tmp_path: Path):
     assert summary["verdict"] == "failed"
 
 
-def test_sort_equivalence_uses_master_failure_verdict_on_every_rank(
-    monkeypatch, tmp_path: Path
-):
+def test_sort_equivalence_uses_master_failure_verdict_on_every_rank(monkeypatch, tmp_path: Path):
     config = {"experiment": {"dir": str(tmp_path)}}
     manifest = StageManifest(stage="sort_sanity", config=config)
     summary_path = tmp_path / "artifacts" / "sort_sanity" / "summary.json"
@@ -348,9 +348,7 @@ def test_axis_worker_accepts_pp2_ep2_overlay_on_four_ranks(monkeypatch, tmp_path
     monkeypatch.setattr(
         axis_worker,
         "load_runtime_hydra_config",
-        lambda _config: OmegaConf.create(
-            {"width_sanity": {"automodel": {"parallel": parallel}}}
-        ),
+        lambda _config: OmegaConf.create({"width_sanity": {"automodel": {"parallel": parallel}}}),
     )
 
     _validate_worker_topology(config, "kv_groups")
@@ -371,9 +369,7 @@ def test_axis_worker_accepts_the_stage_owned_super_mesh(monkeypatch) -> None:
     monkeypatch.setattr(
         axis_worker,
         "load_runtime_hydra_config",
-        lambda _config: OmegaConf.create(
-            {"width_sanity": {"automodel": {"parallel": parallel}}}
-        ),
+        lambda _config: OmegaConf.create({"width_sanity": {"automodel": {"parallel": parallel}}}),
     )
 
     _validate_worker_topology(config, "moe_experts")

--- a/tests/unit/torch/puzzletron/test_granularity_report.py
+++ b/tests/unit/torch/puzzletron/test_granularity_report.py
@@ -88,7 +88,7 @@ def test_nested_bypass_report_selects_exact_subblock_losses(tmp_path: Path):
     assert '<select id="nested-bypass-width-select">' in document
     assert 'id="nested-bypass-axis-filters"' in document
     assert 'id="nested-bypass-config-summary"' in document
-    assert 'nested-bypass-config-select' not in document
+    assert "nested-bypass-config-select" not in document
     assert document.count("id='nested-bypass-unit-plot'") == 1
     assert "layer_0:mamba:linear_attn" in document
     assert "layer_0:ffn:feed_forward" in document

--- a/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
+++ b/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
@@ -43,9 +43,10 @@ def test_near_teacher_axis_targets_selects_two_largest_legal_values():
         }
     }
 
-    assert _near_teacher_axis_targets(
-        config, ["ffn_intermediate", "binary_axis"], count=2
-    ) == {"ffn_intermediate": [10240, 8192], "binary_axis": [1]}
+    assert _near_teacher_axis_targets(config, ["ffn_intermediate", "binary_axis"], count=2) == {
+        "ffn_intermediate": [10240, 8192],
+        "binary_axis": [1],
+    }
 
 
 def test_hidden_width_targets_apply_requested_ratios_and_alignment():
@@ -113,14 +114,20 @@ def test_hidden_only_diagnostic_finishes_without_empty_parent_sweep(tmp_path):
     assert summary["axes"] == ["hidden_width"]
     assert summary["parent_sweep"] == {"status": "not_applicable"}
     assert not temporary.exists()
-    assert json.loads((artifacts / "activation_diagnostic_summary.json").read_text())[
-        "hidden_width"
-    ]["passed"] is True
+    assert (
+        json.loads((artifacts / "activation_diagnostic_summary.json").read_text())["hidden_width"][
+            "passed"
+        ]
+        is True
+    )
     assert (artifacts / "activation_diagnostic_table.md").is_file()
     assert (artifacts / "activation_diagnostic_scores.csv").is_file()
-    assert json.loads((artifacts / "diagnostic_cleanup.json").read_text())[
-        "reverse_checkpoint_removed"
-    ] is True
+    assert (
+        json.loads((artifacts / "diagnostic_cleanup.json").read_text())[
+            "reverse_checkpoint_removed"
+        ]
+        is True
+    )
 
 
 def test_hidden_only_guard_allows_nonmaster_rank_without_summary():

--- a/tests/unit/torch/puzzletron/test_mip_profiles.py
+++ b/tests/unit/torch/puzzletron/test_mip_profiles.py
@@ -155,7 +155,7 @@ def test_matrix_expands_profiles_but_search_lists_do_not():
                     },
                     "search_space": {"depth": [0, 1, 4], "embedding": [2688, 2560]},
                 }
-            }
+            },
         },
         available_depths=range(5),
         available_embeddings=(2688, 2560, 2432),
@@ -187,15 +187,13 @@ def test_explicit_total_depth_selector_matches_list_depth_selector():
     def normalize(depth):
         (profile,) = normalize_mip_profiles(
             {
-                "defaults": {
-                    "objectives": "metrics.cosine_embedding_loss_hidden_states"
-                },
+                "defaults": {"objectives": "metrics.cosine_embedding_loss_hidden_states"},
                 "runs": {
                     "depth": {
                         "constraints": {"params": "75%"},
                         "search_space": {"depth": depth},
                     }
-                }
+                },
             },
             available_depths=range(5),
             available_embeddings=(2688,),
@@ -223,11 +221,9 @@ def test_typed_depth_selectors_form_a_cartesian_product_with_distinct_identities
             "runs": {
                 "typed": {
                     "constraints": {"params": "75%"},
-                    "search_space": {
-                        "depth": {"attention": [1, 2], "moe": [1, 2]}
-                    },
+                    "search_space": {"depth": {"attention": [1, 2], "moe": [1, 2]}},
                 }
-            }
+            },
         },
         available_depths=range(7),
         available_embeddings=(2688,),
@@ -253,7 +249,7 @@ def test_typed_depth_selector_validation_is_eager():
                 "constraints": {"params": "75%"},
                 "search_space": {"depth": {"attention": 1}},
             }
-        }
+        },
     }
     kwargs = {
         "available_depths": range(5),
@@ -285,15 +281,13 @@ def test_invalid_homogeneous_keep_is_rejected(value):
     with pytest.raises(ValueError, match="homogeneous"):
         normalize_mip_profiles(
             {
-                "defaults": {
-                    "objectives": "metrics.cosine_embedding_loss_hidden_states"
-                },
+                "defaults": {"objectives": "metrics.cosine_embedding_loss_hidden_states"},
                 "runs": {
                     "bad": {
                         "homogeneous": {"enabled": True, "keep": value},
                         "constraints": {"params": "75%"},
                     }
-                }
+                },
             },
             available_depths=(0,),
             available_embeddings=(2688,),
@@ -305,12 +299,8 @@ def test_workload_constraint_requires_declared_workload():
         normalize_mip_profiles(
             {
                 "workloads": {},
-                "defaults": {
-                    "objectives": "metrics.cosine_embedding_loss_hidden_states"
-                },
-                "runs": {
-                    "bad": {"constraints": {"runtime": {"at": {"missing": "75%"}}}}
-                },
+                "defaults": {"objectives": "metrics.cosine_embedding_loss_hidden_states"},
+                "runs": {"bad": {"constraints": {"runtime": {"at": {"missing": "75%"}}}}},
             },
             available_depths=(0,),
             available_embeddings=(2688,),

--- a/tests/unit/torch/puzzletron/test_orchestration_controller.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_controller.py
@@ -207,8 +207,7 @@ def test_stage_dashboard_display_name_uses_downstream_evaluation_node_type():
     }
 
     assert (
-        _stage_dashboard_display_name(config, "post.params-75.lmms_eval")
-        == "Downstream Evaluation"
+        _stage_dashboard_display_name(config, "post.params-75.lmms_eval") == "Downstream Evaluation"
     )
 
 

--- a/tests/unit/torch/puzzletron/test_profile_online_evaluation.py
+++ b/tests/unit/torch/puzzletron/test_profile_online_evaluation.py
@@ -146,11 +146,7 @@ def test_online_merge_fans_unique_metrics_back_to_every_profile_alias(tmp_path):
     write_online_evaluation_plan(puzzle_dir, plan)
     written_plan = json.loads(
         (
-            puzzle_dir
-            / "artifacts"
-            / "zero_shot_evaluation"
-            / "online_plan"
-            / "index.json"
+            puzzle_dir / "artifacts" / "zero_shot_evaluation" / "online_plan" / "index.json"
         ).read_text()
     )
     assert written_plan["execution"] == {
@@ -158,9 +154,7 @@ def test_online_merge_fans_unique_metrics_back_to_every_profile_alias(tmp_path):
         "materialized_solution_checkpoints": False,
         "model_loads_per_worker": 1,
     }
-    assert written_plan["widths"]["8"]["execution"] == online_execution_contract(
-        puzzle_dir, 8
-    )
+    assert written_plan["widths"]["8"]["execution"] == online_execution_contract(puzzle_dir, 8)
     raw = (
         puzzle_dir
         / "artifacts"

--- a/tests/unit/torch/puzzletron/test_sanity_verdict.py
+++ b/tests/unit/torch/puzzletron/test_sanity_verdict.py
@@ -149,12 +149,8 @@ def test_folded_correctness_failure_preserves_advisory_finding_severity(tmp_path
             passed=False,
             blocking=True,
             findings=[
-                finding_from_message(
-                    stage="width_sanity", message="ranking quality regressed"
-                ),
-                finding_from_message(
-                    stage="sort_sanity", message="sorted teacher drifted"
-                ),
+                finding_from_message(stage="width_sanity", message="ranking quality regressed"),
+                finding_from_message(stage="sort_sanity", message="sorted teacher drifted"),
             ],
         ),
     )

--- a/tests/unit/torch/puzzletron/test_setup_v2_state_validation.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_state_validation.py
@@ -337,10 +337,6 @@ def test_hugging_face_subset_selection_accepts_revision_locked_metadata(tmp_path
         },
     )
 
-    issues = [
-        issue
-        for issue in validate_state(state)
-        if issue.path.startswith("data.subsets")
-    ]
+    issues = [issue for issue in validate_state(state) if issue.path.startswith("data.subsets")]
 
     assert issues == []

--- a/tests/unit/torch/puzzletron/test_width_sanity_aggregation.py
+++ b/tests/unit/torch/puzzletron/test_width_sanity_aggregation.py
@@ -73,9 +73,18 @@ def test_aggregation_separates_ranking_from_physical_equivalence():
     summaries = {
         "axis_a": {
             "rows": [
-                {"axis": "axis_a", "layer_idx": 2, "target_value": 4, "method": method, "loss": loss}
+                {
+                    "axis": "axis_a",
+                    "layer_idx": 2,
+                    "target_value": 4,
+                    "method": method,
+                    "loss": loss,
+                }
                 for method, loss in (
-                    ("activation", 0.5), ("random", 0.8), ("reverse", 0.9), ("realized", 0.5)
+                    ("activation", 0.5),
+                    ("random", 0.8),
+                    ("reverse", 0.9),
+                    ("realized", 0.5),
                 )
             ]
         },
@@ -85,7 +94,10 @@ def test_aggregation_separates_ranking_from_physical_equivalence():
             "rows": [
                 {"role": role, "metrics": {"loss": loss}}
                 for role, loss in (
-                    ("activation", 1.0), ("original", 0.9), ("reverse", 0.8), ("realized", 1.2)
+                    ("activation", 1.0),
+                    ("original", 0.9),
+                    ("reverse", 0.8),
+                    ("realized", 1.2),
                 )
             ],
         },
@@ -100,8 +112,7 @@ def test_aggregation_separates_ranking_from_physical_equivalence():
     assert width["axes"] == ["axis_a", "hidden_width"]
     assert slicing["axes"] == ["axis_a", "hidden_width"]
     assert any(
-        finding["evidence"]["group"]["axis"] == "hidden_width"
-        for finding in slicing["findings"]
+        finding["evidence"]["group"]["axis"] == "hidden_width" for finding in slicing["findings"]
     )
     assert all("hidden_width" not in finding["message"] for finding in slicing["findings"])
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Running the repository's Ruff and yamlfmt hooks on the current Puzzletron implementation, setup utility, unit tests, and launcher examples rewrites files even when their behavior has not changed. A developer who modifies one of these paths can therefore get formatter-generated changes or a code-quality failure caused by formatting that was already present on the target branch. Those unrelated rewrites obscure the developer's actual change and make reviews harder.

This PR commits the formatter output for 22 Python files across the Puzzletron package, setup utility, and unit tests, plus four YAML launcher examples. Isolating the normalization in this PR gives those paths a clean formatting baseline without mixing the rewrites into later feature or bug-fix PRs.

The Python changes preserve equivalent ASTs, and the YAML changes preserve equivalent parsed values. Ruff findings that cannot be fixed automatically are not changed here, keeping this PR limited to formatter-generated, behavior-neutral updates.

### Testing

Existing CI covers the changed code and examples. The configured Ruff formatter and yamlfmt hooks were rerun and produced no further changes. Python AST equivalence and YAML value equivalence were verified against the target branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Simplified example runner and setup configurations by leaving optional settings unspecified instead of explicitly assigning empty values.

* **Style**
  * Standardized formatting across orchestration, diagnostics, reporting, setup, and registry code without changing behavior or APIs.

* **Tests**
  * Reformatted test cases and assertions for consistency while preserving existing coverage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->