### PR TITLE
Fix changed-file code quality checks

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -35,9 +35,10 @@ jobs:
           extra_args: --results=verified,unknown
       - name: Run changed-file code quality checks
         if: github.event_name == 'pull_request' && github.base_ref == 'feature/puzzletron_v2'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: pip install nox uv && nox -s pre_commit_diff -- "$BASE_SHA" HEAD
+        # The pull-request payload can retain an older base SHA after the target branch advances.
+        # actions/checkout checks out GitHub's current synthetic merge, whose first parent is the
+        # exact target snapshot used to build that merge.
+        run: pip install nox uv && nox -s pre_commit_diff -- HEAD^1 HEAD
       - name: Run all-file code quality checks
         if: github.event_name != 'pull_request' || github.base_ref != 'feature/puzzletron_v2'
         run: pip install nox uv && nox -s pre_commit_all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
+        # --interactive clears legacy non_interactive config while automatic installs stay off.
+        args: [--no-install-types, --interactive]
+        additional_dependencies:
+          - nox==2026.4.10
+          - types-docutils==0.22.3.20260724
+          - types-PyYAML==6.0.12.20260724
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -375,6 +375,8 @@ def _run_mypy(session, checkout, paths, cache_dir):
 
 
 def _run_changed_file_mypy(session, from_ref, to_ref):
