### PR TITLE
Fix minimum-dependency and cross-platform unit failures

### DIFF
--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -32,15 +32,22 @@ DiffusionPipeline: type[Any] | None
 ModelMixin: type[Any] | None
 try:  # diffusers is optional for LTX-2 export paths
     from diffusers import DiffusionPipeline as _DiffusionPipeline
-    from diffusers import ModelMixin as _ModelMixin
 
     DiffusionPipeline = _DiffusionPipeline
-    ModelMixin = _ModelMixin
-    _HAS_DIFFUSERS = True
 except Exception:  # pragma: no cover
     DiffusionPipeline = None
+
+try:
+    try:
+        from diffusers import ModelMixin as _ModelMixin
+    except ImportError:  # older diffusers releases do not export ModelMixin at package level
+        from diffusers.models.modeling_utils import ModelMixin as _ModelMixin
+
+    ModelMixin = _ModelMixin
+except Exception:  # pragma: no cover
     ModelMixin = None
-    _HAS_DIFFUSERS = False
+
+_HAS_DIFFUSERS = DiffusionPipeline is not None or ModelMixin is not None
 
 TI2VidTwoStagesPipeline: type[Any] | None
 try:  # optional for LTX-2 export paths

--- a/tests/unit/onnx/quantization/test_qdq_utils.py
+++ b/tests/unit/onnx/quantization/test_qdq_utils.py
@@ -705,6 +705,7 @@ def create_test_model_with_int4_dq_matmul():
 class TestColumnMajorTransformation:
     """Test suite for column-major storage transformation functions."""
 
+    @pytest.mark.timeout(180)
     def test_column_major_transformation_graph_structure(self):
         """Test that column-major transformation produces correct graph structure.
 

--- a/tests/unit/torch/quantization/test_dist.py
+++ b/tests/unit/torch/quantization/test_dist.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 import torch.distributed as dist
 from _test_utils.torch.distributed.utils import spawn_multiprocess_job
@@ -43,5 +44,6 @@ def _test_data_parallel_helper(rank, size):
     dist.destroy_process_group()
 
 
+@pytest.mark.timeout(120)
 def test_data_parallel(skip_on_windows):
     spawn_multiprocess_job(2, _test_data_parallel_helper, backend="gloo")


### PR DESCRIPTION
### What does this PR do?

The minimum-Transformers unit job can misclassify diffusers models when optional pipeline imports fail, while cold distributed and native-extension tests can exceed the default timeout on Python 3.14 and Windows. This change decouples diffusers model detection from pipeline availability and gives the two slow tests targeted time budgets.

Type of change: Bug fix

- Continue recognizing `ModelMixin` objects when `DiffusionPipeline` is unavailable, with a compatibility fallback for older diffusers releases.
- Allow up to 120 seconds for the distributed Gloo test and 180 seconds for the ONNX column-major native-extension test.

### Testing

Ran the Python 3.14 minimum-dependency unit suite and the focused affected tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with older Diffusers releases.
  - Diffusers support is now recognized when either supported pipeline or model components are available.

- **Tests**
  - Added time limits to prevent selected quantization and distributed tests from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->