### PR TITLE
Fix Mypy availability in unit sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -76,7 +76,7 @@ def _cov_args():
 @nox.parametrize("torch_ver", [nox.param(k, id=k) for k in TORCH_VERSIONS])
 def unit(session, torch_ver, tf_ver):
     """Non-Puzzletron unit tests across the generic dependency matrix."""
-    session.install(TORCH_VERSIONS[torch_ver], "-e", ".[all,dev-test]")
+    session.install(TORCH_VERSIONS[torch_ver], "-e", ".[all,dev-lint,dev-test]")
     tf_pin = TRANSFORMERS_VERSIONS[tf_ver]
     if tf_pin:
         session.install(tf_pin)


### PR DESCRIPTION
### What does this PR do?

Generic unit Nox sessions collect a regression test that invokes Mypy, but those environments did not install the tool. Install the existing lint dependency group alongside the test dependencies so the behavioral check runs with the same interpreter as the suite.

Type of change: Bug fix

### Testing

Covered by the standard unit and code-quality CI workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the unit test environment to include development linting dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->