+    """Run mypy on the base and head snapshots and report only new diagnostics."""
+
     changed_file_output = session.run(
         "git",
         "diff",

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,11 @@ Usage:
 import glob
 import json
 import os
+import re
 import shutil
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 import nox
@@ -239,13 +243,237 @@ def pre_commit_all(session):
     session.run("pre-commit", "run", "--all-files", "--show-diff-on-failure")
 
 
+@dataclass(frozen=True)
+class _ChangedPythonFile:
+    base_path: str | None
+    head_path: str
+
+
+@dataclass(frozen=True)
+class _MypyDiagnostic:
+    path: str
+    line: int
+    column: int | None
+    message: str
+    code: str | None
+    raw: str
+
+    @property
+    def fingerprint(self):
+        return self.path, self.message, self.code
+
+
+_MYPY_LOCATION = re.compile(
+    r"^(?P<path>.*?):(?P<line>\d+)(?::(?P<column>\d+))?: error: (?P<message>.*)$"
+)
+_MYPY_CODE = re.compile(r"^(?P<message>.*)  \[(?P<code>[^]]+)\]$")
+_MYPY_DIFF_DEPENDENCIES = ("types-PyYAML==6.0.12.20260724",)
+
+
+def _normalize_diagnostic_path(path):
+    normalized = path.replace("\\", "/")
+    return normalized.removeprefix("./")
+
+
+def _parse_changed_python_files(output):
+    changes = []
+    for line in output.splitlines():
+        fields = line.split("\t")
+        status = fields[0][:1]
+        if status == "R" and len(fields) == 3:
+            changes.append(_ChangedPythonFile(base_path=fields[1], head_path=fields[2]))
+        elif status == "C" and len(fields) == 3:
+            changes.append(_ChangedPythonFile(base_path=None, head_path=fields[2]))
+        elif status == "A" and len(fields) == 2:
+            changes.append(_ChangedPythonFile(base_path=None, head_path=fields[1]))
+        elif status == "M" and len(fields) == 2:
+            changes.append(_ChangedPythonFile(base_path=fields[1], head_path=fields[1]))
+        else:
+            raise ValueError(f"Unsupported git name-status line: {line!r}")
+    return tuple(changes)
+
+
+def _parse_mypy_diagnostics(output):
+    diagnostics = []
+    for line in output.splitlines():
+        location_match = _MYPY_LOCATION.match(line)
+        if location_match is None:
+            continue
+
+        message = location_match.group("message")
+        code_match = _MYPY_CODE.match(message)
+        code = None
+        if code_match is not None:
+            message = code_match.group("message")
+            code = code_match.group("code")
+        column = location_match.group("column")
+        diagnostics.append(
+            _MypyDiagnostic(
+                path=_normalize_diagnostic_path(location_match.group("path")),
+                line=int(location_match.group("line")),
+                column=int(column) if column is not None else None,
+                message=message,
+                code=code,
+                raw=line,
+            )
+        )
+    return tuple(diagnostics)
+
+
+def _new_mypy_diagnostics(base_output, head_output, base_to_head_paths: dict[str, str]):
+    available_base_diagnostics = Counter(
+        (
+            _normalize_diagnostic_path(base_to_head_paths.get(diagnostic.path, diagnostic.path)),
+            diagnostic.message,
+            diagnostic.code,
+        )
+        for diagnostic in _parse_mypy_diagnostics(base_output)
+    )
+
+    new_diagnostics = []
+    for diagnostic in _parse_mypy_diagnostics(head_output):
+        if available_base_diagnostics[diagnostic.fingerprint]:
+            available_base_diagnostics[diagnostic.fingerprint] -= 1
+        else:
+            new_diagnostics.append(diagnostic)
+    return tuple(new_diagnostics)
+
+
+def _resolve_git_commit(session, ref):
+    return session.run(
+        "git",
+        "rev-parse",
+        "--verify",
+        f"{ref}^{{commit}}",
+        external=True,
+        silent=True,
+    ).strip()
+
+
+def _run_mypy(session, checkout, paths, cache_dir):
+    if not paths:
+        return ""
+    with session.chdir(checkout):
+        return session.run(
+            "mypy",
+            "--no-install-types",
+            "--interactive",
+            "--no-error-summary",
+            "--no-color-output",
+            "--no-pretty",
+            "--show-column-numbers",
+            "--show-error-codes",
+            "--follow-imports=skip",
+            "--ignore-missing-imports",
+            "--cache-dir",
+            str(cache_dir),
+            "--",
+            *paths,
+            success_codes=[0, 1],
+            silent=True,
+        )
+
+
+def _run_changed_file_mypy(session, from_ref, to_ref):
+    changed_file_output = session.run(
+        "git",
+        "diff",
+        "--name-status",
+        "--find-renames",
+        "--diff-filter=ACMR",
+        f"{from_ref}...{to_ref}",
+        "--",
+        "*.py",
+        external=True,
+        silent=True,
+    )
+    changes = _parse_changed_python_files(changed_file_output)
+    if not changes:
+        session.log("mypy diff ratchet: no changed Python files")
+        return
+
+    repository = session.run(
+        "git", "rev-parse", "--show-toplevel", external=True, silent=True
+    ).strip()
+    with tempfile.TemporaryDirectory(prefix="modelopt-mypy-diff-") as temporary_directory:
+        temporary_path = Path(temporary_directory)
+        checkout = temporary_path / "checkout"
+        checkout_index = checkout / ".git" / "index"
+        session.run(
+            "git",
+            "clone",
+            "--quiet",
+            "--shared",
+            "--no-checkout",
+            repository,
+            str(checkout),
+            external=True,
+        )
+
+        session.run(
+            "git",
+            "-C",
+            str(checkout),
+            "checkout",
+            "--quiet",
+            "--detach",
+            from_ref,
+            external=True,
+            env={"GIT_INDEX_FILE": str(checkout_index)},
+        )
+        base_paths = [change.base_path for change in changes if change.base_path is not None]
+        missing_base_paths = [path for path in base_paths if not (checkout / path).is_file()]
+        if missing_base_paths:
+            session.error(f"mypy diff base paths are missing: {', '.join(missing_base_paths)}")
+        base_output = _run_mypy(session, checkout, base_paths, temporary_path / "base-mypy-cache")
+
+        session.run(
+            "git",
+            "-C",
+            str(checkout),
+            "checkout",
+            "--quiet",
+            "--detach",
+            to_ref,
+            external=True,
+            env={"GIT_INDEX_FILE": str(checkout_index)},
+        )
+        head_paths = [change.head_path for change in changes]
+        missing_head_paths = [path for path in head_paths if not (checkout / path).is_file()]
+        if missing_head_paths:
+            session.error(f"mypy diff head paths are missing: {', '.join(missing_head_paths)}")
+        head_output = _run_mypy(session, checkout, head_paths, temporary_path / "head-mypy-cache")
+
+    session.log(f"mypy base diagnostics ({from_ref}):\n{base_output.rstrip() or '(none)'}")
+    session.log(f"mypy head diagnostics ({to_ref}):\n{head_output.rstrip() or '(none)'}")
+
+    base_to_head_paths = {
+        change.base_path: change.head_path for change in changes if change.base_path is not None
+    }
+    new_diagnostics = _new_mypy_diagnostics(base_output, head_output, base_to_head_paths)
+    head_diagnostics = _parse_mypy_diagnostics(head_output)
+    if new_diagnostics:
+        formatted_diagnostics = "\n".join(diagnostic.raw for diagnostic in new_diagnostics)
+        session.log(f"New mypy diagnostics:\n{formatted_diagnostics}")
+        session.error(
+            f"mypy diff ratchet found {len(new_diagnostics)} new diagnostic(s) "
+            f"among {len(head_diagnostics)} at the head"
+        )
+    session.log(
+        f"mypy diff ratchet passed with {len(head_diagnostics)} head diagnostic(s) "
+        "and no new diagnostics"
+    )
+
+
 @nox.session
 def pre_commit_diff(session):
     if len(session.posargs) not in (0, 2):
         session.error("pre_commit_diff expects optional FROM_REF and TO_REF arguments")
 
     from_ref, to_ref = session.posargs or ("origin/main", "HEAD")
-    session.install("-e", ".[all,dev-lint]")
+    from_ref = _resolve_git_commit(session, from_ref)
+    to_ref = _resolve_git_commit(session, to_ref)
+    session.install("-e", ".[all,dev-lint]", *_MYPY_DIFF_DEPENDENCIES)
     skip_hooks = {hook for hook in os.environ.get("SKIP", "").split(",") if hook}
     skip_hooks.add("mypy")
     session.run(
@@ -258,28 +486,7 @@ def pre_commit_diff(session):
         "--show-diff-on-failure",
         env={"SKIP": ",".join(sorted(skip_hooks))},
     )
-
-    changed_files = session.run(
-        "git",
-        "diff",
-        "--name-only",
-        "--diff-filter=ACMR",
-        f"{from_ref}...{to_ref}",
-        "--",
-        "*.py",
-        external=True,
-        silent=True,
-    )
-    changed_python_files = [path for path in changed_files.splitlines() if Path(path).is_file()]
-    if changed_python_files:
-        session.run(
-            "mypy",
-            "--cache-dir",
-            os.devnull,
-            "--follow-imports=skip",
-            "--ignore-missing-imports",
-            *changed_python_files,
-        )
+    _run_changed_file_mypy(session, from_ref, to_ref)
 
 
 # ─── Docs ─────────────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,7 @@ skips = [
 # Show a short test summary info for all except passed tests with -ra flag
 # print execution time for 50 slowest tests and generate coverage reports
 addopts = "-v -ra --instafail --cov-report=term-missing --cov-report=html --cov-report=xml:coverage.xml --cov-config=pyproject.toml --durations=50 --strict-markers"
-pythonpath = ["tests/"]
+pythonpath = ["tests/", "."]
 # Apply per-test timeouts (see tests/conftest.py) to the test call only, not fixture setup/teardown
 timeout_func_only = true
 markers = [

--- a/tests/unit/tools/ci/test_mypy_diff.py
+++ b/tests/unit/tools/ci/test_mypy_diff.py
@@ -17,9 +17,13 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 from contextlib import nullcontext
 from pathlib import Path
+
+import pytest
+import yaml
 
 from noxfile import (
     _ChangedPythonFile,
@@ -60,6 +64,11 @@ def test_parse_changed_python_files_tracks_paths_across_statuses():
         _ChangedPythonFile(base_path="old.py", head_path="renamed.py"),
         _ChangedPythonFile(base_path=None, head_path="copied.py"),
     )
+
+
+def test_parse_changed_python_files_rejects_unsupported_status():
+    with pytest.raises(ValueError, match="Unsupported git name-status line"):
+        _parse_changed_python_files("D\tdeleted.py")
 
 
 def test_new_mypy_diagnostics_preserves_inherited_errors_after_line_shift():
@@ -134,9 +143,9 @@ def test_merge_parent_avoids_target_only_files_selected_by_stale_event_base(tmp_
     (tmp_path / "target_only.py").write_text("target = True\n", encoding="utf-8")
     _git(tmp_path, "add", "target_only.py")
     _git(tmp_path, "commit", "-m", "advance target")
-    current_base = _git(tmp_path, "rev-parse", "HEAD")
     _git(tmp_path, "merge", "--no-ff", "topic", "-m", "synthetic pull request merge")
     merge_head = _git(tmp_path, "rev-parse", "HEAD")
+    current_base = _git(tmp_path, "rev-parse", f"{merge_head}^1")
 
     stale_output = _git(
         tmp_path,
@@ -164,16 +173,36 @@ def test_merge_parent_avoids_target_only_files_selected_by_stale_event_base(tmp_
 
 
 def test_code_quality_uses_checked_out_pull_request_merge_parent():
-    workflow = (REPOSITORY_ROOT / ".github/workflows/code_quality.yml").read_text(encoding="utf-8")
+    workflow = yaml.safe_load(
+        (REPOSITORY_ROOT / ".github/workflows/code_quality.yml").read_text(encoding="utf-8")
+    )
+    changed_file_step = next(
+        step
+        for step in workflow["jobs"]["code-quality"]["steps"]
+        if step.get("name") == "Run changed-file code quality checks"
+    )
+    command = shlex.split(changed_file_step["run"])
 
-    assert "nox -s pre_commit_diff -- HEAD^1 HEAD" in workflow
-    assert "github.event.pull_request.base.sha" not in workflow
+    assert command[-6:] == ["nox", "-s", "pre_commit_diff", "--", "HEAD^1", "HEAD"]
+    assert "github.event.pull_request.base.sha" not in changed_file_step["run"]
 
 
 def test_mypy_hook_pins_stubs_and_disables_automatic_installation():
-    config = (REPOSITORY_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    config = yaml.safe_load(
+        (REPOSITORY_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    )
+    hook = next(
+        hook
+        for repository in config["repos"]
+        for hook in repository["hooks"]
+        if hook["id"] == "mypy"
+    )
+    dependencies = hook["additional_dependencies"]
 
-    assert "args: [--no-install-types, --interactive]" in config
-    assert "nox==2026.4.10" in config
-    assert "types-docutils==0.22.3.20260724" in config
-    assert "types-PyYAML==6.0.12.20260724" in config
+    assert hook["args"] == ["--no-install-types", "--interactive"]
+    assert {dependency.split("==", maxsplit=1)[0] for dependency in dependencies} == {
+        "nox",
+        "types-docutils",
+        "types-PyYAML",
+    }
+    assert all(dependency.count("==") == 1 for dependency in dependencies)

--- a/tests/unit/tools/ci/test_mypy_diff.py
+++ b/tests/unit/tools/ci/test_mypy_diff.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the changed-file mypy quality ratchet."""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import nullcontext
+from pathlib import Path
+
+from noxfile import (
+    _ChangedPythonFile,
+    _new_mypy_diagnostics,
+    _parse_changed_python_files,
+    _run_mypy,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_parse_changed_python_files_tracks_paths_across_statuses():
+    output = "\n".join(
+        [
+            "A\tadded.py",
+            "M\tmodified.py",
+            "R100\told.py\trenamed.py",
+            "C095\tsource.py\tcopied.py",
+        ]
+    )
+
+    changes = _parse_changed_python_files(output)
+
+    assert changes == (
+        _ChangedPythonFile(base_path=None, head_path="added.py"),
+        _ChangedPythonFile(base_path="modified.py", head_path="modified.py"),
+        _ChangedPythonFile(base_path="old.py", head_path="renamed.py"),
+        _ChangedPythonFile(base_path=None, head_path="copied.py"),
+    )
+
+
+def test_new_mypy_diagnostics_preserves_inherited_errors_after_line_shift():
+    base_output = "old.py:10:5: error: Incompatible return value type  [return-value]"
+    head_output = "\n".join(
+        [
+            "renamed.py:14:5: error: Incompatible return value type  [return-value]",
+            "renamed.py:20:1: error: Missing return statement  [return]",
+        ]
+    )
+
+    diagnostics = _new_mypy_diagnostics(base_output, head_output, {"old.py": "renamed.py"})
+
+    assert [diagnostic.raw for diagnostic in diagnostics] == [
+        "renamed.py:20:1: error: Missing return statement  [return]"
+    ]
+
+
+def test_new_mypy_diagnostics_preserves_error_multiplicity():
+    base_output = "module.py:10:5: error: Missing return statement  [return]"
+    head_output = "\n".join(
+        [
+            "module.py:12:5: error: Missing return statement  [return]",
+            "module.py:20:5: error: Missing return statement  [return]",
+        ]
+    )
+
+    diagnostics = _new_mypy_diagnostics(base_output, head_output, {"module.py": "module.py"})
+
+    assert [diagnostic.raw for diagnostic in diagnostics] == [
+        "module.py:20:5: error: Missing return statement  [return]"
+    ]
+
+
+def test_run_mypy_separates_paths_from_options():
+    class RecordingSession:
+        def __init__(self):
+            self.arguments = ()
+
+        def chdir(self, _checkout):
+            return nullcontext()
+
+        def run(self, *arguments, **_kwargs):
+            self.arguments = arguments
+            return ""
+
+    session = RecordingSession()
+
+    _run_mypy(session, Path("checkout"), ["-strict.py"], Path("cache"))
+
+    assert session.arguments[-2:] == ("--", "-strict.py")
+
+
+def test_merge_parent_avoids_target_only_files_selected_by_stale_event_base(tmp_path):
+    _git(tmp_path, "init", "--initial-branch=main")
+    _git(tmp_path, "config", "user.name", "ModelOpt CI")
+    _git(tmp_path, "config", "user.email", "modelopt-ci@example.com")
+    _git(tmp_path, "config", "commit.gpgsign", "false")
+    _git(tmp_path, "config", "core.hooksPath", ".git/no-hooks")
+
+    (tmp_path / "base.py").write_text("value = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", "base.py")
+    _git(tmp_path, "commit", "-m", "base")
+    stale_base = _git(tmp_path, "rev-parse", "HEAD")
+
+    _git(tmp_path, "switch", "-c", "topic")
+    (tmp_path / "README.md").write_text("documentation\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-m", "docs")
+
+    _git(tmp_path, "switch", "main")
+    (tmp_path / "target_only.py").write_text("target = True\n", encoding="utf-8")
+    _git(tmp_path, "add", "target_only.py")
+    _git(tmp_path, "commit", "-m", "advance target")
+    current_base = _git(tmp_path, "rev-parse", "HEAD")
+    _git(tmp_path, "merge", "--no-ff", "topic", "-m", "synthetic pull request merge")
+    merge_head = _git(tmp_path, "rev-parse", "HEAD")
+
+    stale_output = _git(
+        tmp_path,
+        "diff",
+        "--name-status",
+        "--diff-filter=ACMR",
+        f"{stale_base}...{merge_head}",
+        "--",
+        "*.py",
+    )
+    exact_output = _git(
+        tmp_path,
+        "diff",
+        "--name-status",
+        "--diff-filter=ACMR",
+        f"{current_base}...{merge_head}",
+        "--",
+        "*.py",
+    )
+
+    assert _parse_changed_python_files(stale_output) == (
+        _ChangedPythonFile(base_path=None, head_path="target_only.py"),
+    )
+    assert _parse_changed_python_files(exact_output) == ()
+
+
+def test_code_quality_uses_checked_out_pull_request_merge_parent():
+    workflow = (REPOSITORY_ROOT / ".github/workflows/code_quality.yml").read_text(encoding="utf-8")
+
+    assert "nox -s pre_commit_diff -- HEAD^1 HEAD" in workflow
+    assert "github.event.pull_request.base.sha" not in workflow
+
+
+def test_mypy_hook_pins_stubs_and_disables_automatic_installation():
+    config = (REPOSITORY_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert "args: [--no-install-types, --interactive]" in config
+    assert "nox==2026.4.10" in config
+    assert "types-docutils==0.22.3.20260724" in config
+    assert "types-PyYAML==6.0.12.20260724" in config


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

The changed-file code-quality job currently reads the pull request base SHA from the event payload. That value can lag the synthetic merge checked out for a run, causing target-only files and inherited mypy diagnostics to be attributed to an unrelated pull request.

This change binds the comparison to the checked-out merge's first parent, pins the mypy hook dependencies used by the diff session, and compares normalized base and head diagnostics so only newly introduced errors fail the gate. Renames and copies are handled explicitly, and repository-controlled paths are separated from mypy options.

### Testing

The code-quality workflow gains focused coverage for merge-parent selection, changed-file status handling, rename-aware diagnostic comparison, multiplicity, dependency pinning, and option-safe paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request type-checking to compare the correct merge snapshots.
  * Added support for detecting changes across added, modified, renamed, and copied Python files.
  * Type-check results now highlight only newly introduced diagnostics while preserving existing issues.

* **Chores**
  * Improved pre-commit type-checking setup with required type stubs and dependencies.
  * Added comprehensive automated coverage for pull request quality checks.
  * Updated test configuration for more reliable project-wide test discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->