### PR TITLE
Run Mypy with ModelOpt dependencies

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,7 +48,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
@@ -71,7 +71,7 @@ jobs:
         # local developer commit — preventing PRs that fail CI on
         # code-quality.
         run: |
-          pip install pre-commit
+          pip install -e ".[all,dev-lint]"
           pre-commit install
 
       - name: Run Claude

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,16 +29,22 @@ repos:
       - id: ruff-format
         exclude: ^examples/specdec_bench/specdec_bench/datasets/speed\.py$
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+  - repo: local
     hooks:
       - id: mypy
-        # --interactive clears legacy non_interactive config while automatic installs stay off.
-        args: [--no-install-types, --interactive]
-        additional_dependencies:
-          - nox==2026.4.10
-          - types-docutils==0.22.3.20260724
-          - types-PyYAML==6.0.12.20260724
+        name: mypy
+        entry: python -m mypy
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+        # Keep automatic stub installation disabled and imported-module diagnostics quiet without
+        # discarding their type information.
+        args:
+          - --no-install-types
+          - --interactive
+          - --ignore-missing-imports
+          - --follow-imports=silent
+          - --scripts-are-modules
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -241,6 +241,7 @@ def regression(session):
 def pre_commit_all(session):
     session.install("-e", ".[all,dev-lint]")
     session.run("pre-commit", "run", "--all-files", "--show-diff-on-failure")
+    session.run("python", "tests/unit/tools/ci/test_mypy_hook_config.py")
 
 
 @dataclass(frozen=True)
@@ -267,7 +268,6 @@ _MYPY_LOCATION = re.compile(
     r"^(?P<path>.*?):(?P<line>\d+)(?::(?P<column>\d+))?: error: (?P<message>.*)$"
 )
 _MYPY_CODE = re.compile(r"^(?P<message>.*)  \[(?P<code>[^]]+)\]$")
-_MYPY_DIFF_DEPENDENCIES = ("types-PyYAML==6.0.12.20260724",)
 
 
 def _normalize_diagnostic_path(path):
@@ -363,8 +363,9 @@ def _run_mypy(session, checkout, paths, cache_dir):
             "--no-pretty",
             "--show-column-numbers",
             "--show-error-codes",
-            "--follow-imports=skip",
+            "--follow-imports=silent",
             "--ignore-missing-imports",
+            "--scripts-are-modules",
             "--cache-dir",
             str(cache_dir),
             "--",
@@ -475,7 +476,7 @@ def pre_commit_diff(session):
     from_ref, to_ref = session.posargs or ("origin/main", "HEAD")
     from_ref = _resolve_git_commit(session, from_ref)
     to_ref = _resolve_git_commit(session, to_ref)
-    session.install("-e", ".[all,dev-lint]", *_MYPY_DIFF_DEPENDENCIES)
+    session.install("-e", ".[all,dev-lint]")
     skip_hooks = {hook for hook in os.environ.get("SKIP", "").split(",") if hook}
     skip_hooks.add("mypy")
     session.run(
@@ -489,6 +490,7 @@ def pre_commit_diff(session):
         env={"SKIP": ",".join(sorted(skip_hooks))},
     )
     _run_changed_file_mypy(session, from_ref, to_ref)
+    session.run("python", "tests/unit/tools/ci/test_mypy_hook_config.py")
 
 
 # ─── Docs ─────────────────────────────────────────────────────────────────────

--- a/noxfile.py
+++ b/noxfile.py
@@ -239,9 +239,17 @@ def regression(session):
 # ─── Code quality ─────────────────────────────────────────────────────────────
 @nox.session
 def pre_commit_all(session):
-    session.install("-e", ".[all,dev-lint]")
+    session.install("-e", ".[all,dev-lint]", "pytest", "pytest-timeout")
     session.run("pre-commit", "run", "--all-files", "--show-diff-on-failure")
-    session.run("python", "tests/unit/tools/ci/test_mypy_hook_config.py")
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "--confcutdir=tests/unit/tools/ci",
+        "tests/unit/tools/ci/test_mypy_hook_config.py",
+    )
 
 
 @dataclass(frozen=True)
@@ -476,7 +484,7 @@ def pre_commit_diff(session):
     from_ref, to_ref = session.posargs or ("origin/main", "HEAD")
     from_ref = _resolve_git_commit(session, from_ref)
     to_ref = _resolve_git_commit(session, to_ref)
