### PR TITLE
feat(speculative): support Gemma-4-E4B as a streaming DFlash/DSpark target

### DIFF
--- a/examples/speculative_decoding/debug/README.md
+++ b/examples/speculative_decoding/debug/README.md
@@ -1,0 +1,76 @@
+# Draft train-vs-serve activation diff
+
+Tools for answering "the drafter trains fine but acceptance is ~1.0 — where do
+training and serving disagree?" by running ONE fixed sample through both paths
+and diffing every intermediate tensor in forward order.
+
+This found a real defect on Gemma-4-E4B: `FakeBaseModel` rebuilt the base
+embedding as a plain `nn.Embedding` and dropped Gemma's `sqrt(hidden_size)`
+forward-time scale, so the draft trained on inputs 50.6x smaller than vLLM feeds
+it at serve time. Training loss fell normally and `train_acc` reached 31.5%,
+while MT-Bench AL sat at 1.0040. Nothing errored anywhere.
+
+## Why activation diffing and not more AL runs
+
+AL is an end-to-end scalar. It cannot tell you *where* the two paths diverge,
+and it is easily confounded by a second unrelated defect. Five config-level
+hypotheses (chat template, `target_layer_ids`, weight loading, embedding scale
+tested on the *serving* side, RoPE theta) were each tested against AL and each
+gave a wrong answer. The activation diff localized the bug in one run.
+
+## Usage
+
+    # 1. serving-side reference (also produces the aux hidden states)
+    python dump_serve.py --base <base> --draft <vllm-format drafter> \
+        --corpus <jsonl> --row 0 --anchor 64 --seqlen 256 \
+        --capture-ids 6,12,18,24,36,42 --chat-template <jinja> --out OUT
+
+    # 2. training side, consuming the SAME aux tensors
+    python dump_train.py --ckpt <training checkpoint> --base <base> \
+        --corpus <jsonl> --row 0 --anchor 64 --seqlen 256 \
+        --chat-template <jinja> --aux-from OUT/eval_dump.pt --out OUT
+
+    # 3. diff, in forward order -- the FIRST mismatch localizes the bug
+    python compare_activations.py OUT/train_dump.pt OUT/eval_dump.pt
+
+Both sides must consume identical aux hidden states (`--aux-from`) and the same
+fixed anchor, or the comparison is meaningless: anchors are normally sampled
+with `torch.rand`, so `dump_train.py` monkeypatches `_sample_anchor_positions`.
+
+## Scope
+
+`dump_serve.py` is a faithful reimplementation of vLLM's Gemma4DSpark math, not
+a wrapper around vLLM's kernels. On the validation sample it agrees with the
+ModelOpt training path to <2% (bf16 accumulation) with identical top-1 tokens.
+That is enough to localize logic bugs — wrong scale, wrong mask, wrong layer
+wiring — but it does NOT validate vLLM's paged-attention kernel, which needs a
+populated KV cache and attention metadata to exercise. Treat "serving" here as
+"the serving math", not "the serving kernel".
+
+`probe_norm_grads.py` runs one real backward and prints per-parameter gradient
+norms — use it to tell "gradients are zero" (broken graph) apart from
+"gradients flow but updates round away" (bf16 resolution).
+
+## Traps, all of which cost real debugging time
+
+- **Report a norm RATIO, not just cosine.** Cosine is blind to pure scale
+  errors: the 50.6x embedding bug showed `cos = 1.000003`. Cosine over a
+  flattened multi-million-element bf16 tensor is also unreliable near 1.0 — it
+  read `1.0035` on bit-identical inputs. Trust `max|d|` and relative error.
+- **Offline/streaming checkpoints refuse an eval forward** (base layers are
+  deleted). Run `model.train()` under `no_grad` and pass `base_model_outputs`.
+- **`mto.enable_huggingface_checkpointing()` is required** before
+  `from_pretrained`, or you get a bare `FakeBaseModel` and every
+  `dflash_module.*` tensor is silently reported UNEXPECTED and dropped.
+- **ModelOpt has its own `apply_rotary_pos_emb`** (Q takes the LAST `q_len`
+  positions, K takes all). The Qwen3 one assumes `len(Q) == len(K)` and raises.
+- **vLLM's `_kv_proj` returns K *after* `k_norm`.** Tapping raw `k_proj` output
+  on the training side compares different tensors (looked like 16%, was 0%).
+- **The draft attention mask is not a per-query causal ramp.** Measured from the
+  tensor training actually passes to SDPA: all draft queries in a block share
+  ONE window over context `[0, anchor)` — position `anchor` itself is excluded —
+  plus the full block. A block is predicted in one shot.
+- **HF `sdpa_attention_forward` returns `.transpose(1, 2)`** → `[B, q, H, D]`.
+  Reconstructing with `einsum(...->qhd)` gives different head packing.
+- **`VLLM_ENABLE_V1_MULTIPROCESSING=0`** is required to reach a constructed vLLM
+  module from the driver process; otherwise EngineCore spawns elsewhere.

--- a/examples/speculative_decoding/debug/compare_activations.py
+++ b/examples/speculative_decoding/debug/compare_activations.py
@@ -1,0 +1,79 @@
+"""Sub-step diff: TRAIN (real ModelOpt) vs EVAL (real vLLM module).
+
+Auto-pairs every tensor present in both dumps and reports them in forward order.
+Reports max|d| and RELATIVE error -- cosine over a flattened 3M-element bf16
+tensor is unreliable near 1.0 (it read 1.0035 on bit-identical inputs earlier),
+so relative error is the column to trust.
+"""
+
+import re
+import sys
+
+import torch
+
+tr = torch.load(sys.argv[1], map_location="cpu")
+ev = torch.load(sys.argv[2], map_location="cpu")
+
+PRE = ["input_ids", "noise_ids", "position_ids", "aux_hidden", "ctx_fc",
+       "ctx_hidden_norm", "noise_embedding"]
+STEP = ["input_layernorm", "q_proj", "q_norm", "q_rope", "k_proj_block",
+        "k_rope_block", "k_proj_ctx", "k_rope_ctx", "attn_out", "o_proj",
+        "post_attn_norm", "after_attn_residual", "pre_ffn_norm", "mlp",
+        "post_ffn_norm", "out"]
+
+order = [k for k in PRE if k in tr or k in ev]
+layers = sorted({int(m.group(1)) for k in list(tr) + list(ev)
+                 if (m := re.match(r"L(\d+)_", k))})
+for li in layers:
+    for st in STEP:
+        n = f"L{li}_{st}"
+        if n in tr or n in ev:
+            order.append(n)
+for tail in ("draft_final", "backbone_logits", "top1_backbone"):
+    if tail in tr or tail in ev:
+        order.append(tail)
+
+print("=" * 96)
+print("  TRAIN (ModelOpt) vs EVAL (real vLLM module) -- sub-step diff, forward order")
+print("=" * 96)
+print(f"  {'tensor':<28}{'shape':>16}{'max|d|':>13}{'rel_max':>10}{'rel_rms':>10}  verdict")
+print("-" * 96)
+
+first = None
+for n in order:
+    if n not in tr or n not in ev:
+        print(f"  {n:<28}{'':>16}{'':>13}{'':>10}{'':>10}  "
+              f"{'train only' if n in tr else 'eval only'}")
+        continue
+    a, b = tr[n].float(), ev[n].float()
+    if a.shape != b.shape:
+        if a.numel() == b.numel():
+            b = b.reshape(a.shape)
+        else:
+            print(f"  {n:<28}{str(tuple(a.shape)):>16}{'':>13}{'':>10}{'':>10}"
+                  f"  SHAPE {tuple(a.shape)} vs {tuple(b.shape)}")
+            continue
+    if "ids" in n or "top1" in n:
+        eq = (a == b).float().mean().item()
+        print(f"  {n:<28}{str(tuple(a.shape)):>16}{'':>13}{'':>10}{eq:>9.1%}  "
+              f"{'IDENTICAL' if eq == 1.0 else 'DIFFER'}")
+        continue
+    md = (a - b).abs().max().item()
+    scale = max(a.abs().max().item(), b.abs().max().item(), 1e-9)
+    rmsd = (a - b).pow(2).mean().sqrt().item()
+    rms = max(a.pow(2).mean().sqrt().item(), 1e-9)
+    rel, relr = md / scale, rmsd / rms
+    if md == 0.0:
+        v = "BIT-EXACT"
+    elif rel < 0.02:
+        v = "ok (numeric)"
+    else:
+        v = "<-- MISMATCH"
+        if first is None:
+            first = n
+    print(f"  {n:<28}{str(tuple(a.shape)):>16}{md:>13.4e}{rel:>9.2%}{relr:>9.2%}  {v}")
+
+print("=" * 96)
+print(f"  FIRST MISMATCH (>2% rel): {first}" if first
+      else "  All paired tensors agree within numeric tolerance.")
+print("=" * 96)

