### PR TITLE
Map checked-in experiment configs to worker repository paths

### DIFF
--- a/modelopt/torch/puzzletron/orchestration/compiler.py
+++ b/modelopt/torch/puzzletron/orchestration/compiler.py
@@ -61,6 +61,8 @@ __all__ = [
     "resolve_stage_execution_specs",
 ]
 
+_CONTROLLER_REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+
 
 def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
@@ -268,6 +270,19 @@ def _load_yaml(path: str | Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"YAML root must be a mapping: {path}")
     return payload
+
+
+def _worker_experiment_path(path: Path, runner: RunnerEnvironment) -> str:
+    """Map a checked-in config to the repository path visible to workers."""
+
+    resolved = path.resolve()
+    try:
+        relative = resolved.relative_to(_CONTROLLER_REPOSITORY_ROOT)
+    except ValueError:
+        # Generated campaign bundles normally live on shared storage outside
+        # the checkout and retain that explicitly configured absolute path.
+        return str(resolved)
+    return str(Path(runner.contract.repository) / relative)
 
 
 def load_runner_config(path: str | Path) -> RunnerEnvironment:
@@ -574,7 +589,7 @@ def compile_campaign_plan(
 
     contract_hash = execution_contract_hash(runner)
     return CampaignPlan(
-        experiment_config_path=str(experiment_path.resolve()),
+        experiment_config_path=_worker_experiment_path(experiment_path, runner),
         puzzle_dir=puzzle_dir,
         experiment_config=experiment_config,
         runner=runner,

--- a/tests/unit/torch/puzzletron/test_orchestration_compiler.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_compiler.py
@@ -138,6 +138,21 @@ def test_compile_campaign_plan_packs_vllm_stats_instances(tmp_configs):
     assert vllm_node.total_gpus == 16
 
 
+def test_external_campaign_config_keeps_shared_absolute_path(tmp_configs) -> None:
+    experiment_path, runner_path, execution_path = tmp_configs
+    runner_payload = yaml.safe_load(runner_path.read_text())
+    runner_payload["runner"]["execution_contract"]["repository"] = "/worker/modelopt"
+    runner_path.write_text(yaml.safe_dump(runner_payload))
+
+    plan = compile_campaign_plan(
+        experiment_config_path=experiment_path,
+        runner=load_runner_config(runner_path),
+        execution=load_execution_config(execution_path),
+    )
+
+    assert plan.experiment_config_path == str(experiment_path.resolve())
+
+
 def test_compile_campaign_plan_preserves_drain_halt_policy(tmp_configs):
     experiment_path, runner_path, execution_path = tmp_configs
     runner = load_runner_config(runner_path)

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_smoke_plan.py
@@ -158,3 +158,15 @@ def test_qwen3p5_0p8b_runner_requires_an_explicit_site_contract() -> None:
     assert runner.contract.container.startswith("REPLACE_WITH_")
     assert runner.contract.container_mounts is not None
     assert runner.contract.container_mounts.startswith("REPLACE_WITH_")
+
+
+def test_qwen3p5_0p8b_plan_uses_worker_visible_experiment_path(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plan = _compile_plan(monkeypatch, tmp_path)
+    expected = Path(plan.runner.contract.repository) / RUN_PATH.resolve().relative_to(
+        REPOSITORY_ROOT.resolve()
+    )
+
+    assert plan.experiment_config_path == str(expected)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Puzzletron campaign planning currently stores the experiment config as an absolute path from the controller checkout. Slurm and container workers receive that path in generated commands, but their checkout can be mounted at a different location. A valid campaign can therefore fail before a stage starts because the worker cannot open the config file.

For checked-in experiment configs, this change replaces the controller checkout prefix with the repository path declared by the runner execution contract. Configs outside the source checkout, such as generated campaign bundles on shared storage, keep their resolved absolute path. Controller-side config loading is unchanged.

### Testing

Unit coverage verifies both contracts: checked-in Qwen configs map to the worker repository, while external shared-storage configs retain their absolute path. Existing orchestration coverage exercises the compiled campaign plan and dependency-light dry-run path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved experiment configuration path handling when running campaigns from shared or external repositories.
  * Ensured worker-side paths resolve correctly while preserving absolute paths for configurations outside the repository.

* **Tests**
  * Added coverage for external configuration paths.
  * Added validation for repository-relative configuration paths in compiled plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->