-    session.install("-e", ".[all,dev-lint]")
+    session.install("-e", ".[all,dev-lint]", "pytest", "pytest-timeout")
     skip_hooks = {hook for hook in os.environ.get("SKIP", "").split(",") if hook}
     skip_hooks.add("mypy")
     session.run(
@@ -490,7 +498,15 @@ def pre_commit_diff(session):
         env={"SKIP": ",".join(sorted(skip_hooks))},
     )
     _run_changed_file_mypy(session, from_ref, to_ref)
-    session.run("python", "tests/unit/tools/ci/test_mypy_hook_config.py")
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        "--confcutdir=tests/unit/tools/ci",
+        "tests/unit/tools/ci/test_mypy_hook_config.py",
+    )
 
 
 # ─── Docs ─────────────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,11 @@ puzzletron = [ # Dependedencies for modelopt.torch.puzzletron subpackage
 dev-lint = [
     "bandit[toml]==1.7.9", # security/compliance checks
     "mypy==1.17.1",
+    "nox==2026.4.10",
     "pre-commit==4.3.0",
     "ruff==0.12.11",
     "types-docutils==0.22.3.20260724",
+    "types-PyYAML==6.0.12.20260724",
 ]
 dev-docs = [
     "autodoc_pydantic>=2.1.0",

--- a/tests/unit/tools/ci/test_mypy_diff.py
+++ b/tests/unit/tools/ci/test_mypy_diff.py
@@ -120,6 +120,9 @@ def test_run_mypy_separates_paths_from_options():
     _run_mypy(session, Path("checkout"), ["-strict.py"], Path("cache"))
 
     assert session.arguments[-2:] == ("--", "-strict.py")
+    assert "--follow-imports=silent" in session.arguments
+    assert "--follow-imports=skip" not in session.arguments
+    assert "--scripts-are-modules" in session.arguments
 
 
 def test_merge_parent_avoids_target_only_files_selected_by_stale_event_base(tmp_path):
@@ -187,22 +190,26 @@ def test_code_quality_uses_checked_out_pull_request_merge_parent():
     assert "github.event.pull_request.base.sha" not in changed_file_step["run"]
 
 
-def test_mypy_hook_pins_stubs_and_disables_automatic_installation():
+def test_mypy_hook_uses_modelopt_environment():
     config = yaml.safe_load(
         (REPOSITORY_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     )
-    hook = next(
-        hook
+    repository, hook = next(
+        (repository, hook)
         for repository in config["repos"]
         for hook in repository["hooks"]
         if hook["id"] == "mypy"
     )
-    dependencies = hook["additional_dependencies"]
 
-    assert hook["args"] == ["--no-install-types", "--interactive"]
-    assert {dependency.split("==", maxsplit=1)[0] for dependency in dependencies} == {
-        "nox",
-        "types-docutils",
-        "types-PyYAML",
-    }
-    assert all(dependency.count("==") == 1 for dependency in dependencies)
+    assert repository["repo"] == "local"
+    assert hook["entry"] == "python -m mypy"
+    assert hook["language"] == "system"
+    assert hook["types_or"] == ["python", "pyi"]
+    assert hook["require_serial"] is True
+    assert hook["args"] == [
+        "--no-install-types",
+        "--interactive",
+        "--ignore-missing-imports",
+        "--follow-imports=silent",
+        "--scripts-are-modules",
+    ]

--- a/tests/unit/tools/ci/test_mypy_hook_config.py
+++ b/tests/unit/tools/ci/test_mypy_hook_config.py
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Behavioral check for the Mypy pre-commit hook configuration.
-
-Run with ``python tests/unit/tools/ci/test_mypy_hook_config.py``.
-"""
+"""Behavioral tests for the Mypy pre-commit hook configuration."""
 
 import subprocess
 import sys
@@ -28,7 +25,7 @@ import yaml
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 
 
-def main() -> None:
+def test_mypy_hook_reports_imported_interface_error() -> None:
     config = yaml.safe_load(
         (REPOSITORY_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     )
@@ -66,12 +63,6 @@ def main() -> None:
             text=True,
         )
 
-    if result.returncode != 1:
-        raise RuntimeError(result.stdout + result.stderr)
+    assert result.returncode == 1, result.stdout + result.stderr
     expected = 'Argument 1 to "takes_int" has incompatible type "str"; expected "int"  [arg-type]'
-    if expected not in result.stdout:
-        raise RuntimeError(result.stdout + result.stderr)
-
-
-if __name__ == "__main__":
-    main()
+    assert expected in result.stdout, result.stdout + result.stderr

--- a/tests/unit/tools/ci/test_mypy_hook_config.py
+++ b/tests/unit/tools/ci/test_mypy_hook_config.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral check for the Mypy pre-commit hook configuration.
+
+Run with ``python tests/unit/tools/ci/test_mypy_hook_config.py``.
+"""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+
+
+def main() -> None:
+    config = yaml.safe_load(
+        (REPOSITORY_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    )
+    hook = next(
+        hook
+        for repository in config["repos"]
+        for hook in repository["hooks"]
+        if hook["id"] == "mypy"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="modelopt-mypy-hook-test-") as directory:
+        root = Path(directory)
+        (root / "provider.py").write_text(
+            "def takes_int(value: int) -> int:\n    return value\n", encoding="utf-8"
+        )
+        consumer = root / "consumer.py"
+        consumer.write_text(
+            'from provider import takes_int\n\ntakes_int("not an int")\n', encoding="utf-8"
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "mypy",
+                *hook["args"],
+                "--no-color-output",
+                "--show-error-codes",
+                "--cache-dir",
+                str(root / ".mypy_cache"),
+                str(consumer),
+            ],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    if result.returncode != 1:
+        raise RuntimeError(result.stdout + result.stderr)
+    expected = 'Argument 1 to "takes_int" has incompatible type "str"; expected "int"  [arg-type]'
+    if expected not in result.stdout:
+        raise RuntimeError(result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -703,18 +703,18 @@ name = "deepspeed"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "einops", marker = "sys_platform != 'win32'" },
-    { name = "hjson", marker = "sys_platform != 'win32'" },
-    { name = "msgpack", marker = "sys_platform != 'win32'" },
-    { name = "ninja", marker = "sys_platform != 'win32'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'win32'" },
-    { name = "packaging", marker = "sys_platform != 'win32'" },
-    { name = "psutil", marker = "sys_platform != 'win32'" },
-    { name = "py-cpuinfo", marker = "sys_platform != 'win32'" },
-    { name = "pydantic", marker = "sys_platform != 'win32'" },
+    { name = "einops", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "hjson", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "msgpack", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "ninja", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 's390x' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "packaging", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "psutil", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "py-cpuinfo", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "pydantic", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
     { name = "torch", marker = "sys_platform == 'never'" },
-    { name = "tqdm", marker = "sys_platform != 'win32'" },
+    { name = "tqdm", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/5f/32c0f354c3fa421bed077a108d24d62ed060c695633092517d63c190094a/deepspeed-0.19.1.tar.gz", hash = "sha256:75013c83cf0032046b34c5c9e1dfd02a5a32bfad41919e199fa30ba6fb950d4d", size = 1697014, upload-time = "2026-05-30T12:55:09.879Z" }
 
@@ -1751,6 +1751,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2096,6 +2105,7 @@ all = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "peft" },
+    { name = "plotly" },
     { name = "polygraphy" },
     { name = "sentencepiece" },
     { name = "tiktoken" },
@@ -2135,6 +2145,7 @@ dev = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "peft" },
+    { name = "plotly" },
     { name = "polygraphy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -2158,6 +2169,8 @@ dev = [
     { name = "torchvision" },
     { name = "transformers" },
     { name = "typeguard" },
+    { name = "types-docutils" },
+    { name = "types-pyyaml" },
     { name = "uv" },
     { name = "wonderwords" },
 ]
@@ -2175,8 +2188,11 @@ dev-docs = [
 dev-lint = [
     { name = "bandit", extra = ["toml"] },
     { name = "mypy" },
+    { name = "nox" },
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "types-docutils" },
+    { name = "types-pyyaml" },
 ]
 dev-test = [
     { name = "coverage", extra = ["toml"] },
@@ -2227,6 +2243,7 @@ puzzletron = [
     { name = "lru-dict" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "plotly" },
     { name = "typeguard" },
 ]
 
@@ -2251,6 +2268,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev-lint'", specifier = "==1.17.1" },
     { name = "ninja" },
     { name = "nltk", marker = "extra == 'hf'" },
+    { name = "nox", marker = "extra == 'dev-lint'", specifier = "==2026.4.10" },
     { name = "nox", marker = "extra == 'dev-test'" },
     { name = "numpy" },
     { name = "nvidia-ml-py", specifier = ">=12" },
@@ -2270,6 +2288,7 @@ requires-dist = [
     { name = "packaging" },
     { name = "pandas", marker = "extra == 'puzzletron'" },
     { name = "peft", marker = "extra == 'hf'", specifier = ">=0.17.0" },
+    { name = "plotly", marker = "extra == 'puzzletron'" },
     { name = "polygraphy", marker = "extra == 'onnx'", specifier = ">=0.49.22" },
     { name = "pre-commit", marker = "extra == 'dev-lint'", specifier = "==4.3.0" },
     { name = "pulp", specifier = "<4.0" },
@@ -2302,6 +2321,8 @@ requires-dist = [
     { name = "tqdm" },
     { name = "transformers", marker = "extra == 'hf'", specifier = ">=4.56,<5.10" },
     { name = "typeguard", marker = "extra == 'puzzletron'" },
+    { name = "types-docutils", marker = "extra == 'dev-lint'", specifier = "==0.22.3.20260724" },
+    { name = "types-pyyaml", marker = "extra == 'dev-lint'", specifier = "==6.0.12.20260724" },
     { name = "uv", marker = "extra == 'dev-test'" },
     { name = "wonderwords", marker = "extra == 'hf'" },
 ]
@@ -2892,6 +2913,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/18/d8544811ab076f876c4892b3714f5b0dad335e1dc33aef826df431b8325d/plotly-6.9.0-py3-none-any.whl", hash = "sha256:36bebe2f1bb13884774fe61689c329071446f6ce4a8927fb1f0d6fb24f581236", size = 9909646, upload-time = "2026-07-09T14:55:55.421Z" },
 ]
 
 [[package]]
@@ -4426,14 +4460,14 @@ name = "torch"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "fsspec", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "jinja2", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_machine != 's390x' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 's390x' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and platform_machine != 's390x' and sys_platform == 'darwin') or (python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "sympy", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
+    { name = "typing-extensions", marker = "(platform_machine != 's390x' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'win32')" },
 ]
 
 [[package]]
@@ -4570,6 +4604,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
+name = "types-docutils"
+version = "0.22.3.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/8f/30e02b59a9aad81eacd3d02fab5365257e89fde56e7acf44a4128f5f80aa/types_docutils-0.22.3.20260724.tar.gz", hash = "sha256:0223ce87f9b8331a5a3a7c7832e828033d289da6b878a0dcfbc74c30ec58850e", size = 57883, upload-time = "2026-07-24T04:58:36.388Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/1a/898fbb98680dbd5eb7ac8e9cbaf39cf234d329a45d89d04faaf33d7d8008/types_docutils-0.22.3.20260724-py3-none-any.whl", hash = "sha256:45e2fe584608671aa648784c4f805d08a36cd69eb2bd542e60522140c46dc89c", size = 91986, upload-time = "2026-07-24T04:58:35.368Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What does this PR do?

The Mypy hook and changed-file ratchet currently run with different dependency scopes and skip imported modules, so cross-module type errors can be hidden. This change runs both paths with ModelOpt's declared lint dependencies and preserves imported interfaces during focused checks.

Type of change: Bug fix

The `mirrors-mypy` hook is replaced with a local system hook pinned through `dev-lint`. The existing pre-commit nox sessions and Claude workflow install the same declared dependencies, while the changed-file ratchet retains its baseline comparison behavior. A focused regression check ensures invalid calls through imported interfaces remain visible.

### Testing

Focused lint and regression checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Increased the automated AI workflow timeout to improve completion reliability.
  - Updated development setup to install the project’s complete linting and development tools.
  - Added pinned development tooling versions for more consistent local environments.
  - Standardized static type checking through the project’s development environment.

- **Tests**
  - Improved automated validation of static type checking and pre-commit configuration.
  - Added coverage confirming type errors are detected with the configured checking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->