--- a/examples/speculative_decoding/debug/dump_serve.py
+++ b/examples/speculative_decoding/debug/dump_serve.py
@@ -1,0 +1,208 @@
+"""SERVING-side activation dump for the same fixed sample and anchor.
+
+Recomputes the drafter forward with the exported (vLLM-format) checkpoint,
+following vLLM's Gemma4DSpark math: `embed_tokens(ids) * sqrt(hidden_size)`,
+`fc` -> `hidden_norm` on the aux states, k_eq_v (V from the K projection, no
+v_proj), and the block attention mask measured from the training side.
+
+Scope, stated plainly: this is a faithful REIMPLEMENTATION of the serving math,
+not vLLM's own kernels. It agrees with the ModelOpt training path to <2%
+(bf16 accumulation) with identical top-1, which is enough to localize logic
+bugs. It is NOT a substitute for validating vLLM's paged-attention kernel,
+which needs a populated KV cache and attention metadata.
+
+Dumps the same tensor names as dump_train.py so the two are directly diffable.
+"""
+
+import argparse
+import json
+import os
+
+import torch
+import torch.nn.functional as F
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--base", required=True)
+ap.add_argument("--draft", required=True, help="vLLM-format drafter dir")
+ap.add_argument("--corpus", required=True)
+ap.add_argument("--row", type=int, default=0)
+ap.add_argument("--anchor", type=int, default=64)
+ap.add_argument("--seqlen", type=int, default=256)
+ap.add_argument("--capture-ids", default="6,12,18,24,36,42")
+ap.add_argument("--chat-template", default=None)
+ap.add_argument("--out", required=True)
+args = ap.parse_args()
+
+os.makedirs(args.out, exist_ok=True)
+DUMP = {}
+
+
+def save(name, t):
+    if isinstance(t, torch.Tensor):
+        DUMP[name] = t.detach().float().cpu()
+        print(f"  [dump] {name:<24} {tuple(t.shape)}")
+
+
+def rms(x, w, eps):
+    v = x.float()
+    v = v * torch.rsqrt(v.pow(2).mean(-1, keepdim=True) + eps)
+    return (v * w.float()).to(x.dtype)
+
+
+def main():
+    from safetensors.torch import load_file
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    dev, DT = "cuda", torch.bfloat16
+    cfg = json.load(open(os.path.join(args.draft, "config.json")))
+    H = cfg["hidden_size"]
+    NL = cfg["num_hidden_layers"]
+    NH = cfg["num_attention_heads"]
+    HD = cfg.get("global_head_dim") or cfg["head_dim"]
+    NKV = cfg.get("num_global_key_value_heads") or cfg["num_key_value_heads"]
+    EPS = cfg["rms_norm_eps"]
+    BS = cfg["block_size"]
+    MASK = cfg["dflash_config"]["mask_token_id"]
+    THETA = cfg.get("rope_theta", 10000.0)
+
+    tok = AutoTokenizer.from_pretrained(args.base)
+    if args.chat_template and os.path.exists(args.chat_template):
+        tok.chat_template = open(args.chat_template).read()
+
+    row = None
+    with open(args.corpus) as f:
+        for i, line in enumerate(f):
+            if i == args.row:
+                row = json.loads(line)
+                break
+    convs = row.get("conversations") or row.get("messages")
+    msgs = []
+    for m in convs:
+        r = m.get("role") or m.get("from")
+        c = m.get("content") or m.get("value")
+        r = {"human": "user", "gpt": "assistant"}.get(r, r)
+        msgs.append({"role": r, "content": c})
+    text = tok.apply_chat_template(msgs, tokenize=False)
+    ids = tok(text, return_tensors="pt").input_ids[:, : args.seqlen].to(dev)
+    save("input_ids", ids[0])
+
+    # ---- aux hidden states from the REAL base, at the TRAINING capture ids ----
+    base = AutoModelForCausalLM.from_pretrained(
+        args.base, dtype=DT, device_map=dev
+    ).eval()
+    with torch.no_grad():
+        o = base(ids, output_hidden_states=True)
+    hs = o.hidden_states
+    cap = [int(x) for x in args.capture_ids.split(",")]
+    print("capture ids (post-layer, vLLM convention):", cap)
+    # first N-1 are aux, last is the final/base hidden (see hf_streaming_dataset)
+    aux = torch.cat([hs[i][0] for i in cap[:-1]], dim=-1).to(DT)
+    save("aux_hidden", aux)
+    save("base_final_hidden", hs[cap[-1]][0].to(DT))
+    del base
+    torch.cuda.empty_cache()
+
+    # ---- exported drafter weights ----
+    sd = {k: v.to(dev, DT) for k, v in load_file(os.path.join(args.draft, "model.safetensors")).items()}
+    save("hidden_norm.weight", sd["hidden_norm.weight"])
+    save("fc.weight", sd["fc.weight"])
+
+    ctx_fc = F.linear(aux, sd["fc.weight"])
+    save("ctx_fc", ctx_fc)
+    ctx = rms(ctx_fc, sd["hidden_norm.weight"], EPS)
+    save("ctx_hidden_norm", ctx)
+
+    # ---- draft block input at the fixed anchor (vLLM: embed * sqrt(H)) ----
+    A = args.anchor
+    blk = torch.full((BS,), MASK, dtype=torch.long, device=dev)
+    blk[0] = ids[0, A]
+    save("noise_ids", blk)
+    x = sd["embed_tokens.weight"][blk] * (H ** 0.5)
+    save("noise_embedding", x)
+
+    # Use the FULL sequence as context, exactly as training does, so position_ids
+    # and the attended key set match on both sides. Causality is enforced by the
+    # mask below, not by truncating the context.
+    nctx = ctx.shape[0]
+    c = ctx
+    cpos = torch.arange(nctx, device=dev)
+    qpos = torch.arange(A, A + BS, device=dev)
+    save("position_ids", torch.cat([cpos, qpos]))
+
+    def rope(hd, pos):
+        inv = 1.0 / (THETA ** (torch.arange(0, hd, 2, device=dev).float() / hd))
+        f = pos.float()[:, None] * inv[None, :]
+        return torch.cos(f), torch.sin(f)
+
+    def apply(t, cos, sin):
+        d = t.shape[-1]
+        t1, t2 = t[..., : d // 2], t[..., d // 2 :]
+        cc = cos[:, None, :].to(t.dtype)
+        ss = sin[:, None, :].to(t.dtype)
+        return torch.cat([t1 * cc - t2 * ss, t2 * cc + t1 * ss], dim=-1)
+
+    cos_c, sin_c = rope(HD, cpos)
+    cos_q, sin_q = rope(HD, qpos)
+    ones = torch.ones(HD, device=dev, dtype=DT)
+
+    for li in range(NL):
+        p = f"layers.{li}."
+        res = x
+        xn = rms(x, sd[p + "input_layernorm.weight"], EPS)
+        q = rms(F.linear(xn, sd[p + "self_attn.q_proj.weight"]).view(BS, NH, HD),
+                sd[p + "self_attn.q_norm.weight"], EPS)
+        kc = rms(F.linear(c, sd[p + "self_attn.k_proj.weight"]).view(nctx, NKV, HD),
+                 sd[p + "self_attn.k_norm.weight"], EPS)
+        kn = rms(F.linear(xn, sd[p + "self_attn.k_proj.weight"]).view(BS, NKV, HD),
+                 sd[p + "self_attn.k_norm.weight"], EPS)
+        vc = rms(F.linear(c, sd[p + "self_attn.k_proj.weight"]).view(nctx, NKV, HD), ones, EPS)
+        vn = rms(F.linear(xn, sd[p + "self_attn.k_proj.weight"]).view(BS, NKV, HD), ones, EPS)
+        q = apply(q, cos_q, sin_q)
+        kc = apply(kc, cos_c, sin_c)
+        kn = apply(kn, cos_q, sin_q)
+        k = torch.cat([kc, kn], 0).repeat_interleave(NH // NKV, dim=1)
+        v = torch.cat([vc, vn], 0).repeat_interleave(NH // NKV, dim=1)
+        _q = q.permute(1, 0, 2)[None].float()          # [1,H,q,D]
+        _k = k.permute(1, 0, 2)[None].float()          # [1,H,S,D]
+        _v = v.permute(1, 0, 2)[None].float()
+        # Measured from the training mask tensor (not guessed): all 8 draft
+        # queries share ONE window over context [0, A) plus the full 8-token
+        # block. Position A itself is NOT visible, and there is no per-query
+        # causal ramp -- a DSpark block is predicted in one shot.
+        if li == 0:
+            ctx_allow = (cpos < A)[None, :].expand(BS, nctx)
+            blk_allow = torch.ones(BS, BS, dtype=torch.bool, device=dev)
+            allow = torch.cat([ctx_allow, blk_allow], dim=1)[None]  # [1, B, nctx+B]
+        _m = torch.zeros(1, 1, BS, k.shape[0], device=dev).masked_fill(
+            ~allow, float("-inf"))
+        att = F.scaled_dot_product_attention(_q, _k, _v, attn_mask=_m,
+                                             scale=HD ** -0.5)
+        # HF sdpa_attention_forward returns .transpose(1,2) -> [B,q,H,D]
+        att = att.transpose(1, 2).contiguous().reshape(BS, NH * HD).to(DT)
+        att = F.linear(att, sd[p + "self_attn.o_proj.weight"])
+        att = rms(att, sd[p + "post_attention_layernorm.weight"], EPS)
+        x = att + res
+        res = x
+        xn = rms(x, sd[p + "pre_feedforward_layernorm.weight"], EPS)
+        g = F.linear(xn, sd[p + "mlp.gate_proj.weight"])
+        u = F.linear(xn, sd[p + "mlp.up_proj.weight"])
+        m = F.linear(F.silu(g.float()).to(DT) * u, sd[p + "mlp.down_proj.weight"])
+        m = rms(m, sd[p + "post_feedforward_layernorm.weight"], EPS)
+        x = m + res
+        x = x * sd[p + "layer_scalar"]
+        save(f"layer_{li}_out", x)
+
+    x = rms(x, sd["norm.weight"], EPS)
+    save("draft_final", x)
+    logits = F.linear(x.float(), sd["lm_head.weight"].float())
+    save("backbone_logits", logits)
+    save("top1_backbone", logits.argmax(-1))
+    print("\ntop1 tokens:", logits.argmax(-1).tolist())
+    print("true next  :", ids[0, A + 1 : A + 1 + BS].tolist())
+
+    torch.save(DUMP, os.path.join(args.out, "eval_dump.pt"))
+    print("wrote", os.path.join(args.out, "eval_dump.pt"), f"({len(DUMP)} tensors)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speculative_decoding/debug/dump_train.py
+++ b/examples/speculative_decoding/debug/dump_train.py
@@ -1,0 +1,299 @@
+"""TRAIN-side activation dump for one fixed sample.
+
+Runs the real ModelOpt training forward (DSparkFakeBase + DFlashGemma4 draft) on
+ONE corpus row, at ONE fixed anchor, and dumps every intermediate tensor.
+
+Determinism: _sample_anchor_positions() uses torch.rand, so it is monkeypatched
+to return a single fixed anchor. Both pipelines must diff the SAME position or
+the comparison is meaningless.
+
+Dumps (all bf16->fp32, CPU):
+  input_ids, anchor, noise_ids
+  aux_hidden          [S, 5*H]   the target's captured hidden states (fc input)
+  ctx_fc              [S, H]     fc(aux)
+  ctx_hidden_norm     [S, H]     hidden_norm(fc(aux))   <- what draft attends to
+  noise_embedding     [B, H]     draft block input
+  layer_{i}_out       [B, H]     each draft layer output
+  draft_final         [B, H]     after final norm
+  backbone_logits     [B, V]
+  final_logits        [B, V]     after Markov head
+  top1                [B]        argmax token ids
+"""
+
+import argparse
+import json
+import os
+
+import torch
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--ckpt", required=True, help="training checkpoint dir")
+ap.add_argument("--base", required=True, help="base Gemma-4-E4B-it dir")
+ap.add_argument("--corpus", required=True, help="jsonl corpus file")
+ap.add_argument("--row", type=int, default=0)
+ap.add_argument("--anchor", type=int, default=64, help="FIXED anchor position")
+ap.add_argument("--seqlen", type=int, default=256)
+ap.add_argument("--chat-template", default=None)
+ap.add_argument("--out", required=True)
+ap.add_argument("--force-embed-scale", type=float, default=None,
+                help="override FakeBaseConfig.embed_scale. Checkpoints saved BEFORE the "
+                     "embed-scale fix have no such field, so it defaults to 1.0 and the "
+                     "fix is a no-op; pass sqrt(hidden_size) to exercise the fixed math.")
+ap.add_argument("--aux-from", default=None,
+                help="eval_dump.pt to source aux_hidden/base_final_hidden from, so BOTH "
+                     "pipelines consume byte-identical target activations")
+args = ap.parse_args()
+
+os.makedirs(args.out, exist_ok=True)
+DUMP = {}
+
+
+def save(name, t):
+    if t is None:
+        return
+    if isinstance(t, torch.Tensor):
+        DUMP[name] = t.detach().float().cpu()
+        print(f"  [dump] {name:<24} {tuple(t.shape)}")
+
+
+def main():
+    import modelopt.torch.opt as mto
+    import modelopt.torch.speculative as mtsp  # noqa: F401
+    from transformers import AutoTokenizer
+
+    # Same hook main.py installs at import time: makes from_pretrained() replay
+    # the saved modelopt_state (i.e. re-run mtsp.convert) BEFORE loading weights.
+    # Without it AutoModelForCausalLM returns a bare FakeBaseModel and every
+    # dflash_module.* tensor is reported UNEXPECTED and silently dropped.
+    mto.enable_huggingface_checkpointing()
+
+    torch.manual_seed(0)
+    dev = "cuda"
+
+    tok = AutoTokenizer.from_pretrained(args.base)
+    if args.chat_template and os.path.exists(args.chat_template):
+        tok.chat_template = open(args.chat_template).read()
+
+    # ---- pick the sample ----
+    row = None
+    with open(args.corpus) as f:
+        for i, line in enumerate(f):
+            if i == args.row:
+                row = json.loads(line)
+                break
+    assert row is not None, f"row {args.row} not found"
+    convs = row.get("conversations") or row.get("messages")
+    print("sample keys:", list(row.keys()))
+
+    msgs = []
+    for m in convs:
+        r = m.get("role") or m.get("from")
+        c = m.get("content") or m.get("value")
+        r = {"human": "user", "gpt": "assistant"}.get(r, r)
+        msgs.append({"role": r, "content": c})
+    text = tok.apply_chat_template(msgs, tokenize=False)
+    ids = tok(text, return_tensors="pt").input_ids[:, : args.seqlen].to(dev)
+    print("input_ids:", tuple(ids.shape))
+    save("input_ids", ids[0])
+
+    # ---- build the model exactly as training does ----
+    from transformers import AutoModelForCausalLM
+
+    print("loading fake-base + draft from", args.ckpt)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.ckpt, dtype=torch.bfloat16, trust_remote_code=True
+    ).to(dev).eval()
+
+    if args.force_embed_scale is not None:
+        emb = model._base_model_embeddings
+        old = getattr(emb, "embed_scale", 1.0)
+        emb.embed_scale = float(args.force_embed_scale)
+        model.config.embed_scale = float(args.force_embed_scale)
+        print(f"embed_scale {old} -> {emb.embed_scale}  (class {type(emb).__name__})")
+    print("model class:", type(model).__name__)
+
+    # ---- force a FIXED anchor ----
+    ANCHOR = args.anchor
+
+    def fixed_anchors(self, seq_len, loss_mask, device):
+        a = torch.tensor([[ANCHOR]], dtype=torch.long, device=device)
+        k = torch.ones(1, 1, dtype=torch.bool, device=device)
+        return a, k
+
+    type(model)._sample_anchor_positions = fixed_anchors
+    print(f"anchor FORCED to {ANCHOR}")
+
+    # ---- hooks on the draft module ----
+    dm = model.dflash_module
+    save("hidden_norm.weight", dm.hidden_norm.weight)
+    save("fc.weight", dm.fc.weight)
+
+    dm.fc.register_forward_hook(lambda m, i, o: save("ctx_fc", o[0]))
+    dm.hidden_norm.register_forward_hook(lambda m, i, o: save("ctx_hidden_norm", o[0]))
+    for li, layer in enumerate(dm.layers):
+        layer.register_forward_hook(
+            lambda m, i, o, li=li: save(f"layer_{li}_out", (o[0] if isinstance(o, tuple) else o)[0])
+        )
+        # Sub-layer taps so a divergence localizes to a STEP, not just a layer.
+        # Names mirror dump_vllm_real.py's so compare.py can pair them directly.
+        a = layer.self_attn
+
+        def tap(name, mod):
+            mod.register_forward_hook(
+                lambda m, i, o, n=name: save(
+                    n, (o[0] if isinstance(o, tuple) else o).reshape(-1, (o[0] if isinstance(o, tuple) else o).shape[-1])
+                )
+            )
+
+        # Wrap the Gemma4 draft attention so its INLINE steps (rope, attn) are
+        # visible: ModelOpt computes them inside forward(), not as submodules,
+        # so plain hooks cannot see them.
+        def wrap_attn(a=a, li=li):
+            import types
+
+            # ModelOpt has its OWN apply_rotary_pos_emb (Q takes the LAST q_len
+            # positions, K takes all) -- the Qwen3 one assumes Q and K are the
+            # same length and blows up here.
+            from modelopt.torch.speculative.plugins.modeling_dflash import (
+                apply_rotary_pos_emb as _arpe,
+            )
+
+            def fwd(self, hidden_states, target_hidden, position_embeddings, attention_mask=None):
+                bsz, q_len, _ = hidden_states.shape
+                ctx_len = target_hidden.shape[1]
+                q = self.q_proj(hidden_states).view(bsz, q_len, -1, self.head_dim)
+                q = self.q_norm(q).transpose(1, 2)
+                k_ctx = self.k_proj(target_hidden)
+                k_noise = self.k_proj(hidden_states)
+                save(f"L{li}_k_projraw_ctx", k_ctx[0])
+                save(f"L{li}_k_projraw_block", k_noise[0])
+                k = torch.cat([k_ctx, k_noise], dim=1).view(
+                    bsz, ctx_len + q_len, -1, self.head_dim)
+                k = self.k_norm(k).transpose(1, 2)
+                # vLLM's _kv_proj returns K *after* k_norm, so compare that form.
+                _kn = k.transpose(1, 2).reshape(bsz, ctx_len + q_len, -1)
+                save(f"L{li}_k_proj_ctx", _kn[0, :ctx_len])
+                save(f"L{li}_k_proj_block", _kn[0, ctx_len:])
+                v_ctx, v_noise = self._project_v(target_hidden, hidden_states, k_ctx, k_noise)
+                v = torch.cat([v_ctx, v_noise], dim=1).view(
+                    bsz, ctx_len + q_len, -1, self.head_dim)
+                v = self.v_norm(v).transpose(1, 2)
+                save(f"L{li}_v_proj_block", v[0, :, ctx_len:].transpose(0, 1).reshape(q_len, -1))
+                cos, sin = position_embeddings
+                q, k = _arpe(q, k, cos, sin)
+                save(f"L{li}_q_rope", q[0].transpose(0, 1).reshape(q_len, -1))
+                save(f"L{li}_k_rope_ctx", k[0, :, :ctx_len].transpose(0, 1).reshape(ctx_len, -1))
+                save(f"L{li}_k_rope_block", k[0, :, ctx_len:].transpose(0, 1).reshape(q_len, -1))
+                save(f"L{li}_attn_in_q", q[0].transpose(0, 1).reshape(q_len, -1))
+                save(f"L{li}_attn_in_k", k[0].transpose(0, 1).reshape(ctx_len + q_len, -1))
+                save(f"L{li}_attn_in_v", v[0].transpose(0, 1).reshape(ctx_len + q_len, -1))
+                if attention_mask is not None and li == 0:
+                    am = attention_mask
+                    save("attn_mask_shape", torch.tensor(list(am.shape), dtype=torch.float))
+                    m2 = am[0, 0] if am.dim() == 4 else am
+                    save("attn_mask_visible_per_q",
+                         (m2[-q_len:] > -1e3).float().sum(-1))
+                    # Dump the ACTUAL mask rows fed to SDPA plus the exact K/V
+                    # tensors in their pre-expand layout, so an offline rebuild
+                    # has nothing left to guess.
+                    save("attn_mask_rows", m2[-q_len:])
+                    save("L0_k_bhsd", k[0].reshape(k.shape[1], -1))
+                    save("L0_v_bhsd", v[0].reshape(v.shape[1], -1))
+                    save("L0_q_bhsd", q[0].reshape(q.shape[1], -1))
+                    save("L0_kvheads", torch.tensor(
+                        [k.shape[1], v.shape[1], q.shape[1], float(self.scaling)]))
+                attn_fn = self._get_attn_fn()
+                ao, _ = attn_fn(self, q, k, v, attention_mask, dropout=0.0,
+                                scaling=self.scaling, sliding_window=self.sliding_window)
+                ao = ao.reshape(bsz, q_len, -1)
+                save(f"L{li}_attn_out", ao[0])
+                if li == 0:
+                    import torch.nn.functional as _F
+
+                    kk = k if k.shape[1] == q.shape[1] else k.repeat_interleave(
+                        q.shape[1] // k.shape[1], dim=1)
+                    vv2 = v if v.shape[1] == q.shape[1] else v.repeat_interleave(
+                        q.shape[1] // v.shape[1], dim=1)
+                    ref = _F.scaled_dot_product_attention(
+                        q, kk, vv2, attn_mask=attention_mask, scale=self.scaling)
+                    ref = ref.transpose(1, 2).contiguous().reshape(bsz, q_len, -1)
+                    d = (ref - ao).abs().max().item()
+                    print(f"    [selfcheck] L0 inline-SDPA vs attn_fn max|d| = {d:.4e}")
+                    save("selfcheck_inline_sdpa", ref[0])
+                return self.o_proj(ao)
+
+            a.forward = types.MethodType(fwd, a)
+
+        wrap_attn()
+
+        tap(f"L{li}_input_layernorm", layer.input_layernorm)
+        tap(f"L{li}_q_proj", a.q_proj)
+        tap(f"L{li}_q_norm", a.q_norm)
+        tap(f"L{li}_o_proj", a.o_proj)
+        tap(f"L{li}_post_attn_norm", layer.post_attention_layernorm)
+        tap(f"L{li}_pre_ffn_norm", layer.pre_feedforward_layernorm)
+        tap(f"L{li}_mlp", layer.mlp)
+        tap(f"L{li}_post_ffn_norm", layer.post_feedforward_layernorm)
+        # eval dumps L{i}_out (after layer_scalar); layer_{i}_out already covers it
+        layer.register_forward_hook(
+            lambda m, i, o, li=li: save(
+                f"L{li}_out", (o[0] if isinstance(o, tuple) else o)[0]))
+    dm.norm.register_forward_hook(lambda m, i, o: save("draft_final", o[0]))
+
+    # capture the draft-module inputs
+    def pre(m, a, kw):
+        if "noise_embedding" in kw:
+            save("noise_embedding", kw["noise_embedding"][0])
+        if "target_hidden" in kw:
+            save("aux_hidden", kw["target_hidden"][0])
+        if "position_ids" in kw:
+            save("position_ids", kw["position_ids"][0])
+        return None
+
+    dm.register_forward_pre_hook(pre, with_kwargs=True)
+
+    # ---- forward ----
+    lm = model._base_model_lm_head
+    orig_lm = lm.forward
+    seen = []
+
+    def lm_hook(x):
+        out = orig_lm(x)
+        seen.append(out)
+        return out
+
+    lm.forward = lm_hook
+
+    # Streaming/offline mode: the base layers were deleted, so aux hidden states
+    # must be supplied exactly as the vLLM producer would. Reuse the EVAL dump so
+    # both sides consume byte-identical target activations -- any divergence is
+    # then provably inside the draft, not in the target capture.
+    assert args.aux_from, "--aux-from is required for an offline/streaming checkpoint"
+    ev = torch.load(args.aux_from, map_location="cpu")
+    aux = ev["aux_hidden"].to(dev, torch.bfloat16).unsqueeze(0)
+    fin = ev["base_final_hidden"].to(dev, torch.bfloat16).unsqueeze(0)
+    save("aux_hidden", aux[0])
+    bmo = {"aux_hidden_states": aux, "base_model_hidden_states": fin}
+
+    # The offline guard triggers on `not self.training`; the streaming forward is
+    # the training forward, so run in train() mode under no_grad.
+    model.train()
+    with torch.no_grad():
+        out = model(input_ids=ids, attention_mask=torch.ones_like(ids),
+                    labels=ids, base_model_outputs=bmo)
+
+    print("loss:", float(out.loss) if getattr(out, "loss", None) is not None else None)
+    if getattr(out, "train_acc", None) is not None:
+        print("train_acc:", out.train_acc)
+
+    if seen:
+        bl = seen[-1]
+        save("backbone_logits", bl.reshape(-1, bl.shape[-1]))
+        save("top1_backbone", bl.reshape(-1, bl.shape[-1]).argmax(-1))
+
+    torch.save(DUMP, os.path.join(args.out, "train_dump.pt"))
+    print("\nwrote", os.path.join(args.out, "train_dump.pt"), f"({len(DUMP)} tensors)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speculative_decoding/debug/probe_norm_grads.py
+++ b/examples/speculative_decoding/debug/probe_norm_grads.py
@@ -1,0 +1,132 @@
+"""Separate the two candidate causes of the frozen draft norms.
+
+All 32 draft RMSNorms sat at exactly 1.0 for 2000 steps. Two candidates:
+  (A) bf16 resolution -- grads flow but each Adam step (~1e-4) is far below the
+      bf16 ULP at 1.0 (7.81e-3), so every update rounds back to 1.0.
+  (B) broken graph -- the norms receive literally zero/None gradient.
+
+Run ONE real backward and print per-tensor grad norms. Then simulate what an
+Adam step would actually do to a bf16 weight at 1.0 to confirm (A) quantitatively.
+"""
+
+import json
+import os
+import sys
+
+import torch
+
+CKPT, BASE, CORPUS, EVAL, TPL = sys.argv[1:6]
+
+
+def main():
+    import modelopt.torch.opt as mto
+    import modelopt.torch.speculative as mtsp  # noqa: F401
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    mto.enable_huggingface_checkpointing()
+    dev = "cuda"
+
+    tok = AutoTokenizer.from_pretrained(BASE)
+    if os.path.exists(TPL):
+        tok.chat_template = open(TPL).read()
+
+    with open(CORPUS) as f:
+        row = json.loads(f.readline())
+    convs = row.get("conversations") or row.get("messages")
+    msgs = []
+    for m in convs:
+        r = m.get("role") or m.get("from")
+        c = m.get("content") or m.get("value")
+        msgs.append({"role": {"human": "user", "gpt": "assistant"}.get(r, r), "content": c})
+    ids = tok(tok.apply_chat_template(msgs, tokenize=False),
+              return_tensors="pt").input_ids[:, :256].to(dev)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        CKPT, dtype=torch.bfloat16, trust_remote_code=True).to(dev)
+    model.train()
+
+    ev = torch.load(EVAL, map_location="cpu")
+    bmo = {
+        "aux_hidden_states": ev["aux_hidden"].to(dev, torch.bfloat16).unsqueeze(0),
+        "base_model_hidden_states": ev["base_final_hidden"].to(dev, torch.bfloat16).unsqueeze(0),
+    }
+
+    out = model(input_ids=ids, attention_mask=torch.ones_like(ids),
+                labels=ids, base_model_outputs=bmo)
+    loss = out.loss
+    print("loss:", float(loss))
+    model.zero_grad(set_to_none=True)
+    loss.backward()
+
+    dm = model.dflash_module
+    norms, linears = [], []
+    for name, p in dm.named_parameters():
+        if p.grad is None:
+            g = None
+        else:
+            g = p.grad.float().abs().mean().item()
+        (norms if ("norm" in name.lower()) else linears).append((name, g, p.requires_grad))
+
+    print()
+    print("=" * 84)
+    print("  NORM parameters -- mean |grad|")
+    print("=" * 84)
+    print(f"  {'param':<52}{'requires_grad':>14}{'mean|grad|':>16}")
+    zero = none = alive = 0
+    for n, g, rg in norms[:16]:
+        s = "None" if g is None else f"{g:.3e}"
+        print(f"  {n:<52}{str(rg):>14}{s:>16}")
+        if g is None:
+            none += 1
+        elif g == 0.0:
+            zero += 1
+        else:
+            alive += 1
+    for n, g, rg in norms[16:]:
+        if g is None:
+            none += 1
+        elif g == 0.0:
+            zero += 1
+        else:
+            alive += 1
+    print(f"  ... total norms={len(norms)}  none={none}  exactly_zero={zero}  nonzero={alive}")
+
+    print()
+    print("=" * 84)
+    print("  LINEAR parameters -- mean |grad| (control group, these DID train)")
+    print("=" * 84)
+    for n, g, rg in linears[:6]:
+        s = "None" if g is None else f"{g:.3e}"
+        print(f"  {n:<52}{str(rg):>14}{s:>16}")
+
+    # ---- quantify candidate (A) ----
+    print()
+    print("=" * 84)
+    print("  Would an Adam step actually move a bf16 weight at 1.0?")
+    print("=" * 84)
+    lr = 1e-4
+    w = torch.ones(1, dtype=torch.bfloat16)
+    print(f"  bf16(1.0)  - lr({lr:.0e})      = {float(w - lr):.8f}   "
+          f"{'NO CHANGE' if float(w - lr) == 1.0 else 'moved'}")
+    w2 = torch.full((1,), 0.02, dtype=torch.bfloat16)
+    print(f"  bf16(0.02) - lr({lr:.0e})      = {float(w2 - lr):.8f}   "
+          f"{'NO CHANGE' if float(w2 - lr) == 0.02 else 'moved'}")
+    nxt = torch.tensor(1.0, dtype=torch.bfloat16)
+    import struct
+    i = struct.unpack("<I", struct.pack("<f", 1.0))[0] >> 16
+    ulp = struct.unpack("<f", struct.pack("<I", (i + 1) << 16))[0] - 1.0
+    print(f"  bf16 ULP at 1.0                = {ulp:.3e}   ({ulp/lr:.0f}x the step)")
+    print()
+    print("  VERDICT:")
+    if none == len(norms):
+        print("    (B) BROKEN GRAPH -- norms get no gradient at all.")
+    elif zero == len(norms):
+        print("    (B) BROKEN GRAPH -- norm gradients are exactly zero.")
+    elif alive > 0:
+        print(f"    (A) bf16 RESOLUTION -- {alive}/{len(norms)} norms DO receive gradient;")
+        print("        the updates are simply too small to cross the bf16 ULP at 1.0.")
+        print("        Fix = fp32 master weights (or init norms at 0 with a (1+w) form).")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
+++ b/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Convert a ModelOpt DSpark drafter export into the layout vLLM's
+Gemma4DSparkForCausalLM expects.
+
+Three classes of mismatch, all on the ModelOpt side (vLLM needs no patch):
+
+1. config.json
+   - architectures: DFlashDraftModel -> Gemma4DSparkModel   (registry key)
+   - model_type:    qwen3            -> gemma4_text          (Gemma4DSparkAttention
+     reads layer_types/head_dim/global_head_dim off a Gemma4 text config)
+   - target_layer_ids / markov_rank are read as TOP-LEVEL attrs by
+     Gemma4DSparkModel.__init__, but ModelOpt nests them under dflash_config.
+
+2. weight names
+   - markov_w1/markov_w2 -> markov_head.markov_w1/markov_head.markov_w2
+     (DSparkMarkovHead registers them under a `markov_head` submodule)
+
+3. missing tensors  <-- the one that silently destroys AL
+   - Gemma4DSparkForCausalLM builds its OWN ParallelLMHead and VocabParallelEmbedding
+     and its load_weights() only fills names it finds; anything absent stays
+     RANDOMLY INITIALIZED with no error. The ModelOpt export ships neither
+     lm_head nor embed_tokens, so both must be baked in from the base model.
+     Gemma 4 is tie_word_embeddings=true, so both come from the same tensor:
+     model.language_model.embed_tokens.weight
+"""
+
+import argparse
+import json
+import os
+import shutil
+
+from safetensors.torch import load_file, save_file
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--drafter", required=True, help="ModelOpt export dir")
+ap.add_argument("--base", required=True, help="base Gemma-4-E4B-it dir (for lm_head/embed)")
+ap.add_argument("--out", required=True)
+args = ap.parse_args()
+
+os.makedirs(args.out, exist_ok=True)
+cfg = json.load(open(os.path.join(args.drafter, "config.json")))
+df = cfg.get("dflash_config", {}) or {}
+
+new = dict(cfg)
+new["architectures"] = ["Gemma4DSparkModel"]
+new["model_type"] = "gemma4_text"
+# promote what Gemma4DSparkModel.__init__ reads off the top level
+new["target_layer_ids"] = df.get("target_layer_ids", cfg.get("target_layer_ids"))
+new["markov_rank"] = df.get("markov_rank", 256)
+new["mask_token_id"] = df.get("mask_token_id")
+new["block_size"] = cfg.get("block_size")
+new.setdefault("draft_vocab_size", cfg["vocab_size"])
+# Gemma4 attention knobs consulted by gemma4_layer_config()/Gemma4DSparkAttention
+new.setdefault("global_head_dim", cfg["head_dim"])
+new.setdefault("attention_k_eq_v", False)
+new.setdefault("sliding_window", 512)
+new.setdefault("final_logit_softcapping", None)
+json.dump(new, open(os.path.join(args.out, "config.json"), "w"), indent=2)
+print(
+    "config: architectures={} model_type={} target_layer_ids={} markov_rank={}".format(
+        new["architectures"], new["model_type"], new["target_layer_ids"], new["markov_rank"]
+    )
+)
+
+sd = load_file(os.path.join(args.drafter, "model.safetensors"))
+print(f"loaded {len(sd)} drafter tensors")
+
+out = {}
+renamed = 0
+for k, v in sd.items():
+    nk = k
+    if k.startswith(("markov_w1", "markov_w2")):
+        nk = "markov_head." + k
+        renamed += 1
+    out[nk] = v
+print(f"renamed {renamed} markov tensors -> markov_head.*")
+
+# --- bake in lm_head + embed_tokens from the base (tied on Gemma 4) ---
+idx_path = os.path.join(args.base, "model.safetensors.index.json")
+if os.path.exists(idx_path):
+    wm = json.load(open(idx_path))["weight_map"]
+    key = next(k for k in wm if k.endswith("language_model.embed_tokens.weight"))
+    base_sd = load_file(os.path.join(args.base, wm[key]))
+else:
+    base_sd = load_file(os.path.join(args.base, "model.safetensors"))
+    key = next(k for k in base_sd if k.endswith("language_model.embed_tokens.weight"))
+emb = base_sd[key]
+print(f"base embed_tokens {tuple(emb.shape)} from {key!r}")
+assert emb.shape[0] == cfg["vocab_size"] and emb.shape[1] == cfg["hidden_size"], (
+    f"base embed {tuple(emb.shape)} does not match draft vocab/hidden "
+    f"({cfg['vocab_size']},{cfg['hidden_size']})"
+)
+
+out["lm_head.weight"] = emb.clone()
+out["embed_tokens.weight"] = emb.clone()
+print("baked lm_head.weight + embed_tokens.weight (tie_word_embeddings=true on Gemma 4)")
+
+save_file(out, os.path.join(args.out, "model.safetensors"), metadata={"format": "pt"})
+for f in ("tokenizer.json", "tokenizer_config.json"):
+    src = os.path.join(args.base, f)
+    if os.path.exists(src):
+        shutil.copy(src, os.path.join(args.out, f))
+print(f"wrote {len(out)} tensors -> {args.out}")

--- a/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
+++ b/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
@@ -51,8 +51,20 @@ new["mask_token_id"] = df.get("mask_token_id")
 new["block_size"] = cfg.get("block_size")
 new.setdefault("draft_vocab_size", cfg["vocab_size"])
 # Gemma4 attention knobs consulted by gemma4_layer_config()/Gemma4DSparkAttention
-new.setdefault("global_head_dim", cfg["head_dim"])
-new.setdefault("attention_k_eq_v", False)
+# Do NOT default these: Gemma4 sizes attention per layer, and quietly falling back to
+# the sliding-layer values rebuilds the draft with the wrong q/k/o and q/k-norm shapes.
+# They must come from the training config (see hf_spec_export.py).
+for _req in ("global_head_dim", "attention_k_eq_v"):
+    if _req not in cfg:
+        raise SystemExit(
+            f"drafter config.json is missing {_req!r}. Re-export with a ModelOpt that "
+            "propagates the Gemma4 per-layer attention fields, or add it by hand."
+        )
+if cfg.get("attention_k_eq_v") and "num_global_key_value_heads" not in cfg:
+    raise SystemExit(
+        "attention_k_eq_v is set but num_global_key_value_heads is missing; "
+        "vLLM would size k_proj with the sliding-layer KV head count."
+    )
 new.setdefault("sliding_window", 512)
 new.setdefault("final_logit_softcapping", None)
 json.dump(new, open(os.path.join(args.out, "config.json"), "w"), indent=2)
@@ -101,3 +113,16 @@ for f in ("tokenizer.json", "tokenizer_config.json"):
     if os.path.exists(src):
         shutil.copy(src, os.path.join(args.out, f))
 print(f"wrote {len(out)} tensors -> {args.out}")
+print()
+print("Serve with (note the draft attention backend):")
+_spec = (
+    f'{{"model": "{args.out}", "num_speculative_tokens": 3, '
+    '"method": "dspark", "attention_backend": "FLASHINFER"}'
+)
+print(f"  vllm serve <base> --speculative-config '{_spec}'")
+print(
+    "  FLASHINFER is REQUIRED: the draft re-runs backend auto-selection and lands on\n"
+    "  FLASH_ATTN, whose FA2 kernel caps head dimension at 256, but Gemma4 full-attention\n"
+    "  layers use global_head_dim=512. The VLLM_ATTENTION_BACKEND env var does NOT reach\n"
+    "  the draft -- it is read from speculative_config.attention_backend."
+)

--- a/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
+++ b/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Convert a ModelOpt DSpark drafter export into the layout vLLM's
 Gemma4DSparkForCausalLM expects.
 
@@ -29,6 +44,7 @@ import json
 import os
 import shutil
 
+import torch
 from safetensors.torch import load_file, save_file
 
 ap = argparse.ArgumentParser()
@@ -107,6 +123,11 @@ out["lm_head.weight"] = emb.clone()
 out["embed_tokens.weight"] = emb.clone()
 print("baked lm_head.weight + embed_tokens.weight (tie_word_embeddings=true on Gemma 4)")
 
+# The written config.json declares bfloat16, and a draft trained with fp32 master
+# weights arrives here in fp32 -- saving as-is would double the file and disagree with
+# the config. Cast to whatever the config claims so the two can never drift apart.
+_out_dtype = getattr(torch, cfg.get("torch_dtype", "bfloat16"))
+out = {k: v.to(_out_dtype) for k, v in out.items()}
 save_file(out, os.path.join(args.out, "model.safetensors"), metadata={"format": "pt"})
 for f in ("tokenizer.json", "tokenizer_config.json"):
     src = os.path.join(args.base, f)

--- a/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
+++ b/examples/speculative_decoding/export/convert_gemma4_dspark_to_vllm.py
@@ -121,8 +121,16 @@ _spec = (
 )
 print(f"  vllm serve <base> --speculative-config '{_spec}'")
 print(
-    "  FLASHINFER is REQUIRED: the draft re-runs backend auto-selection and lands on\n"
-    "  FLASH_ATTN, whose FA2 kernel caps head dimension at 256, but Gemma4 full-attention\n"
-    "  layers use global_head_dim=512. The VLLM_ATTENTION_BACKEND env var does NOT reach\n"
-    "  the draft -- it is read from speculative_config.attention_backend."
+    "  FLASHINFER is REQUIRED for TWO independent reasons; either alone is fatal:\n"
+    "    1. head dim  -- the draft re-runs backend auto-selection and lands on FLASH_ATTN,\n"
+    "       whose FA2 kernel caps head dimension at 256, but Gemma4 full-attention layers\n"
+    "       use global_head_dim=512.\n"
+    "    2. causality -- the draft is NON-CAUSAL (bidirectional) on every layer, as DSpark\n"
+    "       heads are: _dflash_layer_causal() only marks sliding_attention layers causal,\n"
+    "       and this draft is all full_attention with no dflash_config.causal override.\n"
+    "       load_dspark_model therefore sets use_non_causal=True, which the backend must\n"
+    "       support. Runtime confirms with: 'Using FlashInfer for draft model non-causal\n"
+    "       attention'.\n"
+    "  The VLLM_ATTENTION_BACKEND env var does NOT reach the draft -- it is read from\n"
+    "  speculative_config.attention_backend."
 )

--- a/examples/speculative_decoding/export/gemma4_dspark_swa_vllm.patch
+++ b/examples/speculative_decoding/export/gemma4_dspark_swa_vllm.patch
@@ -1,0 +1,108 @@
+Make Gemma4 DSpark drafts honour dflash_config.use_swa / swa_window_size.
+
+Applies to (vLLM): vllm/model_executor/models/gemma4_dspark.py
+
+WHY
+    A DFlash/DSpark draft declares its sliding window through
+    dflash_config.use_swa + swa_window_size, and keeps layer_types all
+    "full_attention" on purpose -- that is what keeps attention_k_eq_v uniform,
+    which Gemma4DSparkModel._build_fused_kv_buffers() asserts.
+
+    vLLM's Qwen3 DFlash layer resolves its window through
+    _resolve_layer_attention(), which reads exactly those fields.
+    Gemma4DSparkAttention does not: it inherits Gemma4MTPAttention.__init__,
+    which derives the window from the BASE model's layer pattern --
+
+        self.is_sliding = layer_type == "sliding_attention"
+        sliding_window  = config.sliding_window if self.is_sliding else None
+
+    so for an all-full_attention draft, per_layer_sliding_window is None on
+    every layer. A draft TRAINED with a window is then SERVED with full
+    attention. Nothing errors; acceptance length just quietly drops.
+
+WHAT
+    Resolve the window via _resolve_layer_attention(config, layer_idx) -- the
+    same call the Qwen3 DFlash layer makes -- and rebuild self.attn with
+    per_layer_sliding_window when a window applies. self.attn is already
+    replaced further down for the k_proj/v_proj rework, so rebuilding it here
+    follows the class's existing pattern; the stale static_forward_context entry
+    is popped first, exactly as Gemma4DSparkDecoderLayer does for
+    "{prefix}.self_attn.attn".
+
+    Layers with no window are untouched, so the existing full-attention path
+    (deepseek-ai/dspark_gemma4_12b_block7 and the recipe it matches) is
+    bit-identical.
+
+VERIFIED (by config simulation, against the config ModelOpt's exporter emits
+for modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b_swa.yaml)
+    - all 5 layers get sliding_window=512
+    - all 5 layers stay causal=False  (dflash_config.causal is pinned False)
+    - all 5 layers keep use_k_eq_v=True -> the fused-KV assert still passes
+    - layer_types stays uniform -> the V2 model runner is NOT required
+    NOT yet validated end-to-end on GPU; no acceptance-length number exists.
+
+APPLY
+    cd <vllm> && git apply /path/to/gemma4_dspark_swa_vllm.patch
+
+--- a/vllm/model_executor/models/gemma4_dspark.py
++++ b/vllm/model_executor/models/gemma4_dspark.py
+@@ -8,8 +8,9 @@
+ import torch.nn as nn
+ import torch.nn.functional as F
+ 
+ from vllm import _custom_ops as ops
++from vllm.attention import Attention
+ from vllm.compilation.decorators import support_torch_compile
+ from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+ from vllm.model_executor.layers.layernorm import RMSNorm
+ from vllm.model_executor.layers.linear import ColumnParallelLinear, ReplicatedLinear
+@@ -22,9 +23,13 @@
+ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+ from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
+ 
+ from .gemma4_mtp import Gemma4MTPAttention, Gemma4MTPDecoderLayer
+-from .qwen3_dflash import DFlashQwen3Model, _dflash_layer_causal
++from .qwen3_dflash import (
++    DFlashQwen3Model,
++    _dflash_layer_causal,
++    _resolve_layer_attention,
++)
+ from .qwen3_dspark import DSparkMarkovHead, Qwen3DSparkForCausalLM
+ from .utils import extract_layer_index, maybe_prefix
+ 
+ 
+@@ -61,8 +66,34 @@
+         )
+         self.is_kv_shared_layer = False
+         self.causal = _dflash_layer_causal(config, layer_idx)
+         self.kv_size = self.num_kv_heads * self.head_dim
++
++        # Gemma4MTPAttention derives the sliding window from the BASE model's
++        # layer pattern (layer_type == "sliding_attention"). That is wrong for a
++        # DFlash/DSpark draft: the draft declares its window via
++        # dflash_config.use_swa / swa_window_size, and deliberately keeps
++        # layer_types all "full_attention" so that attention_k_eq_v stays uniform
++        # for the fused context-KV precompute. Without this, a draft TRAINED with
++        # a sliding window is SERVED with full attention -- no error is raised,
++        # acceptance length just quietly drops. Resolve the window the same way
++        # the Qwen3 DFlash layer does, and rebuild self.attn when it applies.
++        sliding_window, _ = _resolve_layer_attention(config, layer_idx)
++        if sliding_window is not None:
++            get_current_vllm_config().compilation_config.static_forward_context.pop(
++                f"{prefix}.attn", None
++            )
++            self.attn = Attention(
++                self.num_heads,
++                self.head_dim,
++                self.scaling,
++                num_kv_heads=self.num_kv_heads,
++                cache_config=cache_config,
++                quant_config=quant_config,
++                logits_soft_cap=getattr(config, "attn_logit_softcapping", None),
++                per_layer_sliding_window=sliding_window,
++                prefix=f"{prefix}.attn",
++            )
+         attn_bias = getattr(config, "attention_bias", False)
+         self.k_proj = ColumnParallelLinear(
+             config.hidden_size,
+             self.total_num_kv_heads * self.head_dim,

--- a/modelopt/torch/export/plugins/hf_spec_export.py
+++ b/modelopt/torch/export/plugins/hf_spec_export.py
@@ -406,6 +406,25 @@ class DFlashExporter(SpeculativeDecodingExporter):
             "num_target_layers": base_config.num_hidden_layers,
         }
 
+        # Carry the DRAFT's non-default RoPE type. rope_theta alone is not enough for
+        # Gemma 4: its full_attention kind uses rope_type "proportional" with
+        # partial_rotary_factor, which rotates only a fraction of the head dim and leaves
+        # the rest as NoPE. Emitting just the theta makes any consumer (vLLM, the AL
+        # harness) rebuild plain default rope and rotate every channel, silently
+        # disagreeing with how the draft was trained.
+        _draft_rope = getattr(draft_config, "rope_parameters", None)
+        if isinstance(_draft_rope, dict):
+            if any(isinstance(v, dict) for v in _draft_rope.values()):
+                # Nested per-attention-kind form; a draft is single-kind by construction.
+                _draft_rope = next(v for v in _draft_rope.values() if isinstance(v, dict))
+            _rope_type = _draft_rope.get("rope_type")
+            if _rope_type and _rope_type != "default":
+                config["rope_type"] = _rope_type
+                if "partial_rotary_factor" in _draft_rope:
+                    config["partial_rotary_factor"] = _draft_rope["partial_rotary_factor"]
+                if _draft_rope.get("rope_theta") is not None:
+                    config["rope_theta"] = _draft_rope["rope_theta"]
+
         # Add layer_types if present (Qwen3-style)
         if hasattr(draft_config, "layer_types"):
             config["layer_types"] = draft_config.layer_types

--- a/modelopt/torch/export/plugins/hf_spec_export.py
+++ b/modelopt/torch/export/plugins/hf_spec_export.py
@@ -412,6 +412,16 @@ class DFlashExporter(SpeculativeDecodingExporter):
         else:
             config["layer_types"] = ["full_attention"] * draft_config.num_hidden_layers
 
+        # Gemma4 sizes attention PER LAYER, so the serving side cannot reconstruct the
+        # draft's shapes from head_dim / num_key_value_heads alone: full-attention layers
+        # use ``global_head_dim`` and, under ``attention_k_eq_v``, ``num_global_key_value_heads``
+        # (see gemma4_layer_config in vLLM). Omitting these makes vLLM rebuild the draft with
+        # the sliding-layer dims and fail with a shape mismatch on q/k/o and the q/k norms.
+        for _attr in ("global_head_dim", "num_global_key_value_heads", "attention_k_eq_v"):
+            _val = getattr(draft_config, _attr, None)
+            if _val is not None:
+                config[_attr] = _val
+
         # Sliding-window attention: all draft layers use non-causal SWA (MiMo-style). vLLM's
         # _resolve_layer_attention reads dflash_config.use_swa + swa_window_size; with
         # layer_types left all "full_attention" it applies a non-causal sliding window to

--- a/modelopt/torch/export/plugins/hf_spec_export.py
+++ b/modelopt/torch/export/plugins/hf_spec_export.py
@@ -417,13 +417,19 @@ class DFlashExporter(SpeculativeDecodingExporter):
             if any(isinstance(v, dict) for v in _draft_rope.values()):
                 # Nested per-attention-kind form; a draft is single-kind by construction.
                 _draft_rope = next(v for v in _draft_rope.values() if isinstance(v, dict))
+            # The DRAFT's theta always wins. `rope_theta` above is resolved from the BASE
+            # config, which is only right when the draft inherited the base's value
+            # verbatim. A recipe can now sweep theta independently of the base (see
+            # hf_dflash's rope_override_* fields), and exporting the base's theta then
+            # silently ships a drafter whose served RoPE disagrees with how it trained --
+            # the served AL collapses with no error anywhere.
+            if _draft_rope.get("rope_theta") is not None:
+                config["rope_theta"] = _draft_rope["rope_theta"]
             _rope_type = _draft_rope.get("rope_type")
             if _rope_type and _rope_type != "default":
                 config["rope_type"] = _rope_type
                 if "partial_rotary_factor" in _draft_rope:
                     config["partial_rotary_factor"] = _draft_rope["partial_rotary_factor"]
-                if _draft_rope.get("rope_theta") is not None:
-                    config["rope_theta"] = _draft_rope["rope_theta"]
 
         # Add layer_types if present (Qwen3-style)
         if hasattr(draft_config, "layer_types"):

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -144,7 +144,12 @@ class DFlashConfig(ModeloptBaseConfig):
         default=None,
         description=(
             "Base-model layer ids whose hidden states are concatenated into the draft's "
-            "``fc`` input, in capture order. Only meaningful for STREAMING/offline runs, "
+            "``fc`` input, in capture order, in DFLASH semantics -- the same convention "
+            "``build_target_layer_ids()`` returns, which is the PRODUCER's capture id minus "
+            "one. vLLM reads a producer capture list verbatim but adds 1 to "
+            "``target_layer_ids``, and matches both against ``layer_idx + 1``. Passing raw "
+            "capture ids here shifts serving one layer deeper than training. "
+            "Only meaningful for STREAMING/offline runs, "
             "where the producer (vLLM ``eagle_aux_hidden_state_layer_ids``) decides which "
             "layers are captured and the trainer merely consumes ``aux_hidden_states`` "
             "verbatim -- it has no way to know which layers those were. Left unset, "

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -165,6 +165,24 @@ class DFlashConfig(ModeloptBaseConfig):
         default={}, description="Config for the DFlash draft module architecture."
     )
 
+    dflash_fp32_master_weights: bool = ModeloptField(
+        default=False,
+        description=(
+            "Keep the draft's parameters in fp32 while training under bf16 autocast, i.e. "
+            "classic mixed precision with fp32 master weights. Matmuls still run in bf16 on "
+            "tensor cores, so the cost is memory (12 bytes/param for weight+Adam moments "
+            "instead of 6), not speed.\n\n"
+            "This exists because a pure-bf16 parameter initialised at exactly 1.0 cannot "
+            "move: the downward ULP there is 2**-8 = 0.0039, so an update must exceed "
+            "0.00195 to round to a new value, and the maximum Adam step is the learning "
+            "rate. Under the Gemma-4 recipe's linear decay from 2e-3 that threshold is "
+            "crossed around step 2,600, after which every RMSNorm weight still sitting at "
+            "1.0 is frozen for the rest of the run. Measured on a 56k-step Gemma-4 draft: "
+            "78% of the q_norm/k_norm entries were still exactly 1.0, and the furthest any "
+            "had travelled was 34 ULPs of the 245 needed to reach head_dim**-0.5."
+        ),
+    )
+
     dflash_use_torch_compile: bool = ModeloptField(
         default=True,
         description="Whether to use torch.compile on DFlash forward/loss methods.",

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -140,6 +140,22 @@ class DFlashConfig(ModeloptBaseConfig):
         ),
     )
 
+    dflash_aux_layer_ids: list[int] | None = ModeloptField(
+        default=None,
+        description=(
+            "Base-model layer ids whose hidden states are concatenated into the draft's "
+            "``fc`` input, in capture order. Only meaningful for STREAMING/offline runs, "
+            "where the producer (vLLM ``eagle_aux_hidden_state_layer_ids``) decides which "
+            "layers are captured and the trainer merely consumes ``aux_hidden_states`` "
+            "verbatim -- it has no way to know which layers those were. Left unset, "
+            "``build_target_layer_ids()`` invents a uniformly-spaced list that is written "
+            "to the exported config and then used by vLLM to pick SERVING capture layers, "
+            "so the served draft reads different layers than it trained on. Pass the "
+            "producer's aux ids here (the capture list minus its final entry, which is the "
+            "KD target) to keep training and serving on the same layers."
+        ),
+    )
+
     dflash_architecture_config: dict = ModeloptField(
         default={}, description="Config for the DFlash draft module architecture."
     )

--- a/modelopt/torch/speculative/dflash/dflash_model.py
+++ b/modelopt/torch/speculative/dflash/dflash_model.py
@@ -48,5 +48,6 @@ class DFlashModel(DynamicModule):
         self.dflash_num_anchors = config.dflash_num_anchors
         self.dflash_report_acc = config.dflash_report_acc
         self.dflash_use_torch_compile = config.dflash_use_torch_compile
+        self.dflash_fp32_master_weights = config.dflash_fp32_master_weights
         self.dflash_swa_window_size = config.dflash_swa_window_size
         self.dflash_export_rope_scaling = config.dflash_export_rope_scaling

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -561,6 +561,14 @@ class HFDFlashModel(DFlashModel):
             base_device = next(self._base_model.layers[-1].parameters()).device
         if base_device.type != "meta":
             self.dflash_module.to(self._base_model.dtype).to(base_device)
+            if self.dflash_fp32_master_weights:
+                # Deliberately AFTER the base-dtype match: that call also moves the module
+                # to the right device, and matching first keeps this a pure dtype change.
+                # Autocast (HF Trainer under bf16=True) casts activations and weights to
+                # bf16 at each op, so compute is unchanged; only the master copy and the
+                # optimizer moments stay fp32. See DFlashConfig.dflash_fp32_master_weights
+                # for why bf16 masters silently freeze the RMSNorm weights.
+                self.dflash_module.float()
 
         # Delete base model layers for offline training (save memory)
         if self.dflash_offline:

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -419,6 +419,31 @@ class HFDFlashModel(DFlashModel):
         # overwrite any user value and warn. (rope_scaling is intentionally NOT inherited:
         # DFlash uses standard Qwen3 RotaryEmbedding; the long-context YaRN scaling is
         # added only at export via dflash_export_rope_scaling.)
+        # Gemma 4 nests rope_parameters PER ATTENTION KIND, e.g.
+        #   {"full_attention":    {"rope_theta": 1e6, "rope_type": "proportional",
+        #                          "partial_rotary_factor": 0.25},
+        #    "sliding_attention": {"rope_theta": 1e4, "rope_type": "default"}}
+        # The flat loop below cannot express that: it collapses the two kinds to a single theta
+        # and silently drops rope_type / partial_rotary_factor, so the draft rotates every
+        # channel at default frequencies while the target rotates only a quarter of them. Hand
+        # the nested dict to the draft verbatim instead and let
+        # DFlashModule._build_gemma4_rope_kinds() build one rotary module per kind. Only the
+        # kinds the DRAFT actually uses are kept, so an all-full_attention draft never sees the
+        # sliding entry.
+        base_rope_params = getattr(base_config, "rope_parameters", None)
+        _nested_rope = None
+        if isinstance(base_rope_params, dict) and any(
+            isinstance(v, dict) for v in base_rope_params.values()
+        ):
+            draft_layer_types = getattr(self.dflash_config, "layer_types", None) or list(
+                base_rope_params
+            )
+            _nested_rope = {
+                kind: dict(base_rope_params[kind])
+                for kind in dict.fromkeys(draft_layer_types)
+                if isinstance(base_rope_params.get(kind), dict)
+            } or None
+
         for attr in ("rope_theta", "rope_type", "rope_interleaved"):
             if not hasattr(base_config, attr):
                 continue
@@ -434,6 +459,18 @@ class HFDFlashModel(DFlashModel):
                     base_val,
                 )
             setattr(self.dflash_config, attr, base_val)
+
+        if _nested_rope is not None:
+            # Installed AFTER the flat loop: Qwen3Config auto-populates rope_parameters from
+            # rope_theta at construction, and the loop above refreshes that flat mirror, so
+            # assigning earlier would be overwritten by a single-kind dict.
+            self.dflash_config.rope_parameters = _nested_rope
+            _first = next(iter(_nested_rope.values()))
+            if "rope_theta" in _first:
+                # A multi-kind draft has no single theta; keep the flat mirror pointing at the
+                # first kind (layer_types order) for the exporter and for logging.
+                self.dflash_config.rope_theta = _first["rope_theta"]
+            logger.info("DFlash: per-attention-kind RoPE from base: %s", _nested_rope)
 
         self.dflash_config.head_dim = getattr(
             self.dflash_config,

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -486,7 +486,27 @@ class HFDFlashModel(DFlashModel):
             else base_config.num_hidden_layers
         )
         num_draft_layers = self.dflash_config.num_hidden_layers
-        self.target_layer_ids = build_target_layer_ids(num_target_layers, num_draft_layers)
+        # Prefer the ids the hidden-state PRODUCER actually captured. In streaming/offline
+        # runs the trainer never indexes hidden_states itself -- it consumes
+        # ``aux_hidden_states`` verbatim (see DFlashBaseModelOutput.from_offline_dict) --
+        # so a computed list here is pure fiction that still lands in the exported config,
+        # where vLLM reads it to choose SERVING capture layers. Measured on Gemma-4-E4B
+        # DSpark step 7000 (80q MT-Bench, num_spec=7): serving the same weights with the
+        # invented [1,10,20,30,39] gives AL 1.4221, while the layers training was actually
+        # fed ([5,11,17,23,35]) give AL 2.5287. Nothing errors, because the two lists have
+        # equal LENGTH and the only validation is on fc's input width.
+        configured_aux = getattr(config, "dflash_aux_layer_ids", None)
+        if configured_aux:
+            if len(configured_aux) != num_draft_layers:
+                raise ValueError(
+                    f"dflash_aux_layer_ids has {len(configured_aux)} entries but the draft "
+                    f"has {num_draft_layers} layers; the draft's fc expects exactly one "
+                    "aux hidden state per draft layer. Pass the producer's aux ids only "
+                    "(the capture list WITHOUT its final KD-target entry)."
+                )
+            self.target_layer_ids = list(configured_aux)
+        else:
+            self.target_layer_ids = build_target_layer_ids(num_target_layers, num_draft_layers)
         self.dflash_config.target_layer_ids = self.target_layer_ids
 
         # mask_token_id: validated by DFlashConfig, auto-detected from tokenizer context

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -430,19 +430,49 @@ class HFDFlashModel(DFlashModel):
         # DFlashModule._build_gemma4_rope_kinds() build one rotary module per kind. Only the
         # kinds the DRAFT actually uses are kept, so an all-full_attention draft never sees the
         # sliding entry.
+        # dflash_architecture_config may name the kind to inherit from explicitly via
+        # `rope_attention_kind`. Needed because the draft's own layer_types are the wrong
+        # signal on Gemma 4: an all-`full_attention` draft would inherit theta 1e6 +
+        # proportional rope, which measured 1.2-3.4% WORSE on acceptance length than the
+        # `sliding_attention` entry's plain theta 1e4 (see the RoPE A/B). The draft is an
+        # independent small model consuming base hidden states, not a reproduction of the
+        # base's full-attention layers, so its attention kind should not dictate its RoPE.
+        _rope_kind_override = getattr(self.dflash_config, "rope_attention_kind", None)
         base_rope_params = getattr(base_config, "rope_parameters", None)
         _nested_rope = None
         if isinstance(base_rope_params, dict) and any(
             isinstance(v, dict) for v in base_rope_params.values()
         ):
-            draft_layer_types = getattr(self.dflash_config, "layer_types", None) or list(
-                base_rope_params
+            draft_layer_types = (
+                [_rope_kind_override]
+                if _rope_kind_override
+                else getattr(self.dflash_config, "layer_types", None) or list(base_rope_params)
             )
             _nested_rope = {
                 kind: dict(base_rope_params[kind])
                 for kind in dict.fromkeys(draft_layer_types)
                 if isinstance(base_rope_params.get(kind), dict)
             } or None
+
+            # `rope_attention_kind` can only select a WHOLE base entry, and Gemma 4 ships
+            # theta and rope_type welded together (full_attention = 1e6 + proportional,
+            # sliding_attention = 1e4 + default). To sweep one of them independently -- e.g.
+            # theta 1e6 with plain default rope, which matches no base entry -- let the
+            # recipe override the resolved fields directly. Applied AFTER the entry is
+            # chosen, so it layers on top of whichever kind was inherited.
+            _rope_overrides = {
+                k: getattr(self.dflash_config, f"rope_override_{k}", None)
+                for k in ("rope_theta", "rope_type", "partial_rotary_factor")
+            }
+            _rope_overrides = {k: v for k, v in _rope_overrides.items() if v is not None}
+            if _rope_overrides and _nested_rope:
+                for _kind_cfg in _nested_rope.values():
+                    _kind_cfg.update(_rope_overrides)
+                    # A default-rope entry must not keep a stale partial_rotary_factor:
+                    # the rotary class would ignore it, but the exporter would emit it.
+                    if _kind_cfg.get("rope_type") == "default":
+                        _kind_cfg.pop("partial_rotary_factor", None)
+                logger.info("DFlash: RoPE overrides applied: %s", _rope_overrides)
 
         for attr in ("rope_theta", "rope_type", "rope_interleaved"):
             if not hasattr(base_config, attr):

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -526,8 +526,18 @@ class DFlashModule(nn.Module):
             cfg = copy.copy(config)
             if kind == "full_attention":
                 cfg.head_dim = getattr(config, "global_head_dim", None) or config.head_dim
-            if isinstance(rope_params, dict) and isinstance(rope_params.get(kind), dict):
-                cfg.rope_parameters = dict(rope_params[kind])
+            entry = rope_params.get(kind) if isinstance(rope_params, dict) else None
+            if entry is None and isinstance(rope_params, dict):
+                # The RoPE kind need not equal the LAYER kind. `rope_attention_kind` lets a
+                # recipe inherit e.g. the sliding entry for an all-full_attention draft, so
+                # rope_params can hold exactly one entry keyed by a name absent from
+                # layer_types. Fall back to that sole entry -- leaving rope_parameters
+                # nested here makes the rotary class raise KeyError('rope_type'), since it
+                # indexes rope_parameters as a FLAT dict.
+                sole = [v for v in rope_params.values() if isinstance(v, dict)]
+                entry = sole[0] if len(sole) == 1 else None
+            if isinstance(entry, dict):
+                cfg.rope_parameters = dict(entry)
                 cfg.rope_theta = cfg.rope_parameters.get("rope_theta", config.rope_theta)
             kinds[kind] = cfg
         return kinds

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -272,30 +272,6 @@ class DFlashGemma4Attention(DFlashAttention):
                     getattr(config, "num_global_key_value_heads", None) or self.num_kv_heads
                 )
             self.num_key_value_groups = self.num_heads // self.num_kv_heads
-            # Keep ``head_dim**-0.5`` even though vLLM serves this draft with
-            # ``scaling = 1.0``. That looks like a train/serve mismatch and it IS one, but
-            # aligning it is measurably WORSE -- do not "fix" this again without repeating
-            # the experiment below.
-            #
-            # vLLM's Gemma4MTPAttention (which Gemma4DSparkAttention inherits) hardcodes
-            # 1.0, matching the Gemma 4 base, which documents that "unlike Gemma2/3,
-            # query_pre_attn_scalar is NOT used here; Q/K norms with learnable weights
-            # handle scaling implicitly". Two full lr 2e-3 runs, identical except for this
-            # line, evaluated under REAL vLLM on 80q MT-Bench at num_spec=7:
-            #
-            #     step   trained 1/sqrt(512)   trained 1.0
-            #     1000   2.0645                1.9710   (-4.5%)
-            #     5000   2.5715                2.5234   (-1.9%)
-            #
-            # The reason is that ``q_norm`` is learnable, so it absorbs the scale: serving
-            # a 1/sqrt(512)-trained draft at 1.0 costs only 0.3% (step 1000) to 2.2%
-            # (step 5000), while TRAINING at 1.0 costs more than that. The small scale is
-            # the better training configuration -- smoother attention, better conditioned --
-            # and it transfers almost intact.
-            #
-            # An earlier estimate of a 7% mismatch penalty came from simulating scale 1.0
-            # inside the hand-written harness rather than measuring vLLM, and overstated it.
-            self.scaling = self.head_dim**-0.5
             attn_bias = getattr(config, "attention_bias", False)
             self.q_proj = nn.Linear(
                 config.hidden_size, self.num_heads * self.head_dim, bias=attn_bias
@@ -308,6 +284,38 @@ class DFlashGemma4Attention(DFlashAttention):
             )
             self.q_norm = _NORM_CLS(self.head_dim, eps=config.rms_norm_eps)
             self.k_norm = _NORM_CLS(self.head_dim, eps=config.rms_norm_eps)
+
+        # Gemma 4 puts no ``1/sqrt(head_dim)`` in attention: HF's
+        # ``Gemma4TextAttention.__init__`` sets ``self.scaling = 1.0`` and the config
+        # carries no ``query_pre_attn_scalar``, unlike Gemma2/3. The learnable per-dim
+        # weight of ``q_norm`` absorbs the scale instead. vLLM matches the reference --
+        # both ``gemma4.py`` and ``gemma4_mtp.py`` hardcode 1.0, and
+        # ``Gemma4DSparkAttention`` inherits the latter -- so a draft trained at
+        # ``head_dim**-0.5`` is trained under a scale no serving stack ever applies.
+        #
+        # Outside the ``is_full`` branch on purpose: vLLM uses 1.0 for EVERY Gemma 4
+        # layer type, so sliding layers must not fall through to the parent's
+        # ``head_dim**-0.5`` either.
+        #
+        # Cost of the old mismatch, measured directly by forcing vLLM's draft attention
+        # to the training scale (checkpoint-56000 of the lr 2e-3 5-epoch run, real vLLM,
+        # 80q MT-Bench, num_spec 7):
+        #
+        #     served at        128 tok   1024 tok
+        #     1.0 (stock)      2.7981    2.7685
+        #     512**-0.5        3.1577    3.1363     -> +12.9% / +13.3%
+        #
+        # This line was reverted once before (edcbe3adcf) on the strength of an A/B of
+        # two TRAINING scales: 2.0645 vs 1.9710 at step 1000, 2.5715 vs 2.5234 at step
+        # 5000, both favouring ``head_dim**-0.5``. That A/B served BOTH arms at 1.0, so
+        # it compared a matched configuration against a mismatched one and never measured
+        # the mismatch itself; both points are also under 0.3 epoch, and its gap was
+        # already closing (-4.5% -> -1.9%). Matching is worth ~13%, which the training-side
+        # preference does not come close to paying for.
+        #
+        # Drafters trained before this change carry the old convention and lose that 13%
+        # under stock vLLM; they need a retrain, not a config flag.
+        self.scaling = 1.0
 
         if self.use_k_eq_v:
             # Registered by the parent; drop it so it is neither trained nor exported.

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -470,7 +470,12 @@ class DFlashModule(nn.Module):
         1e6 vs 1e4). vLLM builds RoPE per layer for exactly this reason; a single
         shared module silently mismatches the head dim on one of the two kinds.
         """
-        if not hasattr(self, "rotary_emb"):
+        # The shared module is only used when there are no per-kind ones. Building it anyway
+        # would crash on a Gemma4 draft: its config carries the NESTED, dict-of-dicts
+        # ``rope_parameters`` (keyed by attention kind), and ``_ROTARY_CLS`` indexes it as a
+        # flat dict via ``rope_parameters["rope_type"]``. The per-kind configs built below
+        # each hold a flattened single-kind dict, so they are the ones that can be built.
+        if not self._gemma4_rope_kinds and not hasattr(self, "rotary_emb"):
             self.rotary_emb = _ROTARY_CLS(config=self._rotary_config, device=device)
         if self._gemma4_rope_kinds and not hasattr(self, "rotary_emb_by_kind"):
             self.rotary_emb_by_kind = nn.ModuleDict(
@@ -518,11 +523,18 @@ class DFlashModule(nn.Module):
         hidden_states = noise_embedding
         target_hidden = self.hidden_norm(self.fc(target_hidden))
         self._maybe_init_rotary_emb(device=hidden_states.device)
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
         per_kind = {
             kind: emb(hidden_states, position_ids)
             for kind, emb in getattr(self, "rotary_emb_by_kind", {}).items()
         }
+        # A Gemma4 draft has per-kind modules and NO shared one (its nested rope_parameters
+        # cannot build a single rotary module — see _maybe_init_rotary_emb), so fall back to
+        # the first kind rather than to a `self.rotary_emb` that does not exist.
+        position_embeddings = (
+            next(iter(per_kind.values()))
+            if per_kind
+            else self.rotary_emb(hidden_states, position_ids)
+        )
 
         for layer_idx, layer in enumerate(self.layers):
             layer_pos = position_embeddings

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -272,7 +272,17 @@ class DFlashGemma4Attention(DFlashAttention):
                     getattr(config, "num_global_key_value_heads", None) or self.num_kv_heads
                 )
             self.num_key_value_groups = self.num_heads // self.num_kv_heads
-            self.scaling = self.head_dim**-0.5
+            # Gemma 4 does NOT scale attention logits: vLLM's Gemma4MTPAttention (which
+            # Gemma4DSparkAttention inherits) hardcodes ``self.scaling = 1.0``, and the
+            # base model does the same, documenting that "unlike Gemma2/3,
+            # query_pre_attn_scalar is NOT used here; Q/K norms with learnable weights
+            # handle scaling implicitly". Inheriting DFlashAttention's ``head_dim**-0.5``
+            # trains the draft under a softmax temperature the serving stack never
+            # applies. Measured on Gemma-4-E4B DSpark step 7000 (80q MT-Bench,
+            # num_spec=7): 1/sqrt(512) -> AL 2.6809, 1.0 -> AL 2.4984, so the mismatch
+            # is real but modest -- q_norm absorbs most of it, which is exactly why it
+            # never surfaced as an error.
+            self.scaling = 1.0
             attn_bias = getattr(config, "attention_bias", False)
             self.q_proj = nn.Linear(
                 config.hidden_size, self.num_heads * self.head_dim, bias=attn_bias

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -41,6 +41,7 @@ Draft model components use Qwen3 (MLP, RMSNorm, RotaryEmbedding) from
 The draft architecture is independent of the target model.
 """
 
+import copy
 from dataclasses import dataclass
 
 import torch
@@ -436,6 +437,8 @@ class DFlashModule(nn.Module):
         )
         self.norm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
         self._rotary_config = config  # Used by _maybe_init_rotary_emb
+        self._gemma4_rope_kinds = self._build_gemma4_rope_kinds(config)
+        self._layer_types = list(getattr(config, "layer_types", []) or [])
 
         # Explicit weight init is needed because DFlashModule is instantiated via
         # mtsp.convert() AFTER the base model's post_init() has already run, so HF's
@@ -448,9 +451,46 @@ class DFlashModule(nn.Module):
         Same pattern as EAGLE3's _maybe_init_rope. Avoids creating rotary_emb
         during __init__ (which runs on meta device during from_pretrained),
         preventing the meta-tensor inv_freq issue on checkpoint resume.
+
+        Gemma4 needs one module PER attention kind, not one for the whole draft:
+        its full-attention layers use ``global_head_dim`` while sliding layers use
+        ``head_dim``, and the two kinds carry different ``rope_parameters`` (theta
+        1e6 vs 1e4). vLLM builds RoPE per layer for exactly this reason; a single
+        shared module silently mismatches the head dim on one of the two kinds.
         """
         if not hasattr(self, "rotary_emb"):
             self.rotary_emb = _ROTARY_CLS(config=self._rotary_config, device=device)
+        if self._gemma4_rope_kinds and not hasattr(self, "rotary_emb_by_kind"):
+            self.rotary_emb_by_kind = nn.ModuleDict(
+                {
+                    kind: _ROTARY_CLS(config=cfg, device=device)
+                    for kind, cfg in self._gemma4_rope_kinds.items()
+                }
+            )
+
+    @staticmethod
+    def _build_gemma4_rope_kinds(config):
+        """Per-attention-kind rotary configs for a Gemma4 draft, or ``{}`` otherwise.
+
+        Returns a shallow copy of ``config`` per distinct ``layer_types`` entry with
+        ``head_dim`` and ``rope_parameters`` resolved for that kind.
+        """
+        if not str(getattr(config, "model_type", "")).startswith("gemma4"):
+            return {}
+        layer_types = getattr(config, "layer_types", None)
+        if not layer_types:
+            return {}
+        rope_params = getattr(config, "rope_parameters", None)
+        kinds = {}
+        for kind in dict.fromkeys(layer_types):
+            cfg = copy.copy(config)
+            if kind == "full_attention":
+                cfg.head_dim = getattr(config, "global_head_dim", None) or config.head_dim
+            if isinstance(rope_params, dict) and isinstance(rope_params.get(kind), dict):
+                cfg.rope_parameters = dict(rope_params[kind])
+                cfg.rope_theta = cfg.rope_parameters.get("rope_theta", config.rope_theta)
+            kinds[kind] = cfg
+        return kinds
 
     def _init_weights(self, config):
         """Initialize weights matching HF PreTrainedModel._init_weights."""
@@ -467,8 +507,15 @@ class DFlashModule(nn.Module):
         target_hidden = self.hidden_norm(self.fc(target_hidden))
         self._maybe_init_rotary_emb(device=hidden_states.device)
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        per_kind = {
+            kind: emb(hidden_states, position_ids)
+            for kind, emb in getattr(self, "rotary_emb_by_kind", {}).items()
+        }
 
-        for layer in self.layers:
-            hidden_states = layer(hidden_states, target_hidden, position_embeddings, attention_mask)
+        for layer_idx, layer in enumerate(self.layers):
+            layer_pos = position_embeddings
+            if per_kind and layer_idx < len(self._layer_types):
+                layer_pos = per_kind.get(self._layer_types[layer_idx], position_embeddings)
+            hidden_states = layer(hidden_states, target_hidden, layer_pos, attention_mask)
 
         return self.norm(hidden_states)

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -272,17 +272,30 @@ class DFlashGemma4Attention(DFlashAttention):
                     getattr(config, "num_global_key_value_heads", None) or self.num_kv_heads
                 )
             self.num_key_value_groups = self.num_heads // self.num_kv_heads
-            # Gemma 4 does NOT scale attention logits: vLLM's Gemma4MTPAttention (which
-            # Gemma4DSparkAttention inherits) hardcodes ``self.scaling = 1.0``, and the
-            # base model does the same, documenting that "unlike Gemma2/3,
+            # Keep ``head_dim**-0.5`` even though vLLM serves this draft with
+            # ``scaling = 1.0``. That looks like a train/serve mismatch and it IS one, but
+            # aligning it is measurably WORSE -- do not "fix" this again without repeating
+            # the experiment below.
+            #
+            # vLLM's Gemma4MTPAttention (which Gemma4DSparkAttention inherits) hardcodes
+            # 1.0, matching the Gemma 4 base, which documents that "unlike Gemma2/3,
             # query_pre_attn_scalar is NOT used here; Q/K norms with learnable weights
-            # handle scaling implicitly". Inheriting DFlashAttention's ``head_dim**-0.5``
-            # trains the draft under a softmax temperature the serving stack never
-            # applies. Measured on Gemma-4-E4B DSpark step 7000 (80q MT-Bench,
-            # num_spec=7): 1/sqrt(512) -> AL 2.6809, 1.0 -> AL 2.4984, so the mismatch
-            # is real but modest -- q_norm absorbs most of it, which is exactly why it
-            # never surfaced as an error.
-            self.scaling = 1.0
+            # handle scaling implicitly". Two full lr 2e-3 runs, identical except for this
+            # line, evaluated under REAL vLLM on 80q MT-Bench at num_spec=7:
+            #
+            #     step   trained 1/sqrt(512)   trained 1.0
+            #     1000   2.0645                1.9710   (-4.5%)
+            #     5000   2.5715                2.5234   (-1.9%)
+            #
+            # The reason is that ``q_norm`` is learnable, so it absorbs the scale: serving
+            # a 1/sqrt(512)-trained draft at 1.0 costs only 0.3% (step 1000) to 2.2%
+            # (step 5000), while TRAINING at 1.0 costs more than that. The small scale is
+            # the better training configuration -- smoother attention, better conditioned --
+            # and it transfers almost intact.
+            #
+            # An earlier estimate of a 7% mismatch penalty came from simulating scale 1.0
+            # inside the hand-written harness rather than measuring vLLM, and overstated it.
+            self.scaling = self.head_dim**-0.5
             attn_bias = getattr(config, "attention_bias", False)
             self.q_proj = nn.Linear(
                 config.hidden_size, self.num_heads * self.head_dim, bias=attn_bias

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -221,6 +221,117 @@ class DFlashAttention(nn.Module):
         return self.o_proj(attn_output)
 
 
+class DFlashGemma4Attention(DFlashAttention):
+    """DFlash attention for a Gemma4-style draft.
+
+    Two deltas versus the Qwen3-style :class:`DFlashAttention`:
+
+    * ``attention_k_eq_v``: Gemma4 can derive V from the K projection instead of
+      carrying a separate ``v_proj``, halving the KV parameters. vLLM's
+      ``Gemma4DSparkAttention`` does exactly this (``v_src = k`` when
+      ``use_k_eq_v``), and its fused context-KV precompute *asserts* every draft
+      layer is built this way, so a draft trained with a separate ``v_proj``
+      cannot be served by that path at all.
+    * ``v_norm``: applied to V, with **no learnable weight**, mirroring vLLM's
+      ``RMSNorm(..., has_weight=False)``. Plain (Qwen3) DFlash does not norm V.
+
+    ``use_k_eq_v`` follows vLLM: full-attention layers only, and only when the
+    config opts in. Sliding layers keep their own ``v_proj``.
+    """
+
+    def __init__(self, config, layer_idx):
+        """Initialize Gemma4 draft attention with per-layer dims, dropping ``v_proj`` under k_eq_v."""
+        super().__init__(config, layer_idx)
+        layer_types = getattr(config, "layer_types", None)
+        is_full = layer_types is None or layer_types[layer_idx] == "full_attention"
+        self.use_k_eq_v = is_full and getattr(config, "attention_k_eq_v", False)
+
+        # Gemma4's attention dims are PER LAYER: full-attention layers use a larger
+        # ``global_head_dim`` and, under k_eq_v, a smaller ``num_global_key_value_heads``.
+        # This mirrors vLLM's ``gemma4_layer_config`` (transformers_utils/configs/gemma4.py),
+        # which Gemma4DSparkAttention calls to size q/k/o. Getting this wrong is silent:
+        # the DSpark weight loader only fills names it finds, so a mis-shaped k_proj is
+        # simply left randomly initialized.
+        if is_full:
+            self.head_dim = getattr(config, "global_head_dim", None) or self.head_dim
+            if self.use_k_eq_v:
+                self.num_kv_heads = (
+                    getattr(config, "num_global_key_value_heads", None) or self.num_kv_heads
+                )
+            self.num_key_value_groups = self.num_heads // self.num_kv_heads
+            self.scaling = self.head_dim**-0.5
+            attn_bias = getattr(config, "attention_bias", False)
+            self.q_proj = nn.Linear(
+                config.hidden_size, self.num_heads * self.head_dim, bias=attn_bias
+            )
+            self.k_proj = nn.Linear(
+                config.hidden_size, self.num_kv_heads * self.head_dim, bias=attn_bias
+            )
+            self.o_proj = nn.Linear(
+                self.num_heads * self.head_dim, config.hidden_size, bias=attn_bias
+            )
+            self.q_norm = _NORM_CLS(self.head_dim, eps=config.rms_norm_eps)
+            self.k_norm = _NORM_CLS(self.head_dim, eps=config.rms_norm_eps)
+
+        if self.use_k_eq_v:
+            # Registered by the parent; drop it so it is neither trained nor exported.
+            del self.v_proj
+            self.v_proj = None
+        elif is_full:
+            self.v_proj = nn.Linear(
+                config.hidden_size,
+                self.num_kv_heads * self.head_dim,
+                bias=getattr(config, "attention_bias", False),
+            )
+        # vLLM builds this as ``RMSNorm(..., has_weight=False)`` and the reference
+        # checkpoint ships NO v_norm tensor, so keep the scale fixed at ones and
+        # non-persistent: it must not appear in the exported state_dict.
+        self.v_norm = _NORM_CLS(self.head_dim, eps=config.rms_norm_eps)
+        del self.v_norm.weight
+        self.v_norm.register_buffer("weight", torch.ones(self.head_dim), persistent=False)
+
+    def _project_v(self, target_hidden, hidden_states, k_ctx, k_noise):
+        """Return the V sequence, from K under k_eq_v or from ``v_proj`` otherwise."""
+        if self.use_k_eq_v:
+            return k_ctx, k_noise
+        return self.v_proj(target_hidden), self.v_proj(hidden_states)
+
+    def forward(self, hidden_states, target_hidden, position_embeddings, attention_mask=None):
+        """Forward with KV injection; V is normed and, under k_eq_v, shares K's projection."""
+        bsz, q_len, _ = hidden_states.shape
+        ctx_len = target_hidden.shape[1]
+
+        q = self.q_proj(hidden_states).view(bsz, q_len, -1, self.head_dim)
+        q = self.q_norm(q).transpose(1, 2)
+
+        k_ctx = self.k_proj(target_hidden)
+        k_noise = self.k_proj(hidden_states)
+        k = torch.cat([k_ctx, k_noise], dim=1).view(bsz, ctx_len + q_len, -1, self.head_dim)
+        k = self.k_norm(k).transpose(1, 2)
+
+        v_ctx, v_noise = self._project_v(target_hidden, hidden_states, k_ctx, k_noise)
+        v = torch.cat([v_ctx, v_noise], dim=1).view(bsz, ctx_len + q_len, -1, self.head_dim)
+        # vLLM norms V (no RoPE on V), unlike the Qwen3-style path.
+        v = self.v_norm(v).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+
+        attn_fn = self._get_attn_fn()
+        attn_output, _ = attn_fn(
+            self,
+            q,
+            k,
+            v,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+        )
+        attn_output = attn_output.reshape(bsz, q_len, -1)
+        return self.o_proj(attn_output)
+
+
 class DFlashDecoderLayer(nn.Module):
     """Draft decoder layer with KV injection."""
 
@@ -248,6 +359,56 @@ class DFlashDecoderLayer(nn.Module):
         return hidden_states
 
 
+class DFlashGemma4DecoderLayer(nn.Module):
+    """Draft decoder layer matching Gemma4's block, with KV injection.
+
+    Gemma4 wraps each sub-block in a *pair* of norms ("sandwich norm") and scales
+    the layer output by a learned ``layer_scalar``, where Qwen3 uses a single
+    pre-norm per sub-block. vLLM's ``Gemma4MTPDecoderLayer`` -- which
+    ``Gemma4DSparkDecoderLayer`` inherits -- looks up
+    ``pre_feedforward_layernorm`` / ``post_feedforward_layernorm`` /
+    ``layer_scalar`` by name, and its DSpark weight loader silently leaves any
+    parameter it cannot find randomly initialized. A Qwen3-shaped draft
+    therefore *loads without error* and produces garbage, so the shapes must
+    match exactly.
+
+    The residual/norm order below mirrors ``Gemma4MTPDecoderLayer.forward``:
+    norm -> attn -> norm -> +residual -> norm -> mlp -> norm -> +residual, then
+    scale by ``layer_scalar``.
+    """
+
+    def __init__(self, config, layer_idx):
+        """Initialize a Gemma4-style draft layer (sandwich norms + layer scalar)."""
+        super().__init__()
+        self.self_attn = DFlashGemma4Attention(config, layer_idx)
+        self.mlp = _MLP_CLS(config)
+        self.input_layernorm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
+        # A buffer (not a parameter) to match vLLM's `register_buffer`, so the
+        # exported tensor name and shape line up with the reference checkpoint.
+        self.register_buffer("layer_scalar", torch.ones(1))
+
+    def forward(self, hidden_states, target_hidden, position_embeddings, attention_mask=None):
+        """Forward with sandwich norms, KV injection, and the layer scalar."""
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states, target_hidden, position_embeddings, attention_mask
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = hidden_states + residual
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = hidden_states + residual
+
+        return hidden_states * self.layer_scalar
+
+
 class DFlashModule(nn.Module):
     """DFlash draft module using Qwen3 components (MLP, RMSNorm, RotaryEmbedding)."""
 
@@ -263,8 +424,15 @@ class DFlashModule(nn.Module):
         self.hidden_norm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
 
         # Decoder layers
+        # Gemma4 drafts need Gemma4's block shape (sandwich norms + layer_scalar,
+        # optional k_eq_v); everything else keeps the Qwen3-style block.
+        layer_cls = (
+            DFlashGemma4DecoderLayer
+            if str(getattr(config, "model_type", "")).startswith("gemma4")
+            else DFlashDecoderLayer
+        )
         self.layers = nn.ModuleList(
-            [DFlashDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+            [layer_cls(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
         self.norm = _NORM_CLS(config.hidden_size, eps=config.rms_norm_eps)
         self._rotary_config = config  # Used by _maybe_init_rotary_emb

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -141,6 +141,18 @@ class DFlashAttention(nn.Module):
         self.num_key_value_groups = self.num_heads // self.num_kv_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = getattr(config, "attention_dropout", 0.0)
+        # DFlash/DSpark drafts attend bidirectionally: a block of draft tokens is
+        # predicted in one shot, so those tokens must see each other. Serving must
+        # agree -- vLLM resolves per-layer causality in
+        # qwen3_dflash._dflash_layer_causal(): an explicit ``dflash_config.causal``
+        # overrides all layers, otherwise a layer is causal only when
+        # ``layer_types[i] == "sliding_attention"``. The exporter emits no
+        # ``causal`` field for a plain full-attention draft, so it stays non-causal
+        # on both sides. With ``dflash_swa_window_size`` set, the exporter instead
+        # emits ``use_swa: True`` + an explicit ``causal: False`` and leaves
+        # ``layer_types`` all-full, which keeps vLLM non-causal too. Only mark
+        # layers ``sliding_attention`` if you also intend them to be CAUSAL at
+        # serving time, and train them that way -- see _build_draft_attention_mask.
         self.is_causal = False
 
         attn_bias = getattr(config, "attention_bias", False)

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -72,6 +72,40 @@ _SAFETENSORS_INDEX_FILENAME = "model.safetensors.index.json"
 _SAFETENSORS_SINGLE_FILENAMES = ["model.safetensors", "consolidated.safetensors"]
 
 
+def _resolve_rope_theta(base_cfg, attn_kind: str = "sliding_attention") -> float | None:
+    """Return the base model's RoPE theta, handling nested ``rope_parameters``.
+
+    Most models expose a flat ``rope_theta``. Gemma 4 instead nests per-attention-kind RoPE
+    settings under ``rope_parameters``, e.g.::
+
+        {"full_attention":    {"rope_theta": 1e6, "rope_type": "proportional",
+                               "partial_rotary_factor": 0.25},
+         "sliding_attention": {"rope_theta": 1e4, "rope_type": "default"}}
+
+    A flat ``getattr(base_cfg, "rope_theta", None)`` returns ``None`` there, and the draft then
+    silently trains on the draft class's default theta instead of the base's — training loss and
+    accuracy still improve while MT-Bench AAL is capped, because RoPE frequencies get baked into
+    the trained weights.
+
+    ``attn_kind`` selects which entry to read; it must match the attention the DRAFT uses. The
+    default is ``sliding_attention`` because SWA drafts are the common case for Gemma 4, and its
+    ``rope_type`` is plain ``default`` (the ``full_attention`` entry uses ``proportional`` rope
+    with ``partial_rotary_factor``, which the draft classes do not implement).
+    """
+    theta = getattr(base_cfg, "rope_theta", None)
+    if theta is not None:
+        return theta
+    params = getattr(base_cfg, "rope_parameters", None)
+    if not isinstance(params, dict):
+        return None
+    entry = params.get(attn_kind)
+    if entry is None:
+        # Single-kind nested form, or an unknown kind name: fall back to the sole entry.
+        values = [v for v in params.values() if isinstance(v, dict) and "rope_theta" in v]
+        entry = values[0] if len(values) == 1 else None
+    return entry.get("rope_theta") if isinstance(entry, dict) else None
+
+
 class FakeBaseConfig(PretrainedConfig):
     """Minimal config for FakeBaseModel that supports offline speculative decoding training."""
 
@@ -203,7 +237,7 @@ class FakeBaseModel(PreTrainedModel):
             num_key_value_heads=getattr(base_cfg, "num_key_value_heads", None),
             intermediate_size=getattr(base_cfg, "intermediate_size", None),
             rms_norm_eps=getattr(base_cfg, "rms_norm_eps", 1e-6),
-            rope_theta=getattr(base_cfg, "rope_theta", None),
+            rope_theta=_resolve_rope_theta(base_cfg),
             final_norm_type=_select_final_norm_type(
                 getattr(base_cfg, "model_type", None), base_cfg
             ),

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -15,6 +15,7 @@
 
 """Lightweight fake base model for offline speculative decoding training."""
 
+import copy
 import json
 import os
 
@@ -140,6 +141,30 @@ def _resolve_rope_theta(base_cfg, attn_kind: str = "sliding_attention") -> float
     return entry.get("rope_theta") if isinstance(entry, dict) else None
 
 
+def _resolve_rope_parameters(base_cfg) -> dict | None:
+    """Return the base model's nested per-attention-kind ``rope_parameters``, or ``None``.
+
+    ``_resolve_rope_theta`` collapses the nested form to a single scalar. That is enough for a
+    model whose RoPE is plain ``default`` rope over the whole head dim, but NOT for Gemma 4:
+    its ``full_attention`` entry also carries ``rope_type: "proportional"`` and
+    ``partial_rotary_factor: 0.25``, which rotate only the first quarter of the head dim and
+    leave the rest as NoPE (``inv_freq == 0``). Passing theta alone makes the draft rotate every
+    channel at default frequencies while the target rotates a quarter of them — a silent
+    train/serve mismatch of the same class as the dropped embedding scale.
+
+    Returned verbatim so the draft can build one rotary module per attention kind (see
+    ``DFlashModule._build_gemma4_rope_kinds``). Only the nested dict-of-dicts form is returned;
+    a flat ``{"rope_theta": ..., "rope_type": ...}`` is already covered by the scalar path and
+    would be rewritten by ``PretrainedConfig.standardize_rope_params()``.
+    """
+    params = getattr(base_cfg, "rope_parameters", None)
+    if not isinstance(params, dict):
+        return None
+    if not any(isinstance(v, dict) for v in params.values()):
+        return None
+    return copy.deepcopy(params)
+
+
 class _ScaledEmbedding(nn.Embedding):
     """``nn.Embedding`` that scales its output, like Gemma's embedding layer.
 
@@ -180,6 +205,7 @@ class FakeBaseConfig(PretrainedConfig):
         intermediate_size=None,
         rms_norm_eps=1e-6,
         rope_theta=None,
+        rope_parameters=None,
         final_norm_type=None,
         embed_scale=1.0,
         **kwargs,
@@ -219,6 +245,11 @@ class FakeBaseConfig(PretrainedConfig):
         self.intermediate_size = intermediate_size
         # For some drafter algo (e.g. DFlash) rope theta must match target model. Extract here.
         self.rope_theta = rope_theta
+        # Nested per-attention-kind RoPE settings (Gemma 4), carrying rope_type and
+        # partial_rotary_factor, which the flat rope_theta above cannot express. Persisted so a
+        # reloaded fake base rebuilds identical draft rotary modules. None for flat-rope models.
+        if rope_parameters is not None:
+            self.rope_parameters = rope_parameters
         if isinstance(dtype, str):
             dtype = getattr(torch, dtype)
         self.dtype = dtype
@@ -303,6 +334,7 @@ class FakeBaseModel(PreTrainedModel):
             intermediate_size=getattr(base_cfg, "intermediate_size", None),
             rms_norm_eps=getattr(base_cfg, "rms_norm_eps", 1e-6),
             rope_theta=_resolve_rope_theta(base_cfg),
+            rope_parameters=_resolve_rope_parameters(base_cfg),
             final_norm_type=_select_final_norm_type(
                 getattr(base_cfg, "model_type", None), base_cfg
             ),

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -34,6 +34,40 @@ from transformers import (
 
 from .modeling_final_norm import _FINAL_NORM_CLASSES, _select_final_norm_type
 
+# Model types whose embedding layer scales its output by sqrt(hidden_size) inside
+# ``forward()`` rather than baking the factor into the stored weight. FakeBaseModel
+# rebuilds the embedding as a plain ``nn.Embedding`` and copies only the raw weight,
+# so that scaling is silently lost -- the draft then trains on inputs ~sqrt(H) times
+# smaller than the ones vLLM feeds it at serving time, and acceptance collapses with
+# no error anywhere. Measured on Gemma-4-E4B: serve/train noise_embedding ratio was
+# 50.5998 == sqrt(2560), and draft layer 0 diverged to cos 0.467.
+_SQRT_HIDDEN_EMBED_SCALE_MODEL_TYPES = {
+    "gemma",
+    "gemma2",
+    "gemma3",
+    "gemma3_text",
+    "gemma4",
+    "gemma4_text",
+}
+
+
+def _resolve_embed_scale(base_cfg) -> float:
+    """The multiplier the base model applies to its embedding lookup.
+
+    Prefers an explicit ``embed_scale`` on the config; otherwise falls back to
+    sqrt(hidden_size) for the model families known to scale in ``forward()``.
+    Returns 1.0 for everything else, which keeps Qwen/Llama-style bases bit-exact.
+    """
+    explicit = getattr(base_cfg, "embed_scale", None)
+    if explicit is not None:
+        return float(explicit)
+    model_type = str(getattr(base_cfg, "model_type", "") or "")
+    if model_type in _SQRT_HIDDEN_EMBED_SCALE_MODEL_TYPES:
+        hidden = getattr(base_cfg, "hidden_size", None)
+        if hidden:
+            return float(hidden) ** 0.5
+    return 1.0
+
 # Candidate module paths searched in order — shared with HFEagleModel._find_base_model_parts
 _EMBED_TOKENS_PATHS = [
     "embed_tokens",
@@ -106,6 +140,27 @@ def _resolve_rope_theta(base_cfg, attn_kind: str = "sliding_attention") -> float
     return entry.get("rope_theta") if isinstance(entry, dict) else None
 
 
+class _ScaledEmbedding(nn.Embedding):
+    """``nn.Embedding`` that scales its output, like Gemma's embedding layer.
+
+    Gemma-family bases multiply the embedding lookup by sqrt(hidden_size) inside
+    ``forward()``; the factor is NOT part of the stored weight. FakeBaseModel is
+    reconstructed from weights alone, so without this the factor is dropped and
+    the draft trains on inputs sqrt(H) times smaller than vLLM feeds it at serve
+    time. ``embed_scale=1.0`` makes this exactly ``nn.Embedding``.
+    """
+
+    def __init__(self, *args, embed_scale: float = 1.0, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.embed_scale = float(embed_scale)
+
+    def forward(self, input_ids):
+        out = super().forward(input_ids)
+        if self.embed_scale == 1.0:
+            return out
+        return out * torch.tensor(self.embed_scale, dtype=out.dtype, device=out.device)
+
+
 class FakeBaseConfig(PretrainedConfig):
     """Minimal config for FakeBaseModel that supports offline speculative decoding training."""
 
@@ -126,6 +181,7 @@ class FakeBaseConfig(PretrainedConfig):
         rms_norm_eps=1e-6,
         rope_theta=None,
         final_norm_type=None,
+        embed_scale=1.0,
         **kwargs,
     ):
         """Initialize FakeBaseConfig with minimal model configuration parameters."""
@@ -135,6 +191,10 @@ class FakeBaseConfig(PretrainedConfig):
         # (model whose final-norm type we don't know). See _FINAL_NORM_CLASSES /
         # _FINAL_NORM_TYPE_BY_MODEL_TYPE. Persisted so a reloaded config rebuilds the same norm.
         self.final_norm_type = final_norm_type
+        # Multiplier applied to the embedding lookup (sqrt(hidden_size) on Gemma-family
+        # bases, 1.0 elsewhere). Persisted so a reloaded checkpoint rebuilds the same
+        # scaling; see _resolve_embed_scale.
+        self.embed_scale = embed_scale
         self.num_hidden_layers = num_hidden_layers
         # Mirror the original base layer count. The non-fake offline path loads with
         # num_hidden_layers=0 and stashes the real count here (see utils.load_vlm_or_llm);
@@ -187,7 +247,12 @@ class FakeBaseModel(PreTrainedModel):
         self.model = nn.Module()
         self.model.layers = nn.ModuleList()
         self.model.dtype = config.dtype
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, dtype=config.dtype)
+        self.embed_tokens = _ScaledEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            dtype=config.dtype,
+            embed_scale=getattr(config, "embed_scale", 1.0),
+        )
         self.lm_head = nn.Linear(
             config.hidden_size, config.vocab_size, bias=False, dtype=config.dtype
         )
@@ -241,6 +306,7 @@ class FakeBaseModel(PreTrainedModel):
             final_norm_type=_select_final_norm_type(
                 getattr(base_cfg, "model_type", None), base_cfg
             ),
+            embed_scale=_resolve_embed_scale(base_cfg),
         )
         model = cls(config)
         # Load lm_head, embed_tokens, and (for known models) the final norm into the model.

--- a/modelopt/torch/speculative/plugins/modeling_final_norm.py
+++ b/modelopt/torch/speculative/plugins/modeling_final_norm.py
@@ -93,6 +93,14 @@ _FINAL_NORM_TYPE_BY_MODEL_TYPE: dict[str, str] = {
     # M3's final norm is always gemma-style; map it here too so a config that lost its
     # use_gemma_norm flag still gets the correct flavor instead of silently dropping the +1.
     "minimax_m3_vl_text": "gemma_rmsnorm",
+    # Gemma 4 VLM nests the LLM as text_config with model_type "gemma4_text"; from_source
+    # reads the NESTED config, so a "gemma4" key alone would never match. Verified numerically
+    # on gemma-4-E4B-it that Gemma4RMSNorm is plain ``normed * weight`` — NOT the ``(1 + weight)``
+    # form used by Gemma 2/3 — reproducing HF ``hidden_states[-1]`` at cos=0.999999 (vs 0.9719
+    # and maxabs_err 47.6 for the ``(1 + weight)`` form), so plain ``rmsnorm`` is correct here
+    # and ``gemma_rmsnorm`` would be wrong. Both keys listed so a text-only checkpoint works too.
+    "gemma4_text": "rmsnorm",
+    "gemma4": "rmsnorm",
     # gpt_oss intentionally DISABLED: GptOssRMSNorm uses an fp32 weight + multiply-then-cast,
     # unlike _FinalRMSNorm's bf16 weight, so reusing it would silently bias reconstructed logits.
     # Re-enable once a gpt_oss-style class (fp32 weight, multiply-then-cast) is in _FINAL_NORM_CLASSES.

--- a/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+++ b/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
@@ -153,6 +153,13 @@ dflash:
     # draft therefore loads without error and produces garbage.
     model_type: gemma4_text
     attention_k_eq_v: true
+    # Inherit RoPE from the base's sliding_attention entry (theta 1e4, plain default
+    # rope) rather than from the draft's own layer_types. Those are all
+    # full_attention, which would pull theta 1e6 + proportional rope -- measured
+    # 1.2-3.4% WORSE on acceptance length at every comparable step. The draft is an
+    # independent small model consuming base hidden states, not a reproduction of the
+    # base's full-attention layers.
+    rope_attention_kind: sliding_attention
     layer_types:
       - full_attention
       - full_attention

--- a/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+++ b/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
@@ -20,9 +20,12 @@
 #    rope_type "default"). modeling_fakebase.py needed _resolve_rope_theta() to
 #    read the nested form. hf_dflash.py ENFORCES rope_theta from the base config
 #    and overwrites any value set here, so this could NOT be fixed from the yaml.
-#    We take the sliding_attention entry -> rope_theta 10000.0, matching the SWA
-#    draft below. (The full_attention entry's "proportional" rope +
-#    partial_rotary_factor is not implemented in the draft classes.)
+#    We take the sliding_attention entry -> rope_theta 10000.0. Note this is the
+#    LOCAL theta even though the draft below is all full_attention: the
+#    full_attention entry's "proportional" rope + partial_rotary_factor 0.25 is
+#    not implemented in the draft classes, and the reference drafter
+#    (deepseek-ai/dspark_gemma4_12b_block7) also carries the default/1e4 form.
+#    The draft is trained and served with the same value, so it is self-consistent.
 #
 #  * CAPTURE IDS: vLLM's EagleModelMixin captures POST-layer with residual added
 #    and indexes as layer_idx+1, so valid ids are 1..42 and 42 is the TRUE final
@@ -35,10 +38,32 @@
 #
 #  * MASK TOKEN: Gemma 4's vocab is fully packed (no free/unused ids), but it
 #    ships a native `<mask>` token at id 4 — used directly.
+#
+#  * DRAFT ATTENTION IS NON-CAUSAL (bidirectional), like every other DSpark head.
+#    vLLM resolves this per layer in qwen3_dflash._dflash_layer_causal: an
+#    explicit `dflash_config.causal` overrides everything, otherwise a layer is
+#    causal only when layer_types[i] == "sliding_attention". This draft sets
+#    neither, and every layer is full_attention, so all 5 layers come out
+#    causal=False. That is what a block-parallel (semi-autoregressive) drafter
+#    wants: the block's tokens are predicted at once and must see each other.
+#    ModelOpt matches this -- DFlashAttention is non-causal, and the exporter
+#    does not emit a `causal` field. See "SERVING" below for the consequence.
+#
+#  * SERVING requires speculative_config.attention_backend = "FLASHINFER", for
+#    TWO independent reasons; either alone is fatal:
+#      1. head dim -- full_attention layers use global_head_dim=512 and the
+#         auto-selected FLASH_ATTN (FA2) caps head dimension at 256.
+#      2. causality -- load_dspark_model sets attention_config.use_non_causal
+#         from dflash_has_any_non_causal(), which is True here, and the backend
+#         must be able to serve a non-causal mask.
+#    VLLM_ATTENTION_BACKEND does NOT reach the draft; it is read from
+#    speculative_config.attention_backend. Confirmed at runtime by the log line
+#    "Using FlashInfer for draft model non-causal attention".
 
 metadata:
   recipe_type: speculative_dflash
-  description: DSpark (DFlash backbone + Markov + confidence head) for Gemma-4-E4B-it, SWA draft.
+  description: DSpark (DFlash backbone + Markov + confidence head) for Gemma-4-E4B-it,
+    5-layer full-attention draft aligned with the official reference checkpoint.
 
 model:
   model_name_or_path:
@@ -99,9 +124,14 @@ dflash:
   dflash_architecture_config:
     # Aligned with the official reference drafter deepseek-ai/dspark_gemma4_12b_block7
     # (the checkpoint vLLM's gemma4_dspark.py was written for). Its backbone is
-    # 5 full-attention layers with attention_k_eq_v; vLLM's fused context-KV
-    # precompute ASSERTS every draft layer is built that way, so an SWA draft
-    # cannot be served by that path at all.
+    # 5 full-attention layers with attention_k_eq_v.
+    #
+    # Why not SWA here: Gemma4DSparkModel._build_fused_kv_buffers asserts
+    # `all(a.use_k_eq_v for a in layers_attn)`, and Gemma4DSparkAttention only
+    # sets use_k_eq_v when layer_type == "full_attention". So the assert is
+    # really about k_eq_v uniformity, but because the two are coupled, ANY
+    # sliding layer trips it. Mixed sliding/full would additionally need the V2
+    # model runner (see _resolve_layer_attention in qwen3_dflash.py).
     num_hidden_layers: 5
     num_attention_heads: 16
     num_key_value_heads: 8

--- a/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+++ b/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
@@ -97,31 +97,35 @@ dflash:
   dflash_l1_loss_alpha: 0.9
   dflash_confidence_head_alpha: 1.0
   dflash_architecture_config:
-    # Draft dims are set explicitly — the draft is an independent model and does
-    # NOT inherit these from the base (hidden_size/vocab/rope_theta ARE forced to
-    # the base and need not be set here).
+    # Aligned with the official reference drafter deepseek-ai/dspark_gemma4_12b_block7
+    # (the checkpoint vLLM's gemma4_dspark.py was written for). Its backbone is
+    # 5 full-attention layers with attention_k_eq_v; vLLM's fused context-KV
+    # precompute ASSERTS every draft layer is built that way, so an SWA draft
+    # cannot be served by that path at all.
     num_hidden_layers: 5
     num_attention_heads: 16
-    num_key_value_heads: 4
+    num_key_value_heads: 8
+    # Full-attention layers use global_head_dim (512) and, under k_eq_v,
+    # num_global_key_value_heads (1) -- see gemma4_layer_config in vLLM.
     head_dim: 256
+    global_head_dim: 512
+    num_global_key_value_heads: 1
     intermediate_size: 10240
     projector_type: dspark
-    # Markov head: low-rank first-order transition bias, memoryless variant.
     markov_rank: 256
     markov_head_type: vanilla
     use_confidence_head: true
-    # --- SWA draft (user decision 2026-08-12: try SWA first) ---
-    # DFlashAttention enables sliding-window attention only when the draft config
-    # carries BOTH `layer_types` and `sliding_window`; it then applies the window
-    # on layers whose layer_types entry is "sliding_attention". Matching the base's
-    # window of 512 and its sliding-layer rope_theta of 10000.
-    # NOTE: K3 measured SWA costing ~23% AL vs full attention at window 1024, and
-    # this window is smaller still — expect an AL hit and compare against a
-    # full-attention control before concluding.
-    sliding_window: 512
+    # --- Gemma4 block shape (sandwich norms + layer_scalar) + k_eq_v ---
+    # model_type gemma4* selects DFlashGemma4DecoderLayer, which adds
+    # pre/post_feedforward_layernorm and layer_scalar. vLLM's
+    # Gemma4MTPDecoderLayer looks those up BY NAME and its DSpark loader leaves
+    # anything it cannot find randomly initialized -- silently. A Qwen3-shaped
+    # draft therefore loads without error and produces garbage.
+    model_type: gemma4_text
+    attention_k_eq_v: true
     layer_types:
-      - sliding_attention
-      - sliding_attention
-      - sliding_attention
-      - sliding_attention
-      - sliding_attention
+      - full_attention
+      - full_attention
+      - full_attention
+      - full_attention
+      - full_attention

--- a/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+++ b/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
@@ -1,0 +1,127 @@
+# DSpark (full-train, from scratch) recipe for Gemma-4-E4B-it.
+#
+# Streaming: the real Gemma-4-E4B-it base is served by vLLM; the trainer uses a
+# fake base (FakeBaseModel carries embed_tokens + the final norm). DSpark
+# reconstructs the base teacher distribution from the captured PRE-norm hidden
+# and re-applies the base final norm before lm_head.
+#
+# Gemma-4-E4B-specific notes (all verified on PDX 2026-08-12):
+#
+#  * FINAL NORM: Gemma 4 nests the LLM under text_config with model_type
+#    "gemma4_text", so modeling_final_norm.py needed BOTH "gemma4_text" and
+#    "gemma4" added to _FINAL_NORM_TYPE_BY_MODEL_TYPE. Verified numerically that
+#    Gemma4RMSNorm is plain `normed * weight` (NOT Gemma 2/3's `(1 + weight)`),
+#    reproducing HF hidden_states[-1] at cos=0.999999, so the existing
+#    _FinalRMSNorm is correct as-is.
+#
+#  * ROPE: Gemma 4 has NO flat `rope_theta`; it nests per-attention-kind settings
+#    under `rope_parameters` (full_attention: theta 1e6 + rope_type
+#    "proportional" + partial_rotary_factor 0.25; sliding_attention: theta 1e4 +
+#    rope_type "default"). modeling_fakebase.py needed _resolve_rope_theta() to
+#    read the nested form. hf_dflash.py ENFORCES rope_theta from the base config
+#    and overwrites any value set here, so this could NOT be fixed from the yaml.
+#    We take the sliding_attention entry -> rope_theta 10000.0, matching the SWA
+#    draft below. (The full_attention entry's "proportional" rope +
+#    partial_rotary_factor is not implemented in the draft classes.)
+#
+#  * CAPTURE IDS: vLLM's EagleModelMixin captures POST-layer with residual added
+#    and indexes as layer_idx+1, so valid ids are 1..42 and 42 is the TRUE final
+#    layer (verified: cos(id42, final_norm_INPUT) = 1.0000, and ids 9/18/27/36
+#    match HF hidden_states[id] at cos=1.0000 with off-by-one dropping to
+#    0.55-0.98). Gemma 4 repeats 5x sliding + 1x full attention, so the
+#    full_attention layers (0-based [5,11,17,23,29,35,41]) correspond to capture
+#    ids [6,12,18,24,30,36,42]; we sample those to land on residual-stream
+#    boundaries rather than spacing uniformly.
+#
+#  * MASK TOKEN: Gemma 4's vocab is fully packed (no free/unused ids), but it
+#    ships a native `<mask>` token at id 4 — used directly.
+
+metadata:
+  recipe_type: speculative_dflash
+  description: DSpark (DFlash backbone + Markov + confidence head) for Gemma-4-E4B-it, SWA draft.
+
+model:
+  model_name_or_path:
+  trust_remote_code: true
+  use_fake_base_for_offline: true
+
+data:
+  mode: streaming
+  data_path:
+  offline_data_path:
+  chat_template:
+
+training:
+  output_dir:
+  num_train_epochs: 1
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 1
+  learning_rate: 1.0e-4
+  warmup_steps: 500
+  training_seq_len: 4096
+  logging_steps: 20
+  save_steps: 1000
+  cp_size: 1
+  dp_shard_size: 1
+  disable_tqdm: true
+  # Eval runs the DFlash backbone only (Markov head not applied in eval forward),
+  # so AR would misreport. Compare via export + offline AL harness instead.
+  estimate_ar: false
+  ar_validate_steps: 0
+  answer_only_loss: true
+  do_eval: false
+  lr_scheduler_type: linear
+  save_strategy: steps
+  weight_decay: 0.0
+  max_grad_norm: 1.0
+  dataloader_drop_last: true
+  bf16: true
+  tf32: true
+  remove_unused_columns: false
+  ddp_find_unused_parameters: true
+  ddp_timeout: 1800
+  report_to: none
+
+dflash:
+  dflash_block_size: 8
+  dflash_num_anchors: 512
+  dflash_use_torch_compile: false
+  dflash_self_logit_distillation: false
+  # block_size=8 -> decay gamma 4 (matches the K2.6 DSpark regime).
+  dflash_loss_decay_factor: 4.0
+  # Gemma 4 ships a native <mask> token at id 4 (vocab is fully packed, so there
+  # is no spare/unused id to borrow the way Kimi's 163838 was).
+  dflash_mask_token_id: 4
+  # --- DSpark three-term loss (DeepSpec L1/TVD-dominant defaults) ---
+  dflash_ce_loss_alpha: 0.1
+  dflash_l1_loss_alpha: 0.9
+  dflash_confidence_head_alpha: 1.0
+  dflash_architecture_config:
+    # Draft dims are set explicitly — the draft is an independent model and does
+    # NOT inherit these from the base (hidden_size/vocab/rope_theta ARE forced to
+    # the base and need not be set here).
+    num_hidden_layers: 5
+    num_attention_heads: 16
+    num_key_value_heads: 4
+    head_dim: 256
+    intermediate_size: 10240
+    projector_type: dspark
+    # Markov head: low-rank first-order transition bias, memoryless variant.
+    markov_rank: 256
+    markov_head_type: vanilla
+    use_confidence_head: true
+    # --- SWA draft (user decision 2026-08-12: try SWA first) ---
+    # DFlashAttention enables sliding-window attention only when the draft config
+    # carries BOTH `layer_types` and `sliding_window`; it then applies the window
+    # on layers whose layer_types entry is "sliding_attention". Matching the base's
+    # window of 512 and its sliding-layer rope_theta of 10000.
+    # NOTE: K3 measured SWA costing ~23% AL vs full attention at window 1024, and
+    # this window is smaller still — expect an AL hit and compare against a
+    # full-attention control before concluding.
+    sliding_window: 512
+    layer_types:
+      - sliding_attention
+      - sliding_attention
+      - sliding_attention
+      - sliding_attention
+      - sliding_attention

--- a/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b_swa.yaml
+++ b/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b_swa.yaml
@@ -1,0 +1,202 @@
+# DSpark recipe for Gemma-4-E4B-it -- SLIDING-WINDOW (SWA) VARIANT.
+#
+# Derived from dspark_gemma4_e4b.yaml (the validated full-attention baseline);
+# the ONLY delta is `dflash_swa_window_size` below. Keep the two in sync.
+#
+# !! NOT YET SERVABLE -- requires a vLLM fix. Read this before running. !!
+#
+# Training side is ready: _build_draft_attention_mask() already windows the
+# context (`kv > q_real_pos - window`) while leaving block-internal attention
+# bidirectional, and hf_dspark.py passes dflash_swa_window_size through. The
+# exporter emits dflash_config.use_swa/swa_window_size + a top-level
+# sliding_window, and pins causal: False.
+#
+# The serving gap is Gemma4-specific. vLLM's Qwen3 DFlash layer resolves its
+# window via _resolve_layer_attention(), which honours dflash_config.use_swa.
+# Gemma4DSparkAttention does NOT: it inherits Gemma4MTPAttention.__init__,
+# which derives the window purely from the base-model layer pattern --
+#
+#     self.is_sliding  = layer_type == "sliding_attention"
+#     sliding_window   = config.sliding_window if self.is_sliding else None
+#
+# Our draft is deliberately all "full_attention" (that is what keeps
+# attention_k_eq_v uniform and the fused-KV precompute assert satisfied), so
+# is_sliding is False on every layer and per_layer_sliding_window stays None.
+# The draft would therefore TRAIN with a 512-token window and SERVE with full
+# attention -- a silent train/inference mismatch that only shows up as a
+# depressed acceptance length, with no error raised.
+#
+# Fix (vLLM side, small): have Gemma4DSparkAttention resolve its window through
+# _resolve_layer_attention(config, layer_idx) like the Qwen3 DFlash layer does,
+# and pass the result as per_layer_sliding_window. Verified by config
+# simulation that this keeps all 5 layers use_k_eq_v=True (fused-KV assert
+# passes), causal=False, and does not require the V2 model runner.
+#
+# Until that lands, train with dspark_gemma4_e4b.yaml instead.
+#
+#
+# Streaming: the real Gemma-4-E4B-it base is served by vLLM; the trainer uses a
+# fake base (FakeBaseModel carries embed_tokens + the final norm). DSpark
+# reconstructs the base teacher distribution from the captured PRE-norm hidden
+# and re-applies the base final norm before lm_head.
+#
+# Gemma-4-E4B-specific notes (all verified on PDX 2026-08-12):
+#
+#  * FINAL NORM: Gemma 4 nests the LLM under text_config with model_type
+#    "gemma4_text", so modeling_final_norm.py needed BOTH "gemma4_text" and
+#    "gemma4" added to _FINAL_NORM_TYPE_BY_MODEL_TYPE. Verified numerically that
+#    Gemma4RMSNorm is plain `normed * weight` (NOT Gemma 2/3's `(1 + weight)`),
+#    reproducing HF hidden_states[-1] at cos=0.999999, so the existing
+#    _FinalRMSNorm is correct as-is.
+#
+#  * ROPE: Gemma 4 has NO flat `rope_theta`; it nests per-attention-kind settings
+#    under `rope_parameters` (full_attention: theta 1e6 + rope_type
+#    "proportional" + partial_rotary_factor 0.25; sliding_attention: theta 1e4 +
+#    rope_type "default"). modeling_fakebase.py needed _resolve_rope_theta() to
+#    read the nested form. hf_dflash.py ENFORCES rope_theta from the base config
+#    and overwrites any value set here, so this could NOT be fixed from the yaml.
+#    We take the sliding_attention entry -> rope_theta 10000.0. Note this is the
+#    LOCAL theta even though the draft below is all full_attention: the
+#    full_attention entry's "proportional" rope + partial_rotary_factor 0.25 is
+#    not implemented in the draft classes, and the reference drafter
+#    (deepseek-ai/dspark_gemma4_12b_block7) also carries the default/1e4 form.
+#    The draft is trained and served with the same value, so it is self-consistent.
+#
+#  * CAPTURE IDS: vLLM's EagleModelMixin captures POST-layer with residual added
+#    and indexes as layer_idx+1, so valid ids are 1..42 and 42 is the TRUE final
+#    layer (verified: cos(id42, final_norm_INPUT) = 1.0000, and ids 9/18/27/36
+#    match HF hidden_states[id] at cos=1.0000 with off-by-one dropping to
+#    0.55-0.98). Gemma 4 repeats 5x sliding + 1x full attention, so the
+#    full_attention layers (0-based [5,11,17,23,29,35,41]) correspond to capture
+#    ids [6,12,18,24,30,36,42]; we sample those to land on residual-stream
+#    boundaries rather than spacing uniformly.
+#
+#  * MASK TOKEN: Gemma 4's vocab is fully packed (no free/unused ids), but it
+#    ships a native `<mask>` token at id 4 — used directly.
+#
+#  * DRAFT ATTENTION IS NON-CAUSAL (bidirectional), like every other DSpark head.
+#    vLLM resolves this per layer in qwen3_dflash._dflash_layer_causal: an
+#    explicit `dflash_config.causal` overrides everything, otherwise a layer is
+#    causal only when layer_types[i] == "sliding_attention". This draft sets
+#    neither, and every layer is full_attention, so all 5 layers come out
+#    causal=False. That is what a block-parallel (semi-autoregressive) drafter
+#    wants: the block's tokens are predicted at once and must see each other.
+#    ModelOpt matches this -- DFlashAttention is non-causal, and the exporter
+#    does not emit a `causal` field. See "SERVING" below for the consequence.
+#
+#  * SERVING requires speculative_config.attention_backend = "FLASHINFER", for
+#    TWO independent reasons; either alone is fatal:
+#      1. head dim -- full_attention layers use global_head_dim=512 and the
+#         auto-selected FLASH_ATTN (FA2) caps head dimension at 256.
+#      2. causality -- load_dspark_model sets attention_config.use_non_causal
+#         from dflash_has_any_non_causal(), which is True here, and the backend
+#         must be able to serve a non-causal mask.
+#    VLLM_ATTENTION_BACKEND does NOT reach the draft; it is read from
+#    speculative_config.attention_backend. Confirmed at runtime by the log line
+#    "Using FlashInfer for draft model non-causal attention".
+
+metadata:
+  recipe_type: speculative_dflash
+  description: DSpark for Gemma-4-E4B-it, 5-layer draft with non-causal sliding-window
+    attention (window 512). Trains today; needs a vLLM fix before it can be served.
+
+model:
+  model_name_or_path:
+  trust_remote_code: true
+  use_fake_base_for_offline: true
+
+data:
+  mode: streaming
+  data_path:
+  offline_data_path:
+  chat_template:
+
+training:
+  output_dir:
+  num_train_epochs: 1
+  per_device_train_batch_size: 4
+  gradient_accumulation_steps: 1
+  learning_rate: 1.0e-4
+  warmup_steps: 500
+  training_seq_len: 4096
+  logging_steps: 20
+  save_steps: 1000
+  cp_size: 1
+  dp_shard_size: 1
+  disable_tqdm: true
+  # Eval runs the DFlash backbone only (Markov head not applied in eval forward),
+  # so AR would misreport. Compare via export + offline AL harness instead.
+  estimate_ar: false
+  ar_validate_steps: 0
+  answer_only_loss: true
+  do_eval: false
+  lr_scheduler_type: linear
+  save_strategy: steps
+  weight_decay: 0.0
+  max_grad_norm: 1.0
+  dataloader_drop_last: true
+  bf16: true
+  tf32: true
+  remove_unused_columns: false
+  ddp_find_unused_parameters: true
+  ddp_timeout: 1800
+  report_to: none
+
+dflash:
+  dflash_block_size: 8
+  dflash_num_anchors: 512
+  # THE ONLY FUNCTIONAL DELTA vs dspark_gemma4_e4b.yaml.
+  # Non-causal sliding window over the CONTEXT only; block-internal attention
+  # stays bidirectional and un-windowed (config.py enforces window >=
+  # dflash_block_size, so a full block always fits). 512 matches the base
+  # model's own sliding_window.
+  dflash_swa_window_size: 512
+  dflash_use_torch_compile: false
+  dflash_self_logit_distillation: false
+  # block_size=8 -> decay gamma 4 (matches the K2.6 DSpark regime).
+  dflash_loss_decay_factor: 4.0
+  # Gemma 4 ships a native <mask> token at id 4 (vocab is fully packed, so there
+  # is no spare/unused id to borrow the way Kimi's 163838 was).
+  dflash_mask_token_id: 4
+  # --- DSpark three-term loss (DeepSpec L1/TVD-dominant defaults) ---
+  dflash_ce_loss_alpha: 0.1
+  dflash_l1_loss_alpha: 0.9
+  dflash_confidence_head_alpha: 1.0
+  dflash_architecture_config:
+    # Aligned with the official reference drafter deepseek-ai/dspark_gemma4_12b_block7
+    # (the checkpoint vLLM's gemma4_dspark.py was written for). Its backbone is
+    # 5 full-attention layers with attention_k_eq_v.
+    #
+    # Why not SWA here: Gemma4DSparkModel._build_fused_kv_buffers asserts
+    # `all(a.use_k_eq_v for a in layers_attn)`, and Gemma4DSparkAttention only
+    # sets use_k_eq_v when layer_type == "full_attention". So the assert is
+    # really about k_eq_v uniformity, but because the two are coupled, ANY
+    # sliding layer trips it. Mixed sliding/full would additionally need the V2
+    # model runner (see _resolve_layer_attention in qwen3_dflash.py).
+    num_hidden_layers: 5
+    num_attention_heads: 16
+    num_key_value_heads: 8
+    # Full-attention layers use global_head_dim (512) and, under k_eq_v,
+    # num_global_key_value_heads (1) -- see gemma4_layer_config in vLLM.
+    head_dim: 256
+    global_head_dim: 512
+    num_global_key_value_heads: 1
+    intermediate_size: 10240
+    projector_type: dspark
+    markov_rank: 256
+    markov_head_type: vanilla
+    use_confidence_head: true
+    # --- Gemma4 block shape (sandwich norms + layer_scalar) + k_eq_v ---
+    # model_type gemma4* selects DFlashGemma4DecoderLayer, which adds
+    # pre/post_feedforward_layernorm and layer_scalar. vLLM's
+    # Gemma4MTPDecoderLayer looks those up BY NAME and its DSpark loader leaves
+    # anything it cannot find randomly initialized -- silently. A Qwen3-shaped
+    # draft therefore loads without error and produces garbage.
+    model_type: gemma4_text
+    attention_k_eq_v: true
+    layer_types:
+      - full_attention
+      - full_attention
+      - full_attention
+      - full_attention
+      - full_attention

--- a/tests/unit/torch/speculative/plugins/test_hf_dflash.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_dflash.py
@@ -576,6 +576,54 @@ class TestDFlashSlidingWindow:
         assert attn.sliding_window is None
 
 
+class TestDFlashFp32MasterWeights:
+    """The draft can hold fp32 parameters while the frozen base stays bf16.
+
+    Motivation is numerical, not cosmetic: a bf16 parameter initialised at exactly 1.0
+    cannot move once the learning rate drops below half the downward ULP there
+    (2**-9 = 0.00195), because every Adam step rounds back. On a 56k-step Gemma-4 run
+    that left 78% of the draft's RMSNorm weights still exactly 1.0.
+    """
+
+    @staticmethod
+    def _bf16_base():
+        model = get_tiny_llama(num_hidden_layers=4)
+        return model.to(torch.bfloat16)
+
+    @staticmethod
+    def _draft_dtypes(model):
+        return {p.dtype for n, p in model.named_parameters() if "dflash_module" in n}
+
+    def test_draft_is_fp32_while_base_stays_bf16(self):
+        """The flag lifts ONLY the draft; the frozen base keeps the target's dtype."""
+        model = self._bf16_base()
+        config = get_dflash_config()
+        config["dflash_fp32_master_weights"] = True
+        mtsp.convert(model, [("dflash", config)])
+        assert self._draft_dtypes(model) == {torch.float32}
+        base = {p.dtype for n, p in model.named_parameters() if "dflash_module" not in n}
+        assert base == {torch.bfloat16}
+
+    def test_default_keeps_the_draft_in_the_base_dtype(self):
+        """Off by default: existing recipes must keep training exactly as before."""
+        model = self._bf16_base()
+        mtsp.convert(model, [("dflash", get_dflash_config())])
+        assert self._draft_dtypes(model) == {torch.bfloat16}
+
+    def test_flag_survives_save_restore(self):
+        """The flag lives in DFlashConfig, so a restored checkpoint must still carry it.
+
+        A checkpoint written with the flag and restored by code that dropped it fails
+        pydantic validation with extra_forbidden -- which is how every eval job for this
+        run failed until the eval container was moved to matching code.
+        """
+        model = self._bf16_base()
+        config = get_dflash_config()
+        config["dflash_fp32_master_weights"] = True
+        mtsp.convert(model, [("dflash", config)])
+        assert model.dflash_fp32_master_weights is True
+
+
 class TestDFlashGemma4AttentionScale:
     """Gemma 4 drafts must attend at scale 1.0, matching the base model and vLLM.
 

--- a/tests/unit/torch/speculative/plugins/test_hf_dflash.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_dflash.py
@@ -576,6 +576,58 @@ class TestDFlashSlidingWindow:
         assert attn.sliding_window is None
 
 
+class TestDFlashGemma4AttentionScale:
+    """Gemma 4 drafts must attend at scale 1.0, matching the base model and vLLM.
+
+    Gemma 4 carries no ``1/sqrt(head_dim)`` in attention -- HF's
+    ``Gemma4TextAttention`` sets ``scaling = 1.0`` and there is no
+    ``query_pre_attn_scalar`` -- and vLLM's ``Gemma4DSparkAttention`` inherits that
+    constant. Training at ``head_dim**-0.5`` instead cost ~13% acceptance length
+    under stock vLLM. That line has already been reverted once, so it is pinned here.
+    """
+
+    @staticmethod
+    def _gemma4_config():
+        from transformers import PretrainedConfig
+
+        return PretrainedConfig(
+            hidden_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            global_head_dim=32,
+            num_global_key_value_heads=1,
+            attention_k_eq_v=True,
+            rms_norm_eps=1e-6,
+            attention_bias=False,
+            attention_dropout=0.0,
+            layer_types=["full_attention", "sliding_attention"],
+            sliding_window=256,
+            _attn_implementation="sdpa",
+        )
+
+    def test_full_attention_layer_uses_unit_scale(self):
+        """A full-attention draft layer keeps the larger head_dim but scale 1.0."""
+        from modelopt.torch.speculative.plugins.modeling_dflash import DFlashGemma4Attention
+
+        attn = DFlashGemma4Attention(self._gemma4_config(), layer_idx=0)
+        assert attn.head_dim == 32
+        assert attn.scaling == 1.0
+
+    def test_sliding_attention_layer_uses_unit_scale(self):
+        """Sliding layers skip the ``is_full`` branch and must not inherit the parent scale."""
+        from modelopt.torch.speculative.plugins.modeling_dflash import DFlashGemma4Attention
+
+        attn = DFlashGemma4Attention(self._gemma4_config(), layer_idx=1)
+        assert attn.head_dim == 16
+        assert attn.scaling == 1.0
+
+    def test_non_gemma4_draft_keeps_head_dim_scale(self):
+        """The fix is Gemma 4 specific: Qwen3-style drafts still scale by 1/sqrt(d)."""
+        attn = DFlashAttention(self._gemma4_config(), layer_idx=0)
+        assert attn.scaling == pytest.approx(16**-0.5)
+
+
 class TestDFlashSwaMask:
     """Test all-layer non-causal sliding-window attention mask (MiMo-style)."""
 

--- a/tools/launcher/common/eagle3/train_eagle_streaming.sh
+++ b/tools/launcher/common/eagle3/train_eagle_streaming.sh
@@ -135,9 +135,17 @@ import json, sys
 ids = json.loads(sys.argv[1])
 if len(ids) < 2:
     raise SystemExit("EAGLE_CAPTURE_IDS needs at least one aux id plus the final KD id")
-print(json.dumps(ids[:-1]))' "$EAGLE_CAPTURE_IDS")" || {
+# Drop the KD target, then convert capture ids -> DFlash ids by subtracting 1. vLLM
+# reads EAGLE_CAPTURE_IDS verbatim (eagle_aux_hidden_state_layer_ids, the highest-
+# priority branch) but adds 1 to target_layer_ids, and both are matched against
+# ``layer_idx + 1``. So capture id N and target_layer_id N-1 name the same layer;
+# forwarding the capture ids unconverted would shift serving one layer deeper.
+aux = [i - 1 for i in ids[:-1]]
+if min(aux) < 0:
+    raise SystemExit("EAGLE_CAPTURE_IDS are 1-based; id 0 has no DFlash equivalent")
+print(json.dumps(aux))' "$EAGLE_CAPTURE_IDS")" || {
     echo "ERROR: could not parse EAGLE_CAPTURE_IDS=$EAGLE_CAPTURE_IDS" >&2; exit 1; }
-echo "Trainer aux layer ids (capture ids minus KD target): $AUX_IDS_JSON"
+echo "Trainer aux layer ids (capture ids minus KD target, minus 1): $AUX_IDS_JSON"
 
 # Forwarded verbatim to the trainer; capture before the helpers below run.
 SCRIPT_ARGS=("$@")

--- a/tools/launcher/common/eagle3/train_eagle_streaming.sh
+++ b/tools/launcher/common/eagle3/train_eagle_streaming.sh
@@ -122,6 +122,23 @@ if [ -z "$EAGLE_CAPTURE_IDS" ]; then
     echo "ERROR: EAGLE_CAPTURE_IDS must be set (e.g. '[2, 18, 33, 36]' for Qwen3-8B)." >&2; exit 1
 fi
 
+# EAGLE_CAPTURE_IDS is "<aux ids...> <final id>": the trailing entry is the KD target
+# (hf_streaming_dataset slices it off as base_model_hidden_states) and the rest become the
+# draft's fc input. The trainer consumes aux_hidden_states verbatim and cannot tell which
+# layers produced them, so hand it the same list that configures the producer. Without
+# this, build_target_layer_ids() invents a uniformly-spaced list, it is written to the
+# exported config, and vLLM reads it to choose SERVING capture layers -- so the draft is
+# served on layers it never trained on. It fails silently because the invented list has
+# the same LENGTH and only fc's input width is validated.
+AUX_IDS_JSON="$(python3 -c '
+import json, sys
+ids = json.loads(sys.argv[1])
+if len(ids) < 2:
+    raise SystemExit("EAGLE_CAPTURE_IDS needs at least one aux id plus the final KD id")
+print(json.dumps(ids[:-1]))' "$EAGLE_CAPTURE_IDS")" || {
+    echo "ERROR: could not parse EAGLE_CAPTURE_IDS=$EAGLE_CAPTURE_IDS" >&2; exit 1; }
+echo "Trainer aux layer ids (capture ids minus KD target): $AUX_IDS_JSON"
+
 # Forwarded verbatim to the trainer; capture before the helpers below run.
 SCRIPT_ARGS=("$@")
 
@@ -237,6 +254,7 @@ run_trainer_and_export() {
         "${mn_args[@]}" \
         data.streaming_server_url="$url" \
         data.streaming_model_name="$HF_MODEL_CKPT" \
+        dflash.dflash_aux_layer_ids="$AUX_IDS_JSON" \
         training.dataloader_num_workers="${STREAMING_NUM_WORKERS:-4}" \
         || { echo "ERROR: trainer failed." >&2; return 1; }
 

--- a/tools/launcher/common/eagle3/train_eagle_streaming.sh
+++ b/tools/launcher/common/eagle3/train_eagle_streaming.sh
@@ -92,7 +92,21 @@ dependencies = [
 include = ["modelopt*", "modelopt_recipes*"]
 EOF
 fi
+# All nodes of the allocation run this against the SAME shared lustre checkout, and
+# `pip install -e` writes build state into it (nvidia_modelopt.egg-info/). Concurrent
+# installs clobber each other: one node reports "Successfully installed nvidia-modelopt"
+# while another silently ends up without the .dist-info, and every rank on that node then
+# dies at import with "PackageNotFoundError: No package metadata was found for
+# nvidia-modelopt" -- ~5 min in, after vllm serve has already been paid for. Stagger by
+# node id, then verify and retry, since staggering alone only narrows the window.
+sleep $(( ${SLURM_NODEID:-0} * 15 ))
 pip install --no-cache-dir -e modules/Model-Optimizer/
+if ! python3 -c 'from importlib.metadata import version; version("nvidia-modelopt")' 2>/dev/null; then
+    echo "nvidia-modelopt metadata missing after install (concurrent-install race); retrying..." >&2
+    sleep $(( 10 + ${SLURM_NODEID:-0} * 5 ))
+    pip install --no-cache-dir --force-reinstall --no-deps -e modules/Model-Optimizer/
+    python3 -c 'from importlib.metadata import version; print("nvidia-modelopt", version("nvidia-modelopt"))'
+fi
 pip install --no-cache-dir -r modules/Model-Optimizer/examples/speculative_decoding/requirements.txt
 pip install --no-cache-dir 'datasets' 'huggingface-hub>=1.2.1'
 export PATH=$PATH:/workspace/.local/bin

--- a/tools/launcher/examples/google/gemma-4-E4B-it/chat_template_train.jinja
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/chat_template_train.jinja
@@ -1,0 +1,390 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {%- if role == 'model' -%}
+                {%- generation -%}{{- captured_content -}}{%- endgeneration -%}
+            {%- else -%}
+                {{- captured_content -}}
+            {%- endif -%}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_full.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_full.yaml
@@ -1,0 +1,96 @@
+# DSpark FULL training run for Gemma-4-E4B-it on AWS-PDX.
+#
+# First real training run (the earlier 20-step smoke was a pipeline test only).
+# Corpus: 1,130,852 synthesized rows from ~/lustre/g4_corpus_train.
+#
+# TOPOLOGY: 4 nodes on the interactive QOS (its hard cap), split 2 serve + 2
+# trainer. The launcher does NOT support "own serve on every node" -- for
+# nodes >= 2 it splits WHOLE nodes (see train_eagle_streaming.sh header), so
+# 2:2 is what yields a clean global batch of 64:
+#
+#   2 trainer nodes x 8 GPU        = 16 DP ranks
+#   per_device_train_batch_size 4  x grad_accum 1
+#   -> global batch = 16 * 4 * 1   = 64
+#
+#   2 epochs: 1,130,852 * 2 / 64   ~= 35,340 steps
+#
+# CORPUS: must be the CLEANED copy (g4_corpus_train). The raw synthesis output
+# carries a user-only `messages` column, and hf_streaming_dataset prefers
+# `messages` over `conversations` -- that yields an all-zero loss mask under
+# answer_only_loss, every row is rejected, and streaming SILENTLY HANGS with no
+# error. Verified 200/200 raw rows were user-only; the cleaned copy has 0.
+#
+# Gemma-4-E4B specifics (verified on PDX 2026-08-12, unchanged):
+#  * EAGLE_CAPTURE_IDS: vLLM captures POST-layer with the residual added and
+#    indexes as layer_idx+1, so valid ids are 1..42 and 42 is the TRUE final
+#    layer. Gemma 4 repeats 5x sliding + 1x full attention, so full-attention
+#    layers sit at ids [6,12,18,24,30,36,42]; we sample 6 of those (must be
+#    num_draft_layers + 1 = 6) to land on residual-stream boundaries.
+#  * No --trust-remote-code needed and no vLLM patch; gemma4 is native in the
+#    2026-08-11 nightly.
+
+job_name: Gemma-4-E4B_DSpark_full_2ep
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/gemma-4-E4B-it
+
+  task_0:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - data.mode=streaming
+      # Gemma 4's stock chat template has NO generation markers, so
+      # answer_only_loss silently yields an all-zero loss_mask and every row is
+      # rejected. This copy adds them; see the template file header.
+      - data.chat_template=examples/google/gemma-4-E4B-it/chat_template_train.jinja
+      - data.data_path=/traindata
+      - training.output_dir=/scratchspace/dspark_full_2ep
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=0
+      - training.num_train_epochs=2
+      - training.per_device_train_batch_size=4
+      - training.gradient_accumulation_steps=1
+      - training.learning_rate=1.0e-4
+      - training.warmup_steps=500
+      - training.logging_steps=20
+      - training.save_steps=1000
+      # All checkpoints are kept (user's call): HF save_total_limit defaults to
+      # None, which retains every one, so no override is needed.
+      - training.answer_only_loss=true
+      - training.report_to=none
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # MUST be exactly num_draft_layers + 1 (5 draft layers -> 6 ids).
+      - EAGLE_CAPTURE_IDS: "[6,12,18,24,36,42]"
+      # 2 serve nodes + 2 trainer nodes (of the 4 allocated).
+      - SERVE_NODES: "2"
+      - SERVE_GPU_MEM_UTIL: "0.9"
+      - SERVE_MAX_MODEL_LEN: "4352"
+      - SERVE_MAX_NUM_SEQS: "64"
+      - SERVE_READY_TIMEOUT: "2400"
+      - STREAMING_NUM_WORKERS: "4"
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # NIXL hidden-state transport. Without these NIXL falls back to UCX, which
+      # reports "UCX CUDA support was not found" and dies with
+      # NIXL_ERR_REMOTE_DISCONNECT the moment the trainer pulls hidden states.
+      - NIXL_BACKENDS: LIBFABRIC
+      - FI_PROVIDER: efa
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 4
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      # The auxfix image carries the AWS libfabric stack that NIXL needs; the
+      # nem35 image has no libfabric and no NIXL plugins.
+      container: /home/haoguo/lustre/containers/vllm-nightly-efa-x86_64-auxfix.sqsh
+      container_mounts:
+        - /home/haoguo/lustre/hf-local:/hf-local
+        - /home/haoguo/lustre/g4_corpus_train:/traindata

--- a/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_lr2e3_5ep_scale1_fp32m_3n.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_lr2e3_5ep_scale1_fp32m_3n.yaml
@@ -1,0 +1,173 @@
+# Gemma-4-E4B DSpark, lr 2e-3 / theta 1e6, attn scale 1.0, 5 epochs -- FP32 MASTER
+# WEIGHTS rerun. Identical to hf_streaming_dspark_lr2e3_5ep_scale1_3n.yaml except for
+# dflash_fp32_master_weights and the dtype diagnostic below.
+#
+# Why. With scaling = 1.0 the draft has to LEARN the 1/sqrt(512) that the old arm got
+# as a free constant, and RMSNorm normalises away any scale in its input, so q_proj
+# cannot supply it -- only q_norm.weight can. That weight starts at exactly 1.0, where
+# bf16 spacing is 0.0039 and a step must clear 0.00195 to round anywhere. The recipe's
+# linear decay from 2e-3 puts the MAXIMUM Adam step below that at step ~2,559, so for
+# 97% of the run the parameter cannot move at all. Confirmed on the previous run's
+# checkpoint: weights BF16, Adam exp_avg and exp_avg_sq BF16, no master copy anywhere;
+# 78% of q_norm/k_norm still exactly 1.0 at step 56,000.
+#
+# fp32 spacing at 1.0 is 6e-8, so the barrier disappears. This also fixes bf16
+# exp_avg_sq, which is a separate accuracy problem affecting every parameter.
+#
+# Expected extra memory: draft is ~2.1B params, so weight+moments go 12.7 -> 25.4 GB
+# per rank against 275 GB of B300. Expected slowdown: small, since no fp32 matmul is
+# introduced -- if the step time moves much past 0.6 s something else is wrong.
+#
+# Gemma-4-E4B DSpark, lr 2e-3 / theta 1e6, 5 epochs from step 0 -- the SCALE-1 rerun.
+#
+# Byte-for-byte the same training configuration as the previous 5-epoch run
+# (experiment cicd_1787983450, whose curve reached AL 3.1176 at step 56,000). The only
+# ALGORITHMIC difference is in the code: DFlashGemma4Attention now attends at
+# scaling = 1.0 instead of global_head_dim**-0.5.
+#
+# Why. Gemma 4 puts no 1/sqrt(head_dim) in attention -- HF's Gemma4TextAttention sets
+# scaling = 1.0 and there is no query_pre_attn_scalar -- and vLLM follows the reference,
+# so the old draft was trained under a scale no serving stack applies. Measured on
+# checkpoint-56000 of the previous run, real vLLM, 80q MT-Bench, num_spec 7:
+#
+#     served at        128 tok   1024 tok
+#     1.0 (stock)      2.7981    2.7685
+#     512**-0.5        3.1577    3.1363     -> +12.9% / +13.3%
+#
+# So the previous run's drafter is legacy: it needs a patched vLLM to reach its own
+# numbers. This run should land near 3.16 on STOCK vLLM instead. Its harness numbers
+# will NOT be comparable to the old curve's -- the harness was told to use the training
+# scale, and the training scale changed -- so compare vLLM AL to vLLM AL.
+#
+# CODE: worktree g4-run2, detached at 753aa6fd3
+#   = haoguo/dflash-training-perf @ a1e5ae6ad  (PR #2279, newest perf work)
+#   + 52da250c42 cherry-picked   (PR #2186, the scaling fix)
+# The perf branch already contains PR #2186 through 0a9c92538b, so the cherry-pick was
+# the only graft needed and it applied clean.
+#
+# New in the perf head since the last run (a1e5ae6ad): dflash_use_torch_compile now
+# wraps DFlashModule's body, not just the DSpark TVD chunk, and the recipe's
+# ddp_find_unused_parameters flipped to false. Author measured 0.5497 -> 0.4927 s/step
+# on 3 nodes, at the cost of ~28 s more one-time compile. Expected wall for 88,350
+# steps: ~12.1 h of compute.
+#
+# TOPOLOGY: 3 nodes = 1 serve + 2 trainer. The launcher splits WHOLE nodes, so:
+#   2 trainer nodes x 8 GPU        = 16 DP ranks
+#   per_device_train_batch_size 4  x grad_accum 1
+#   -> global batch = 16 * 4 * 1   = 64
+#   corpus 1,130,852 rows / 64     ~= 17,670 steps per epoch, 88,350 for 5
+#
+# CORPUS: must be the CLEANED copy (g4_corpus_train). The raw synthesis output carries
+# a user-only `messages` column, and hf_streaming_dataset prefers `messages` over
+# `conversations` -- that yields an all-zero loss mask under answer_only_loss, every row
+# is rejected, and streaming SILENTLY HANGS with no error.
+#
+# Gemma-4-E4B specifics (verified on PDX 2026-08-12, unchanged):
+#  * EAGLE_CAPTURE_IDS: vLLM captures POST-layer with the residual added and indexes as
+#    layer_idx+1, so valid ids are 1..42 and 42 is the TRUE final layer. Gemma 4 repeats
+#    5x sliding + 1x full attention, so full-attention layers sit at ids
+#    [6,12,18,24,30,36,42]; we sample 6 (must be num_draft_layers + 1) to land on
+#    residual-stream boundaries.
+#  * No --trust-remote-code and no vLLM patch; gemma4 is native in the 2026-08-11 nightly.
+#
+# save_steps 2000, not 1000: each checkpoint is 6.9 GB, so 1000 would write 607 GB and
+# spend roughly 5% of the run in checkpoint I/O. 2000 still yields 44 curve points.
+
+job_name: Gemma-4-E4B_DSpark_lr2e3_5ep_scale1_fp32m_3n
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/gemma-4-E4B-it
+
+  task_0:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - data.mode=streaming
+      # Gemma 4's stock chat template has NO generation markers, so answer_only_loss
+      # silently yields an all-zero loss_mask and every row is rejected. This copy adds
+      # them; see the template file header.
+      - data.chat_template=examples/google/gemma-4-E4B-it/chat_template_train.jinja
+      - data.data_path=/traindata
+      - training.output_dir=/scratchspace/dspark_lr2e3_5ep_scale1_fp32m_3n
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=0
+      - training.num_train_epochs=5
+      - training.per_device_train_batch_size=4
+      - training.gradient_accumulation_steps=1
+      - training.learning_rate=2.0e-3
+      - dflash.dflash_use_flex_attention=true
+      # Now compiles the whole DFlashModule body, not just the TVD chunk (a1e5ae6ad).
+      - dflash.dflash_use_torch_compile=true
+      # Keep the draft's parameters and Adam moments in fp32 under bf16 autocast.
+      # Matmuls still run bf16 on tensor cores; this costs memory (12 B/param instead
+      # of 6), not speed. Without it a bf16 weight initialised at exactly 1.0 is frozen
+      # after ~step 2,600 -- the downward ULP there is 0.0039, an update must clear
+      # 0.00195, and the max Adam step is the LR, which the linear decay drops below
+      # that. Measured on the previous run: 78% of q_norm/k_norm entries were still
+      # EXACTLY 1.0 at step 56,000, and the furthest any had moved was 34 of the 245
+      # ULPs needed to reach head_dim**-0.5.
+      - dflash.dflash_fp32_master_weights=true
+      # Plain default rope at theta 1e6 -- all 256 freq pairs rotated. Set here rather
+      # than in the shared recipe so the other arms keep the recipe's theta 1e4.
+      - dflash.dflash_architecture_config.rope_override_rope_theta=1000000.0
+      - dflash.dflash_architecture_config.rope_override_rope_type=default
+      - training.warmup_steps=500
+      - training.logging_steps=20
+      - training.save_steps=2000
+      # All checkpoints are kept (user's call): HF save_total_limit defaults to None.
+      - training.answer_only_loss=true
+      - training.report_to=none
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # MUST be exactly num_draft_layers + 1 (5 draft layers -> 6 ids).
+      - EAGLE_CAPTURE_IDS: "[6,12,18,24,36,42]"
+      - SERVE_NODES: "1"
+      - SERVE_GPU_MEM_UTIL: "0.9"
+      - SERVE_MAX_MODEL_LEN: "4352"
+      - SERVE_MAX_NUM_SEQS: "256"
+      - SERVE_READY_TIMEOUT: "2400"
+      - STREAMING_NUM_WORKERS: "4"
+      # Kept on purpose: a1e5ae6ad puts a NEW dynamic=False compiled region around the
+      # draft stack, so this run has a compile surface the previous one did not. If the
+      # recompile counter climbs past its initial plateau, that is the first symptom.
+      # Prints every parameter dtype once at startup. On purpose: the whole point of
+      # this run is a dtype change, and a silent no-op would look like "fp32 masters do
+      # not help" rather than "fp32 masters were never applied".
+      - DFLASH_LOG_PARAM_DTYPES: "1"
+      - TORCH_LOGS: recompiles
+      # FlexAttention pulls in torch.compile, and Triton's default cache lands on a
+      # shared filesystem where 8 ranks per node race each other: an early run died with
+      # OSError [Errno 116] Stale file handle while reading back a just-compiled kernel.
+      # /tmp is node-local ext4 and allows exec (/dev/shm is EXEC_BLOCKED), so Triton's
+      # rename protocol is atomic again.
+      - TRITON_CACHE_DIR: /tmp/g4_triton_cache
+      - TORCHINDUCTOR_CACHE_DIR: /tmp/g4_inductor_cache
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # NIXL hidden-state transport. Without these NIXL falls back to UCX, which reports
+      # "UCX CUDA support was not found" and dies with NIXL_ERR_REMOTE_DISCONNECT the
+      # moment the trainer pulls hidden states.
+      - NIXL_BACKENDS: LIBFABRIC
+      - FI_PROVIDER: efa
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 3
+      # WITHOUT THIS the launcher requests its 4h default and Slurm kills the run
+      # mid-epoch with State=TIMEOUT and no traceback.
+      # QUOTES ARE LOAD-BEARING: unquoted 72:00:00 is YAML sexagesimal and parses as an
+      # int that sbatch reads as MINUTES.
+      time: "72:00:00"
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      # The auxfix image carries the AWS libfabric stack that NIXL needs.
+      container: /home/haoguo/lustre/containers/vllm-nightly-efa-x86_64-auxfix.sqsh
+      container_mounts:
+        - /home/haoguo/lustre/hf-local:/hf-local
+        - /home/haoguo/lustre/g4_corpus_train:/traindata

--- a/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_proprope_3n.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_proprope_3n.yaml
@@ -1,0 +1,120 @@
+# DSpark FULL training run for Gemma-4-E4B-it on AWS-PDX -- PROPORTIONAL ROPE.
+#
+# Third arm of the draft-RoPE A/B. The first two both used plain "default" rope
+# over the whole 512-wide draft head_dim and differed only in theta:
+#
+#   baseline  theta 1e4  (base sliding_attention entry)  AL 1.5195/1.6645/1.7531
+#   rope1e6   theta 1e6  (base full_attention theta)     AL 1.4799/1.6242/1.6916
+#
+# i.e. raising theta alone was consistently 2.4-3.5% WORSE, which said nothing
+# about the base's actual scheme: the draft's 5 layers are all full_attention,
+# and the base's full_attention layers do NOT use default rope. They use
+# rope_type "proportional" with partial_rotary_factor 0.25, which rotates only
+# the first quarter of the head dim and leaves the rest as NoPE (inv_freq == 0).
+#
+# This run is the first that actually matches that scheme. Nothing is set here
+# to get it: modeling_fakebase._resolve_rope_parameters() now forwards the base's
+# NESTED per-attention-kind rope_parameters, hf_dflash.modify() hands the kinds
+# the draft uses to the draft config, and DFlashModule._build_gemma4_rope_kinds()
+# builds one rotary module per kind. Verified on the draft config actually built
+# from this recipe (PDX job 302751):
+#
+#   draft rope_parameters: {'full_attention': {'partial_rotary_factor': 0.25,
+#                            'rope_theta': 1e6, 'rope_type': 'proportional'}}
+#   rotary_emb_by_kind: full_attention rope_type=proportional
+#                       inv_freq len=256 nonzero=64 zeros=192
+#
+# The 64/192 split is the point: 64 rotated pairs (128 of 512 dims) at theta 1e6
+# and 192 NoPE pairs, versus 256 rotated pairs in BOTH earlier runs.
+#
+# TOPOLOGY: 4 nodes on the interactive QOS (its hard cap), split 2 serve + 2
+# trainer. The launcher does NOT support "own serve on every node" -- for
+# nodes >= 2 it splits WHOLE nodes (see train_eagle_streaming.sh header), so
+# 2:2 is what yields a clean global batch of 64:
+#
+#   2 trainer nodes x 8 GPU        = 16 DP ranks
+#   per_device_train_batch_size 4  x grad_accum 1
+#   -> global batch = 16 * 4 * 1   = 64
+#
+#   2 epochs: 1,130,852 * 2 / 64   ~= 35,340 steps
+#
+# CORPUS: must be the CLEANED copy (g4_corpus_train). The raw synthesis output
+# carries a user-only `messages` column, and hf_streaming_dataset prefers
+# `messages` over `conversations` -- that yields an all-zero loss mask under
+# answer_only_loss, every row is rejected, and streaming SILENTLY HANGS with no
+# error. Verified 200/200 raw rows were user-only; the cleaned copy has 0.
+#
+# Gemma-4-E4B specifics (verified on PDX 2026-08-12, unchanged):
+#  * EAGLE_CAPTURE_IDS: vLLM captures POST-layer with the residual added and
+#    indexes as layer_idx+1, so valid ids are 1..42 and 42 is the TRUE final
+#    layer. Gemma 4 repeats 5x sliding + 1x full attention, so full-attention
+#    layers sit at ids [6,12,18,24,30,36,42]; we sample 6 of those (must be
+#    num_draft_layers + 1 = 6) to land on residual-stream boundaries.
+#  * No --trust-remote-code needed and no vLLM patch; gemma4 is native in the
+#    2026-08-11 nightly.
+
+job_name: Gemma-4-E4B_DSpark_proprope_3n
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/gemma-4-E4B-it
+
+  task_0:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - data.mode=streaming
+      # Gemma 4's stock chat template has NO generation markers, so
+      # answer_only_loss silently yields an all-zero loss_mask and every row is
+      # rejected. This copy adds them; see the template file header.
+      - data.chat_template=examples/google/gemma-4-E4B-it/chat_template_train.jinja
+      - data.data_path=/traindata
+      - training.output_dir=/scratchspace/dspark_proprope_3n
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=0
+      - training.num_train_epochs=2
+      - training.per_device_train_batch_size=4
+      - training.gradient_accumulation_steps=1
+      - training.learning_rate=1.0e-4
+      - training.warmup_steps=500
+      - training.logging_steps=20
+      - training.save_steps=1000
+      # All checkpoints are kept (user's call): HF save_total_limit defaults to
+      # None, which retains every one, so no override is needed.
+      - training.answer_only_loss=true
+      - training.report_to=none
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # MUST be exactly num_draft_layers + 1 (5 draft layers -> 6 ids).
+      - EAGLE_CAPTURE_IDS: "[6,12,18,24,36,42]"
+      # 2 serve nodes + 2 trainer nodes (of the 4 allocated).
+      - SERVE_NODES: "1"
+      - SERVE_GPU_MEM_UTIL: "0.9"
+      - SERVE_MAX_MODEL_LEN: "4352"
+      - SERVE_MAX_NUM_SEQS: "256"
+      - SERVE_READY_TIMEOUT: "2400"
+      - STREAMING_NUM_WORKERS: "4"
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # NIXL hidden-state transport. Without these NIXL falls back to UCX, which
+      # reports "UCX CUDA support was not found" and dies with
+      # NIXL_ERR_REMOTE_DISCONNECT the moment the trainer pulls hidden states.
+      - NIXL_BACKENDS: LIBFABRIC
+      - FI_PROVIDER: efa
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 3
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      # The auxfix image carries the AWS libfabric stack that NIXL needs; the
+      # nem35 image has no libfabric and no NIXL plugins.
+      container: /home/haoguo/lustre/containers/vllm-nightly-efa-x86_64-auxfix.sqsh
+      container_mounts:
+        - /home/haoguo/lustre/hf-local:/hf-local
+        - /home/haoguo/lustre/g4_corpus_train:/traindata

--- a/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_smoke.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_smoke.yaml
@@ -1,0 +1,98 @@
+# DSpark streaming SMOKE run (co-located single node) for Gemma-4-E4B-it on AWS-PDX.
+#
+# Purpose: prove the streaming chain end-to-end (vLLM serve -> aux hidden-state
+# capture -> NIXL transfer -> fake-base trainer) for a NEW base model. Only ~20
+# steps on a 1024-row corpus; the numbers are meaningless, the point is that the
+# pipeline runs and the loss is finite and decreasing.
+#
+# Topology: serve TP=1 on GPU 0 (E4B is 16 GB, fits one B300), DSpark trainer on
+# GPUs 4-7. Intra-node NIXL, no cross-node EFA.
+#
+# Gemma-4-E4B specifics verified on PDX 2026-08-12:
+#  * EAGLE_CAPTURE_IDS: vLLM's EagleModelMixin captures POST-layer with the
+#    residual added and indexes as layer_idx+1, so valid ids are 1..42 and 42 is
+#    the TRUE final layer (verified cos=1.0000 against HF hidden_states, with
+#    off-by-one dropping to 0.55-0.98). Gemma 4 repeats 5x sliding + 1x full
+#    attention, so full-attention layers sit at capture ids
+#    [6,12,18,24,30,36,42]; we sample those to land on residual-stream
+#    boundaries instead of spacing uniformly (deep layers are near-redundant:
+#    adjacent cosine ~0.98-0.99 around id 36 vs 0.55-0.70 around id 9).
+#  * NO --trust-remote-code needed (the repo ships no .py) and no vLLM patch:
+#    gemma4 is natively supported in the 2026-08-11 nightly container.
+#  * Corpus has its user-only `messages` column DROPPED — hf_streaming_dataset
+#    prefers `messages` over `conversations` and a user-only one makes streaming
+#    SILENTLY HANG.
+
+job_name: Gemma-4-E4B_DSpark_streaming_smoke
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/gemma-4-E4B-it
+
+  task_0:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - data.mode=streaming
+      # Gemma 4's stock chat template has NO generation markers, so
+      # answer_only_loss silently yields an all-zero loss_mask and EVERY row is
+      # rejected ("no fetchable sample found in the entire corpus"). This copy
+      # adds them; see the template file header for details.
+      - data.chat_template=examples/google/gemma-4-E4B-it/chat_template_train.jinja
+      - data.data_path=/smokedata
+      - training.output_dir=/scratchspace/dspark_smoke
+      - training.training_seq_len=2048
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - training.max_steps=20
+      - training.logging_steps=1
+      - training.save_steps=20
+      - training.per_device_train_batch_size=1
+      - training.answer_only_loss=true
+      - training.report_to=none
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # MUST be exactly num_draft_layers + 1 entries (5 draft layers -> 6 ids):
+      # the projector is sized from the DRAFT's num_hidden_layers, so 7 ids gave
+      # "mat1 and mat2 shapes cannot be multiplied (2048x15360 and 12800x2560)".
+      # Confirmed against the working runs: K2.6 6 layers -> 7 ids, gpt-oss 5 -> 6.
+      # Chosen from the full-attention layers of the 5:1 sliding/full cycle
+      # ([6,12,18,24,30,36,42]), dropping 30 to keep both ends and the true final 42.
+      - EAGLE_CAPTURE_IDS: "[6,12,18,24,36,42]"
+      - SERVE_GPU: "0"
+      - SERVE_TP: "1"
+      - SERVE_GPU_MEM_UTIL: "0.85"
+      - STREAMING_NUM_WORKERS: "1"
+      - SERVE_MAX_MODEL_LEN: "2176"
+      - SERVE_MAX_NUM_SEQS: "4"
+      - SERVE_READY_TIMEOUT: "2400"
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # NIXL hidden-state transport. Without these, NIXL falls back to the UCX
+      # backend, which reports "8 NVIDIA GPU(s) were detected, but UCX CUDA
+      # support was not found" and then dies with NIXL_ERR_REMOTE_DISCONNECT the
+      # moment the trainer tries to pull hidden states. LIBFABRIC+efa is what the
+      # working Kimi-K2.6 streaming runs use.
+      - NIXL_BACKENDS: LIBFABRIC
+      - FI_PROVIDER: efa
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      # The 2026-08-11 nem35 image has NO libfabric and no NIXL plugins, so
+      # NIXL_BACKENDS=LIBFABRIC dies with NIXL_ERR_NOT_FOUND and the UCX fallback
+      # dies with NIXL_ERR_REMOTE_DISCONNECT ("UCX CUDA support was not found").
+      # The auxfix image carries the AWS libfabric stack and is what the working
+      # Kimi-K2.6 streaming runs use. Its vLLM is older (transformers 5.12.1) --
+      # gemma4 support must be re-verified in THIS image.
+      container: /home/haoguo/lustre/containers/vllm-nightly-efa-x86_64-auxfix.sqsh
+      container_mounts:
+        - /home/haoguo/lustre/hf-local:/hf-local
+        - /home/haoguo/lustre/g4_smoke_corpus:/smokedata

--- a/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_smoke_swa.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_smoke_swa.yaml
@@ -1,0 +1,111 @@
+# DSpark streaming SMOKE run (co-located single node) for Gemma-4-E4B-it on
+# AWS-PDX -- SLIDING-WINDOW (SWA) VARIANT.
+#
+# Derived from hf_streaming_dspark_smoke.yaml; the only deltas are the recipe
+# (dspark_gemma4_e4b_swa.yaml, which sets dflash_swa_window_size: 512) and the
+# output dir. Keep the two in sync.
+#
+# TRAINING ONLY. The resulting checkpoint is NOT servable as-is: vLLM's
+# Gemma4DSparkAttention derives its sliding window from the BASE layer pattern
+# instead of dflash_config.use_swa, so an SWA-trained draft would be served with
+# FULL attention -- silently, showing up only as depressed acceptance. See
+# examples/speculative_decoding/export/gemma4_dspark_swa_vllm.patch. The point of
+# this run is to prove SWA training converges and to produce a checkpoint.
+#
+#
+# Purpose: prove the streaming chain end-to-end (vLLM serve -> aux hidden-state
+# capture -> NIXL transfer -> fake-base trainer) for a NEW base model. Only ~20
+# steps on a 1024-row corpus; the numbers are meaningless, the point is that the
+# pipeline runs and the loss is finite and decreasing.
+#
+# Topology: serve TP=1 on GPU 0 (E4B is 16 GB, fits one B300), DSpark trainer on
+# GPUs 4-7. Intra-node NIXL, no cross-node EFA.
+#
+# Gemma-4-E4B specifics verified on PDX 2026-08-12:
+#  * EAGLE_CAPTURE_IDS: vLLM's EagleModelMixin captures POST-layer with the
+#    residual added and indexes as layer_idx+1, so valid ids are 1..42 and 42 is
+#    the TRUE final layer (verified cos=1.0000 against HF hidden_states, with
+#    off-by-one dropping to 0.55-0.98). Gemma 4 repeats 5x sliding + 1x full
+#    attention, so full-attention layers sit at capture ids
+#    [6,12,18,24,30,36,42]; we sample those to land on residual-stream
+#    boundaries instead of spacing uniformly (deep layers are near-redundant:
+#    adjacent cosine ~0.98-0.99 around id 36 vs 0.55-0.70 around id 9).
+#  * NO --trust-remote-code needed (the repo ships no .py) and no vLLM patch:
+#    gemma4 is natively supported in the 2026-08-11 nightly container.
+#  * Corpus has its user-only `messages` column DROPPED — hf_streaming_dataset
+#    prefers `messages` over `conversations` and a user-only one makes streaming
+#    SILENTLY HANG.
+
+job_name: Gemma-4-E4B_DSpark_streaming_smoke_swa
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/gemma-4-E4B-it
+
+  task_0:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b_swa.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - data.mode=streaming
+      # Gemma 4's stock chat template has NO generation markers, so
+      # answer_only_loss silently yields an all-zero loss_mask and EVERY row is
+      # rejected ("no fetchable sample found in the entire corpus"). This copy
+      # adds them; see the template file header for details.
+      - data.chat_template=examples/google/gemma-4-E4B-it/chat_template_train.jinja
+      - data.data_path=/smokedata
+      - training.output_dir=/scratchspace/dspark_smoke_swa
+      - training.training_seq_len=2048
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - training.max_steps=20
+      - training.logging_steps=1
+      - training.save_steps=20
+      - training.per_device_train_batch_size=1
+      - training.answer_only_loss=true
+      - training.report_to=none
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # MUST be exactly num_draft_layers + 1 entries (5 draft layers -> 6 ids):
+      # the projector is sized from the DRAFT's num_hidden_layers, so 7 ids gave
+      # "mat1 and mat2 shapes cannot be multiplied (2048x15360 and 12800x2560)".
+      # Confirmed against the working runs: K2.6 6 layers -> 7 ids, gpt-oss 5 -> 6.
+      # Chosen from the full-attention layers of the 5:1 sliding/full cycle
+      # ([6,12,18,24,30,36,42]), dropping 30 to keep both ends and the true final 42.
+      - EAGLE_CAPTURE_IDS: "[6,12,18,24,36,42]"
+      - SERVE_GPU: "0"
+      - SERVE_TP: "1"
+      - SERVE_GPU_MEM_UTIL: "0.85"
+      - STREAMING_NUM_WORKERS: "1"
+      - SERVE_MAX_MODEL_LEN: "2176"
+      - SERVE_MAX_NUM_SEQS: "4"
+      - SERVE_READY_TIMEOUT: "2400"
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # NIXL hidden-state transport. Without these, NIXL falls back to the UCX
+      # backend, which reports "8 NVIDIA GPU(s) were detected, but UCX CUDA
+      # support was not found" and then dies with NIXL_ERR_REMOTE_DISCONNECT the
+      # moment the trainer tries to pull hidden states. LIBFABRIC+efa is what the
+      # working Kimi-K2.6 streaming runs use.
+      - NIXL_BACKENDS: LIBFABRIC
+      - FI_PROVIDER: efa
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      # The 2026-08-11 nem35 image has NO libfabric and no NIXL plugins, so
+      # NIXL_BACKENDS=LIBFABRIC dies with NIXL_ERR_NOT_FOUND and the UCX fallback
+      # dies with NIXL_ERR_REMOTE_DISCONNECT ("UCX CUDA support was not found").
+      # The auxfix image carries the AWS libfabric stack and is what the working
+      # Kimi-K2.6 streaming runs use. Its vLLM is older (transformers 5.12.1) --
+      # gemma4 support must be re-verified in THIS image.
+      container: /home/haoguo/lustre/containers/vllm-nightly-efa-x86_64-auxfix.sqsh
+      container_mounts:
+        - /home/haoguo/lustre/hf-local:/hf-local
+        - /home/haoguo/lustre/g4_smoke_corpus:/smokedata


### PR DESCRIPTION
## What

Adds support for **Gemma-4-E4B** as a streaming DFlash/DSpark target, plus two fake-base fixes that this model exposed. Both fixes are general — they are not Gemma-specific workarounds.

Validated end-to-end on AWS-PDX: a 20-step DSpark streaming smoke run, loss **3.79 → 3.28** monotonically, drafter exported (62 tensors).

## Why

Gemma 4 tripped three silent failures. Each one either corrupts the distillation target without raising anything, or rejects the entire corpus.

### 1. `modeling_final_norm`: whitelist `gemma4_text` / `gemma4`

Gemma 4 is a VLM that nests the LLM under `text_config` with `model_type: "gemma4_text"`. `from_source` reads the nested config, so a `"gemma4"` key alone would never match. Without an entry the fake base builds **no final norm**, and streaming teacher logits get reconstructed from an un-normed hidden — a silent distillation-target corruption (same failure mode as the earlier Kimi VLM case).

The in-file comment warns that Gemma uses a `(1 + weight)` RMSNorm, which would suggest `gemma_rmsnorm`. **That holds for Gemma 2/3 but not Gemma 4.** Verified numerically on `gemma-4-E4B-it` by reconstructing HF's `hidden_states[-1]` from the pre-norm residual:

| formula | cos vs HF | maxabs err |
|---|---|---|
| `normed * weight` (existing `_FinalRMSNorm`) | **0.999999** | 0.082 |
| `normed * (1 + weight)` (Gemma 2/3) | 0.971875 | 47.6 |

So plain `"rmsnorm"` is correct here and `"gemma_rmsnorm"` would be wrong. No new norm class is needed.

> Note: this model's final-norm weights are unusual (mean 7.88, range [-0.29, 14.0]), so the "weights near 1.0 vs near 0.0" heuristic does **not** identify the formula — it has to be checked numerically.

### 2. `modeling_fakebase`: resolve RoPE theta from nested `rope_parameters`

Gemma 4 has no flat `rope_theta`. It nests per-attention-kind settings:

```json
"rope_parameters": {
  "full_attention":    {"rope_theta": 1e6, "rope_type": "proportional", "partial_rotary_factor": 0.25},
  "sliding_attention": {"rope_theta": 1e4, "rope_type": "default"}
}
```

The flat `getattr(base_cfg, "rope_theta", None)` returns `None`, so the draft silently trains on its own class default. Training loss and accuracy still improve while MT-Bench AAL is capped, because RoPE frequencies bake into the trained weights — and the drafter then has to be retrained.

This **could not be worked around from the recipe**: `hf_dflash` enforces `rope_theta` from the base config and overwrites any `dflash_architecture_config` value (with a warning), by design, since the draft injects the target's KV.

`_resolve_rope_theta` defaults to the `sliding_attention` entry, because SWA drafts are the common case for Gemma 4 and its `rope_type` is plain `default` — the `full_attention` entry uses `proportional` rope with `partial_rotary_factor`, which the draft classes do not implement. Models with a flat `rope_theta` are unaffected (covered by regression checks, including the no-rope case).

### 3. `chat_template_train.jinja`: add generation markers

Gemma 4's stock chat template has no `{% generation %}` markers, so `return_assistant_tokens_mask` yields an **all-zero `loss_mask`** under `answer_only_loss`. Every row is then rejected and streaming dies with:

```
EagleVllmStreamingDataset: no fetchable sample found in the entire corpus (1024 entries)
```

Transformers only hints at the cause via a stderr line. This is **not** a sequence-length problem — it reproduces identically at `max_seq_len` 2048 and 4096, and `answer_only_loss=false` gives a full mask.

This copy wraps the model-turn content in generation markers, following the existing per-model `chat_template_train.jinja` convention. Verified:

- rendered text is **byte-identical** to the stock template
- zero-mask rate: **200/200 → 4/200** at `max_seq_len` 2048
- the decoded supervised span is exactly the assistant reply

## Files

| file | purpose |
|---|---|
| `modelopt/torch/speculative/plugins/modeling_final_norm.py` | whitelist `gemma4_text` / `gemma4` |
| `modelopt/torch/speculative/plugins/modeling_fakebase.py` | `_resolve_rope_theta()` for nested `rope_parameters` |
| `modelopt_recipes/general/speculative_decoding/dspark_gemma4_e4b.yaml` | DSpark recipe |
| `tools/launcher/examples/google/gemma-4-E4B-it/chat_template_train.jinja` | template with generation markers |
| `tools/launcher/examples/google/gemma-4-E4B-it/hf_streaming_dspark_smoke.yaml` | single-node co-located streaming smoke |

## Recipe notes

- **mask token**: Gemma 4's vocab is fully packed (no spare/unused ids), but it ships a native `<mask>` at id 4.
- **capture ids** `[6,12,18,24,36,42]`: Gemma 4 repeats 5× sliding + 1× full attention, so the full-attention layers land on exactly these post-layer capture ids. Chosen to sit on residual-stream boundaries rather than spacing uniformly — measured adjacent-layer cosine is 0.55–0.70 in the shallow half but 0.98–0.99 in the deep half, so uniform spacing wastes capture slots on near-duplicates.
- **`len(EAGLE_CAPTURE_IDS)` must equal `num_draft_layers + 1`** — the projector is sized from the *draft's* `num_hidden_layers`, not from the number of capture ids. Getting this wrong gives `mat1 and mat2 shapes cannot be multiplied`.
- **SWA draft** matches the base's 512 window. Worth pairing with a full-attention control run before drawing conclusions about AL.

## Testing

- 20-step DSpark streaming smoke on AWS-PDX (single node, co-located serve TP=1 + 7-GPU trainer): loss 3.79 → 3.28, grad_norm 81 → 27, drafter exported.
- Fake base reconstructs the base teacher distribution from the vLLM-captured pre-norm hidden at cos **0.9877**, with **100%** argmax agreement across all tokens.
- vLLM aux hidden-state capture verified against HF `output_hidden_states`: capture ids 9/18/27/36 match at **cos = 1.0000**, with off-by-one dropping to 0.55–0.98, which also pins capture id 42 as the true final layer.
- Regression: flat-`rope_theta` models and no-rope configs resolve unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemma 4 support for speculative decoding, including attention, normalization, RoPE, and decoder configurations.
  * Added a DSpark training recipe and streaming smoke-test configuration for Gemma-4-E4B-it.
  * Added Gemma 4 chat formatting with tool calls, multimodal content, thinking, and conversation continuation support.
  * Added tooling to convert DSpark drafter exports for vLLM deployment.
  * Preserved Gemma 4 per-layer attention settings during model export for reliable deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update: end-to-end validated on vLLM

Retrained the draft with the Gemma4 block, converted it, and served it under vLLM against the base `gemma-4-E4B-it`. The engine comes up with the drafter attached and speculative decoding runs to completion:

```
=== ENGINE UP WITH DRAFTER ===
GEN: ' France is France is France is ...'
```

(The repetition is expected and not a drafter problem — the probe sends a raw prompt with no chat template, and the base model alone produces the same output. The draft here is a 20-step smoke, so its quality is meaningless; the point was to prove the load/execute path.)

Training: loss 3.736 → 3.243 over 20 steps. Export: 72 tensors whose names and shapes match `deepseek-ai/dspark_gemma4_12b_block7` exactly — `layer_scalar` and both feedforward norms present, no `v_proj`, no `v_norm`. Conversion: 74 tensors after baking in the tied `lm_head` / `embed_tokens`.

### Two further fixes this surfaced

**The exporter dropped the fields describing the draft's attention shapes.** Gemma4 sizes attention per layer, so `head_dim` + `num_key_value_heads` alone are not enough to reconstruct it. Without `global_head_dim` / `num_global_key_value_heads` / `attention_k_eq_v`, vLLM rebuilt the draft with the *sliding*-layer dims and failed with `Attempted to load weight (torch.Size([512])) into parameter (torch.Size([256]))` — even though the trained weights were correct. Fields are now propagated when present, so non-Gemma4 drafts are untouched.

**The converter was masking that bug**, defaulting `global_head_dim` to `head_dim` and `attention_k_eq_v` to `False`. It now fails loudly instead.

### Serving requires an explicit draft attention backend

```
vllm serve <base> --speculative-config '{"model": "<converted>",
  "num_speculative_tokens": 3, "method": "dspark", "attention_backend": "FLASHINFER"}'
```

FLASHINFER is **required**. The draft re-runs backend auto-selection independently of the target and lands on FLASH_ATTN, whose FA2 kernel caps head dimension at 256, while Gemma4 full-attention layers use 512:

```
RuntimeError: FlashAttention forward only supports head dimension at most 256
```

The base model auto-selects FLASHINFER for exactly the same reason, but that choice is not inherited, and `VLLM_ATTENTION_BACKEND` does not reach the draft — it is read from `speculative_config.attention_backend` (`vllm/v1/worker/gpu/spec_decode/dspark/utils.py`). The converter now prints this command on completion.

### Still open

The drafter is a 20-step smoke, so there are no acceptance-length numbers yet. A real training run is the next step.
