### PR TITLE
fix(launcher): use the schema's draft_model global var

### DIFF
--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/specdec_bench.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/specdec_bench.yaml
@@ -32,13 +32,13 @@ pipeline:
 
   global_vars:
     hf_model: /hf-local/nvidia/Kimi-K2.5-NVFP4
-    # Trained+exported DFLASH draft; override: pipeline.global_vars.draft_model_dir=<path>
-    draft_model_dir: /hf-local/nvidia/Kimi-K2.5-DFlash
+    # Trained+exported DFLASH draft; override: pipeline.global_vars.draft_model=<path>
+    draft_model: /hf-local/nvidia/Kimi-K2.5-DFlash
 
   task_0:
     script: common/specdec_bench/run.sh
     args:
-      - --draft_model_dir <<global_vars.draft_model_dir>>
+      - --draft_model_dir <<global_vars.draft_model>>
       - --speculative_algorithm DFLASH
       - --engine VLLM
       - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_streaming_dspark_warmstart.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_streaming_dspark_warmstart.yaml
@@ -56,7 +56,7 @@ pipeline:
     # config.json layer-type vocabulary already patched for tf5 (see header).
     hf_model: /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
     # The published drafter the warm start continues from.
-    drafter: /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
+    draft_model: /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark
 
   # Build /scratchspace/data/train.jsonl. Point data.data_path at the full
   # Spec-Decoding-Dataset-v2 corpus to reproduce; eagle_utils also accepts a
@@ -80,7 +80,7 @@ pipeline:
       # causal attention and attention sink all come from this recipe — see header.
       - --config modules/Model-Optimizer/modelopt_recipes/huggingface/models/nvidia/Nemotron-3.5-Lightning-30B-A3B-BF16/speculative_decoding/dspark_warmstart.yaml
       - model.model_name_or_path=<<global_vars.hf_model>>
-      - dflash.dflash_init_checkpoint=<<global_vars.drafter>>
+      - dflash.dflash_init_checkpoint=<<global_vars.draft_model>>
       - data.data_path=/scratchspace/data/train.jsonl
       # The stock Nemotron template has no {% generation %} tags; without a tagged copy
       # answer_only_loss trains on an all-zero mask (see header).

--- a/tools/precommit/check_launcher_yaml.py
+++ b/tools/precommit/check_launcher_yaml.py
@@ -112,6 +112,52 @@ def _try_load_recipe(recipe_path: Path, source: Path) -> list[str]:
     return []
 
 
+def _global_vars_schema() -> set[str] | None:
+    """Field names accepted by ``GlobalVariables``, or None if it can't be read.
+
+    Parsed out of ``core.py`` rather than imported: importing it pulls in ``nemo_run``,
+    which is not a dependency of the pre-commit environment.
+    """
+    core = _LAUNCHER_DIR / "core.py"
+    try:
+        source = core.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r"^class GlobalVariables.*?(?=^@|\Z)", source, re.MULTILINE | re.DOTALL)
+    if not match:
+        return None
+    return set(re.findall(r"^\s{4}(\w+)\s*:", match.group(0), re.MULTILINE))
+
+
+def _check_global_vars(pipeline: dict, path: Path) -> list[str]:
+    """Reject ``global_vars`` keys the launcher's dataclass cannot accept.
+
+    ``global_vars`` is a fixed-field dataclass, not a free-form mapping, so an unknown key
+    fails at launch with ``No parameter named 'X' exists`` — after the user has set up a
+    cluster environment. This has now bitten twice (OMNIML-5024, then the Nemotron-3.5
+    DSpark warm-start example), so it is checked here instead.
+    """
+    schema = _global_vars_schema()
+    global_vars = pipeline.get("global_vars")
+    if schema is None or not isinstance(global_vars, dict):
+        return []
+    errors = [
+        f"{path}: global_vars key {key!r} is not a field of GlobalVariables "
+        f"(valid: {', '.join(sorted(schema))})"
+        for key in global_vars
+        if key not in schema
+    ]
+    # A reference to a key that is never defined interpolates to the literal
+    # ``<<global_vars.X>>`` and reaches the job as a nonsense path.
+    refs = sorted(set(re.findall(r"<<global_vars\.(\w+)>>", path.read_text("utf-8"))))
+    errors.extend(
+        f"{path}: <<global_vars.{ref}>> is referenced but never defined"
+        for ref in refs
+        if ref not in global_vars
+    )
+    return errors
+
+
 def _scan_launcher_yaml(path: Path) -> list[str]:
     errors: list[str] = []
     try:
@@ -123,6 +169,8 @@ def _scan_launcher_yaml(path: Path) -> list[str]:
     pipeline = data.get("pipeline")
     if not isinstance(pipeline, dict):
         return []
+
+    errors.extend(_check_global_vars(pipeline, path))
 
     for task in pipeline.values():
         if not isinstance(task, dict):


### PR DESCRIPTION
### What does this PR do?

**Type of change:** Bug fix

Fixes the launcher example added in #2149, which could not run at all.

`pipeline.global_vars` is a fixed-field dataclass ([`GlobalVariables`](https://github.com/NVIDIA/Model-Optimizer/blob/main/tools/launcher/core.py)), not a free-form mapping, so an unknown key is rejected at launch:

```
Error processing argument 'pipeline.global_vars.drafter=/hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16-DSpark':
Invalid argument: No parameter named 'drafter' exists for <function launch at 0x...>
```

The Nemotron-3.5 DSpark warm-start example invented `drafter:`. `draft_model` is the field that already exists for exactly this purpose, so the fix is to use it.

### Changes

| File | Change |
| --- | --- |
| `examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/hf_streaming_dspark_warmstart.yaml` | `drafter:` → `draft_model:` (the reported bug) |
| `examples/moonshotai/Kimi-K2.5/specdec_bench.yaml` | `draft_model_dir:` → `draft_model:` — the same latent break, pre-existing. Only the global-var key is renamed; the script's `--draft_model_dir` flag is unchanged. |

### Testing

Not end-to-end verified against a live cluster — the reported error is a launch-time argument-parsing failure that occurs before any job is submitted, and it is gone. Later steps in the Nemotron YAML still need the environment-specific placeholders (`<vllm-image-with-nemotron_h-eagle3>`, chat template path) filled in.

### Additional Information

Follow-up to #2149.

An earlier revision of this PR also added a `check_launcher_yaml.py` pre-commit rule that rejected unknown `global_vars` keys, since this class of bug has now shipped twice (the comment on `GlobalVariables.draft_model` records the first, OMNIML-5024). That has been dropped to keep this PR to the bug fix; the check can be proposed separately if wanted.
