### PR TITLE
Apply main-branch GPU test fixes to Puzzletron v2

### DIFF
--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -495,6 +495,8 @@ def get_dataset_samples(
             "Use ``get_dataset_dataloader`` to expand combos, or pass one of "
             f"its members: {DATASET_COMBOS[dataset_name]}"
         )
+    if num_samples < 0:
+        raise ValueError(f"``num_samples`` must be non-negative, got {num_samples}.")
 
     # Local JSONL: load via HF's ``json`` builder and route through the same
     # auto-preprocess path as unregistered HF datasets so chat / prompt / text
@@ -613,7 +615,7 @@ def get_dataset_samples(
     # load_dataset does not support a list of splits while streaming, so load each separately.
     print_rank_0(f"Loading dataset with {config=} and {splits=} {data_files_tmpl=}")
 
-    def _load_split(s: str):
+    def _load_split(s: str | None):
         if data_files_tmpl:
             # Raw files via the ``json`` builder: schema is inferred from data, and the
             # file-based builder labels everything as the ``train`` split.
@@ -626,14 +628,15 @@ def get_dataset_samples(
         return load_dataset(streaming=True, **config, split=s)
 
     try:
-        dataset_splits = [_load_split(s) for s in splits]
-
-        num_per_split = [num_samples // len(dataset_splits)] * len(dataset_splits)
+        num_per_split = [num_samples // len(splits)] * len(splits)
         num_per_split[-1] += num_samples - sum(num_per_split)
 
         samples: list[str] = []
-        for dataset, n in zip(dataset_splits, num_per_split):
-            for i, sample in enumerate(dataset):
+        for split_name, n in zip(splits, num_per_split):
+            # Skip zero-quota splits: starting a streamed split fetches its first record batch.
+            if n == 0:
+                continue
+            for i, sample in enumerate(_load_split(split_name)):
                 if i >= n:
                     break
                 text = _preprocess(sample)

--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -21,6 +21,7 @@ import os
 import random
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
+from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -636,9 +637,7 @@ def get_dataset_samples(
             # Skip zero-quota splits: starting a streamed split fetches its first record batch.
             if n == 0:
                 continue
-            for i, sample in enumerate(_load_split(split_name)):
-                if i >= n:
-                    break
+            for sample in islice(_load_split(split_name), n):
                 text = _preprocess(sample)
                 if text:
                     samples.append(text)

--- a/noxfile.py
+++ b/noxfile.py
@@ -197,8 +197,10 @@ def gpu(session):
         "pip",
         "install",
         "--no-build-isolation",
-        "git+https://github.com/state-spaces/mamba.git",
-        "git+https://github.com/Dao-AILab/causal-conv1d.git",
+        # Install released sdists instead of Git main, which can pull an
+        # incompatible apache-tvm-ffi dependency through mamba_ssm.
+        "mamba_ssm",
+        "causal-conv1d",
     )
     session.run("python", "-m", "pytest", "tests/gpu", *_cov_args())
 

--- a/tests/gpu/torch/quantization/test_deepspeed.py
+++ b/tests/gpu/torch/quantization/test_deepspeed.py
@@ -38,6 +38,7 @@ def get_ds_config(zero_stage: int = 3):
         "zero_optimization": {"stage": zero_stage},  # Restore Stage 3
         "fp16": {"enabled": False},
         "bf16": {"enabled": False},
+        "gradient_clipping": 0.0,
     }
 
 

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -829,6 +829,19 @@ class TestLocalDatasetDirRoundTrips:
         train_samples = get_dataset_samples(dataset, num_samples=4, split="train")
         assert default_samples == train_samples
 
+    def test_zero_quota_split_is_not_loaded(self, monkeypatch, make_toy_hf_dataset):
+        """1 sample over 2 splits → quotas [0, 1]: the zero-quota split is never opened."""
+        datasets = pytest.importorskip("datasets")
+        loaded, real_load_dataset = [], datasets.load_dataset
+
+        def _spy(*args, **kwargs):
+            loaded.append(kwargs.get("split"))
+            return real_load_dataset(*args, **kwargs)
+
+        monkeypatch.setattr(datasets, "load_dataset", _spy)
+        get_dataset_samples(make_toy_hf_dataset(), num_samples=1, split=["train", "test"])
+        assert loaded == ["test"]
+
     def test_download_to_jsonl_then_load(self, tmp_path, make_toy_hf_dataset):
         """Dump the dataset to JSONL, then reload it via the local-jsonl path."""
         dataset = make_toy_hf_dataset()

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -831,6 +831,7 @@ class TestLocalDatasetDirRoundTrips:
 
     def test_zero_quota_split_is_not_loaded(self, monkeypatch, make_toy_hf_dataset):
         """1 sample over 2 splits → quotas [0, 1]: the zero-quota split is never opened."""
+        # The optional datasets package is required to spy on local load_dataset calls.
         datasets = pytest.importorskip("datasets")
         loaded, real_load_dataset = [], datasets.load_dataset
 


### PR DESCRIPTION
### What does this PR do?

These failures are already fixed on `main`, but `feature/puzzletron_v2` diverged before the fixes landed. This PR applies the same three changes to the feature branch:

Type of change: Bug fix

- Use released Mamba packages to avoid the incompatible dependency resolution fixed by [PR #1901](https://github.com/NVIDIA/Model-Optimizer/pull/1901).
- Disable clipping in the DeepSpeed comparison test so it matches the unclipped PyTorch reference, as fixed by [commit `3c9137d28`](https://github.com/NVIDIA/Model-Optimizer/commit/3c9137d28ed7c858ffb2638ca4d44df9a8ea0175).
- Skip streamed dataset splits assigned zero samples, avoiding the Nemotron-v3 timeout fixed by [PR #2043](https://github.com/NVIDIA/Model-Optimizer/pull/2043).

### Testing

Focused GPU and unit tests passed for the affected dependency, DeepSpeed, and dataset-loading paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dataset sampling now rejects negative sample counts.
  * Dataset splits with no requested samples are skipped, reducing unnecessary data loading.
  * Sample allocation across multiple splits remains consistent.

* **Tests**
  * Added regression coverage for skipping zero-quota dataset splits.
  * Improved GPU test configuration for more predictable DeepSpeed behavior.

* **Chores**
  * GPU test setup now uses released dependency packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->