### PR TITLE
[6648996] Fix NVFP4 ONNX packed-weight scale rounding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Changelog
 **Bug Fixes**
 
 - Avoid querying CUDA/Blackwell capability when ``NVFP4QTensor.quantize`` uses its CPU path or has the optional TensorRT-LLM fast path disabled.
+- Fix NVFP4 ONNX export to quantize FP4 weights with the published FP8 block scales, matching eager ModelOpt packed weights.
 - Update HuggingFace checkpoint export to use name-based tied-weight deduplication instead of the previous address-based approach. The address-based deduplication could incorrectly drop an untied weight that happened to share memory with a tied one, producing an incomplete checkpoint (observed as a false positive on MiniMax-M2.7).
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
 - Polygraphy minimum dependency upgraded to ``0.53.4`` to solve ONNX AutoCast failures when marking optional graph outputs.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ Changelog
 **Bug Fixes**
 
 - Avoid querying CUDA/Blackwell capability when ``NVFP4QTensor.quantize`` uses its CPU path or has the optional TensorRT-LLM fast path disabled.
-- Fix NVFP4 ONNX export to quantize FP4 weights with the published FP8 block scales, matching eager ModelOpt packed weights.
+- Fix NVFP4 ONNX export to quantize FP4 weights with the published FP8 block scales, matching eager ModelOpt packed weights. Block scales below ``2**-9`` are now clamped to that minimum, and non-finite or negative scales raise an error.
 - Update HuggingFace checkpoint export to use name-based tied-weight deduplication instead of the previous address-based approach. The address-based deduplication could incorrectly drop an untied weight that happened to share memory with a tied one, producing an incomplete checkpoint (observed as a false positive on MiniMax-M2.7).
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
 - Polygraphy minimum dependency upgraded to ``0.53.4`` to solve ONNX AutoCast failures when marking optional graph outputs.

--- a/modelopt/onnx/export/nvfp4_exporter.py
+++ b/modelopt/onnx/export/nvfp4_exporter.py
@@ -30,6 +30,7 @@ from modelopt.onnx.quantization.quant_utils import (
     quantize,
 )
 from modelopt.torch.quantization.qtensor import NVFP4QTensor
+from modelopt.torch.quantization.qtensor.nvfp4_tensor import _cast_per_block_scale_to_fp8
 
 from .base_exporter import ONNXQuantExporter
 
@@ -65,6 +66,23 @@ def _cast_fp8(array: np.ndarray) -> np.ndarray:
     array_f8_t = array_f32_t.clamp(min=-448, max=448).to(torch.float8_e4m3fn).view(torch.uint8)
     array_f8 = array_f8_t.cpu().numpy().astype(np.uint8)
     return array_f8
+
+
+def _encode_nvfp4_block_scale(array: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return FP8-rounded block scales as FP32 values and encoded bytes."""
+    if not np.all(np.isfinite(array)) or np.any(array < 0):
+        raise ValueError("NVFP4 block scales must be finite and nonnegative.")
+
+    array_f32_t = torch.from_numpy(array)
+    if torch.cuda.is_available():
+        array_f32_t = array_f32_t.cuda()
+    array_f8_t = _cast_per_block_scale_to_fp8(array_f32_t)
+    array_f32 = array_f8_t.float().cpu().numpy()
+    array_f8 = array_f8_t.view(torch.uint8).cpu().numpy().astype(np.uint8)
+
+    if not np.all(np.isfinite(array_f32)) or np.any(array_f32 <= 0):
+        raise ValueError("NVFP4 block scales are not representable in FLOAT8E4M3FN.")
+    return array_f32, array_f8
 
 
 def _replace_fp4qdq_with_2dq(
@@ -295,12 +313,12 @@ class NVFP4QuantExporter(ONNXQuantExporter):
 
             sw_f32_per_block = sw_f32_per_block.reshape(sw_per_block_shape)
 
-            # Quantize weights
-            w_f32 = quantize(w32, block_size, sw_f32_per_block, sw_f32_per_tensor)
+            if not np.all(np.isfinite(sw_f32_per_tensor)) or np.any(sw_f32_per_tensor <= 0):
+                raise ValueError("NVFP4 per-tensor scales must be finite and positive.")
 
-            # Cast to FP4 and FP8
+            sw_f32_per_block, sw_f8_per_block = _encode_nvfp4_block_scale(sw_f32_per_block)
+            w_f32 = quantize(w32, block_size, sw_f32_per_block, sw_f32_per_tensor)
             w_f4 = _cast_fp4(w_f32)
-            sw_f8_per_block = _cast_fp8(sw_f32_per_block)
 
             # Store compressed data as node attributes for post_process
             w_f4_attr = node.attribute.add()

--- a/modelopt/onnx/export/nvfp4_exporter.py
+++ b/modelopt/onnx/export/nvfp4_exporter.py
@@ -30,7 +30,6 @@ from modelopt.onnx.quantization.quant_utils import (
     quantize,
 )
 from modelopt.torch.quantization.qtensor import NVFP4QTensor
-from modelopt.torch.quantization.qtensor.nvfp4_tensor import _cast_per_block_scale_to_fp8
 
 from .base_exporter import ONNXQuantExporter
 
@@ -58,16 +57,6 @@ def _cast_fp4(array: np.ndarray) -> np.ndarray:
     return array_f4
 
 
-def _cast_fp8(array: np.ndarray) -> np.ndarray:
-    """Cast a numpy array to FLOAT8E4M3FN using PyTorch."""
-    array_f32_t = torch.from_numpy(array)
-    if torch.cuda.is_available():
-        array_f32_t = array_f32_t.cuda()
-    array_f8_t = array_f32_t.clamp(min=-448, max=448).to(torch.float8_e4m3fn).view(torch.uint8)
-    array_f8 = array_f8_t.cpu().numpy().astype(np.uint8)
-    return array_f8
-
-
 def _encode_nvfp4_block_scale(array: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Return FP8-rounded block scales as FP32 values and encoded bytes."""
     if not np.all(np.isfinite(array)) or np.any(array < 0):
@@ -76,12 +65,10 @@ def _encode_nvfp4_block_scale(array: np.ndarray) -> tuple[np.ndarray, np.ndarray
     array_f32_t = torch.from_numpy(array)
     if torch.cuda.is_available():
         array_f32_t = array_f32_t.cuda()
-    array_f8_t = _cast_per_block_scale_to_fp8(array_f32_t)
+    array_f8_t = NVFP4QTensor._cast_per_block_scale_to_fp8(array_f32_t)
     array_f32 = array_f8_t.float().cpu().numpy()
     array_f8 = array_f8_t.view(torch.uint8).cpu().numpy().astype(np.uint8)
 
-    if not np.all(np.isfinite(array_f32)) or np.any(array_f32 <= 0):
-        raise ValueError("NVFP4 block scales are not representable in FLOAT8E4M3FN.")
     return array_f32, array_f8
 
 
@@ -312,9 +299,6 @@ class NVFP4QuantExporter(ONNXQuantExporter):
             )
 
             sw_f32_per_block = sw_f32_per_block.reshape(sw_per_block_shape)
-
-            if not np.all(np.isfinite(sw_f32_per_tensor)) or np.any(sw_f32_per_tensor <= 0):
-                raise ValueError("NVFP4 per-tensor scales must be finite and positive.")
 
             sw_f32_per_block, sw_f8_per_block = _encode_nvfp4_block_scale(sw_f32_per_block)
             w_f32 = quantize(w32, block_size, sw_f32_per_block, sw_f32_per_tensor)

--- a/modelopt/onnx/quantization/qdq_utils.py
+++ b/modelopt/onnx/quantization/qdq_utils.py
@@ -1520,7 +1520,11 @@ def fp4qdq_to_2dq(onnx_model: onnx.ModelProto, verbose: bool = False) -> onnx.Mo
     )
 
     # Lazy import to avoid a circular import: nvfp4_exporter imports from this module.
-    from modelopt.onnx.export.nvfp4_exporter import _cast_fp4, _replace_fp4qdq_with_2dq
+    from modelopt.onnx.export.nvfp4_exporter import (
+        _cast_fp4,
+        _encode_nvfp4_block_scale,
+        _replace_fp4qdq_with_2dq,
+    )
 
     logger.info("Converting model with FP4QDQ nodes to 2DQ only model")
     graph = onnx_model.graph
@@ -1584,11 +1588,10 @@ def fp4qdq_to_2dq(onnx_model: onnx.ModelProto, verbose: bool = False) -> onnx.Mo
         w32 = read_f16_tensor_as_fp32(tensor)
         sw_f32_per_tensor = get_weights_scaling_factor_2(w32)
         sw_f32_per_block = get_weights_scaling_factor(w32, block_size, sw_f32_per_tensor)
+        sw_f32_per_block, sw_f8_per_block = _encode_nvfp4_block_scale(sw_f32_per_block)
         w_f32 = quantize(w32, block_size, sw_f32_per_block, sw_f32_per_tensor)
 
-        # Real quantize the tensors
         w_f4 = _cast_fp4(w_f32)
-        sw_f8_per_block = _cast_fp8(sw_f32_per_block)
 
         _replace_fp4qdq_with_2dq(
             graph,

--- a/modelopt/onnx/quantization/quant_utils.py
+++ b/modelopt/onnx/quantization/quant_utils.py
@@ -125,8 +125,7 @@ def pack_float32_to_4bit_cpp_based(array: np.ndarray | Sequence, signed: bool) -
 
 def get_weights_scaling_factor_2(input: np.ndarray):
     """Returns per tensor weight scaling factor."""
-    per_block_scale_amax = np.max(np.abs(input)) / 6.0
-    per_block_quant_scale = per_block_scale_amax / 448.0
+    per_block_quant_scale = np.float32(np.max(np.abs(input))) / np.float32(6.0 * 448.0)
     if per_block_quant_scale == 0:
         per_block_quant_scale = 1.0
     return np.float32(per_block_quant_scale)
@@ -146,13 +145,11 @@ def get_weights_scaling_factor(
 
     input = input.reshape(n, k // block_size, block_size)
     # Get per block amax
-    per_block_amax = np.max(np.abs(input), axis=-1)
-    # Get per-block-scale
-    per_block_scale = per_block_amax / 6.0
-    # Quantize per_block_scale to FP8
-    q_per_block_scale = per_block_scale / weights_scaling_factor_2
+    per_block_amax = np.max(np.abs(input), axis=-1).astype(np.float32)
+    # Quantize per-block scale to FP8
+    q_per_block_scale = per_block_amax / (np.float32(6.0) * weights_scaling_factor_2)
     # Set all zero values in scale to 1.0
-    zero_mask = per_block_scale == 0
+    zero_mask = q_per_block_scale == 0
     q_per_block_scale[zero_mask] = 1.0
     return q_per_block_scale.astype(np.float32)
 

--- a/modelopt/onnx/quantization/quant_utils.py
+++ b/modelopt/onnx/quantization/quant_utils.py
@@ -128,6 +128,8 @@ def get_weights_scaling_factor_2(input: np.ndarray):
     per_block_quant_scale = np.float32(np.max(np.abs(input))) / np.float32(6.0 * 448.0)
     if per_block_quant_scale == 0:
         per_block_quant_scale = 1.0
+    if not np.isfinite(per_block_quant_scale):
+        raise ValueError("NVFP4 per-tensor scales must be finite and positive.")
     return np.float32(per_block_quant_scale)
 
 

--- a/modelopt/onnx/quantization/quant_utils.py
+++ b/modelopt/onnx/quantization/quant_utils.py
@@ -129,7 +129,7 @@ def get_weights_scaling_factor_2(input: np.ndarray):
     if per_block_quant_scale == 0:
         per_block_quant_scale = 1.0
     if not np.isfinite(per_block_quant_scale):
-        raise ValueError("NVFP4 per-tensor scales must be finite and positive.")
+        raise ValueError("NVFP4 per-tensor scales must be finite.")
     return np.float32(per_block_quant_scale)
 
 

--- a/modelopt/torch/quantization/qtensor/nvfp4_tensor.py
+++ b/modelopt/torch/quantization/qtensor/nvfp4_tensor.py
@@ -55,6 +55,7 @@ class NVFP4QTensor(BaseQuantizedTensor):
 
     e2m1_values_on_device = {}
     e2m1_bounds_on_device = {}
+    _cast_per_block_scale_to_fp8 = staticmethod(_cast_per_block_scale_to_fp8)
 
     @classmethod
     def get_e2m1_values(cls, device):

--- a/tests/unit/onnx/quantization/test_qdq_utils.py
+++ b/tests/unit/onnx/quantization/test_qdq_utils.py
@@ -22,8 +22,9 @@ import pytest
 from onnx import TensorProto, helper, numpy_helper
 
 from modelopt.onnx.export import INT4QuantExporter, MXFP8QuantExporter, NVFP4QuantExporter
-from modelopt.onnx.export.nvfp4_exporter import _cast_fp4, _cast_fp8
+from modelopt.onnx.export.nvfp4_exporter import _cast_fp4
 from modelopt.onnx.quantization.qdq_utils import (
+    _cast_fp8,
     apply_column_major_transformation,
     fp4qdq_to_2dq,
     insert_transpose_nodes_for_column_major,

--- a/tests/unit/onnx/quantization/test_quant_utils.py
+++ b/tests/unit/onnx/quantization/test_quant_utils.py
@@ -55,7 +55,7 @@ def test_nvfp4_scaling_factors_handle_zero_and_nonfinite_amax():
         np.ones((2, 1), dtype=np.float32),
     )
 
-    with pytest.raises(ValueError, match="finite and positive"):
+    with pytest.raises(ValueError, match="must be finite"):
         get_weights_scaling_factor_2(np.array([np.inf], dtype=np.float32))
 
 

--- a/tests/unit/onnx/quantization/test_quant_utils.py
+++ b/tests/unit/onnx/quantization/test_quant_utils.py
@@ -20,6 +20,8 @@ import torch
 from modelopt.onnx.quantization.quant_utils import (
     compute_e8m0,
     get_amax,
+    get_weights_scaling_factor,
+    get_weights_scaling_factor_2,
     pack_float32_to_4bit_cpp_based,
     pack_float32_to_4bit_optimized,
     pack_weights_to_int4,  # Add this import
@@ -30,6 +32,31 @@ def _validate_results(expected_values, observed_values):
     assert len(expected_values) == len(observed_values), "length-mismatch"
     for i in range(len(expected_values)):
         assert expected_values[i] == observed_values[i], "data-mismatch"
+
+
+def test_nvfp4_scaling_factors_use_single_fp32_division():
+    weight = np.zeros((2, 16), dtype=np.float32)
+    weight[:, 0] = [2.24609375, 2.515625]
+
+    per_tensor_scale = get_weights_scaling_factor_2(weight)
+    assert per_tensor_scale.view(np.uint32) == 0x3A755555
+    np.testing.assert_array_equal(
+        get_weights_scaling_factor(weight, 16, per_tensor_scale),
+        np.array([[400.0], [448.0]], dtype=np.float32),
+    )
+
+
+def test_nvfp4_scaling_factors_handle_zero_and_nonfinite_amax():
+    weight = np.zeros((2, 16), dtype=np.float32)
+    per_tensor_scale = get_weights_scaling_factor_2(weight)
+    assert per_tensor_scale == 1.0
+    np.testing.assert_array_equal(
+        get_weights_scaling_factor(weight, 16, per_tensor_scale),
+        np.ones((2, 1), dtype=np.float32),
+    )
+
+    with pytest.raises(ValueError, match="finite and positive"):
+        get_weights_scaling_factor_2(np.array([np.inf], dtype=np.float32))
 
 
 def test_pack_float32_to_4bit_utils():

--- a/tests/unit/torch/quantization/test_onnx_export_cpu.py
+++ b/tests/unit/torch/quantization/test_onnx_export_cpu.py
@@ -33,6 +33,9 @@ import modelopt.torch.quantization as mtq
 import modelopt.torch.quantization.tensor_quant as tensor_quant
 from modelopt.onnx import utils
 from modelopt.onnx.export import NVFP4QuantExporter
+from modelopt.onnx.export.nvfp4_exporter import _encode_nvfp4_block_scale
+from modelopt.onnx.quantization.qdq_utils import fp4qdq_to_2dq
+from modelopt.torch.quantization.qtensor import NVFP4QTensor
 from modelopt.torch.quantization.utils import is_quantized_linear
 
 
@@ -100,6 +103,103 @@ def test_nvfp4_exported_onnx_is_topologically_sorted(monkeypatch):
     converted_model = NVFP4QuantExporter.process_model(exported_model)
     assert not any(node.op_type == "TRT_FP4QDQ" for node in converted_model.graph.node)
     onnx.checker.check_model(converted_model)
+
+
+@pytest.mark.parametrize(
+    ("convert", "deprecated"),
+    [
+        pytest.param(NVFP4QuantExporter.process_model, False, id="exporter"),
+        pytest.param(fp4qdq_to_2dq, True, id="deprecated-shim"),
+    ],
+)
+@pytest.mark.parametrize(
+    "scale_case", ["fp8-rounding", "fp32-tensor-arithmetic", "fp32-block-arithmetic"]
+)
+def test_nvfp4_packed_weights_match_eager(scale_case, convert, deprecated):
+    block_size = 16
+    if scale_case == "fp8-rounding":
+        weight = np.zeros((4, block_size), dtype=np.float16)
+        weight[0, 0] = 6.0
+        weight[1, :2] = [0.231689453125, 0.0297393798828125]
+        expected_scale = np.array([[448.0], [18.0], [1.0], [1.0]], dtype=np.float32)
+    elif scale_case == "fp32-tensor-arithmetic":
+        weight = np.zeros((2, block_size), dtype=np.float16)
+        weight[0, 0] = 3.296875
+        weight[1, 0] = 2.099609375
+        weight[1, -2:] = [-1.501953125, 0.6181640625]
+        expected_scale = np.array([[448.0], [288.0]], dtype=np.float32)
+    else:
+        weight = np.zeros((2, block_size), dtype=np.float16)
+        weight[:, 0] = [2.24609375, 2.515625]
+        expected_scale = np.array([[384.0], [448.0]], dtype=np.float32)
+
+    weight_dq = helper.make_tensor_value_info("weight_dq", TensorProto.FLOAT, list(weight.shape))
+    model = helper.make_model(
+        helper.make_graph(
+            [
+                helper.make_node(
+                    "TRT_FP4QDQ",
+                    ["weight"],
+                    ["weight_dq"],
+                    name="weight_qdq",
+                    block_size=block_size,
+                ),
+                helper.make_node(
+                    "MatMul",
+                    ["activation", "weight_dq"],
+                    ["output"],
+                    name="matmul",
+                ),
+            ],
+            "nvfp4_packed_weights",
+            [
+                helper.make_tensor_value_info(
+                    "activation", TensorProto.FLOAT16, [1, weight.shape[0]]
+                )
+            ],
+            [helper.make_tensor_value_info("output", TensorProto.FLOAT16, [1, weight.shape[1]])],
+            [numpy_helper.from_array(weight, "weight")],
+            value_info=[weight_dq],
+        ),
+        opset_imports=[helper.make_opsetid("", 23)],
+    )
+
+    if deprecated:
+        with pytest.warns(DeprecationWarning):
+            converted = convert(model)
+    else:
+        converted = convert(model)
+    eager_qtensor, eager_scale, _ = NVFP4QTensor.quantize(
+        torch.from_numpy(weight.astype(np.float32)), block_size
+    )
+
+    np.testing.assert_array_equal(eager_scale.float().cpu().numpy(), expected_scale)
+
+    fp8_scale = next(
+        initializer
+        for initializer in converted.graph.initializer
+        if initializer.name == "weight_f8_scale"
+    )
+    np.testing.assert_array_equal(
+        np.frombuffer(fp8_scale.raw_data, dtype=np.uint8),
+        eager_scale.view(torch.uint8).cpu().numpy().reshape(-1),
+    )
+
+    fp4_weight = next(
+        initializer
+        for initializer in converted.graph.initializer
+        if initializer.name == "weight_f4"
+    )
+    np.testing.assert_array_equal(
+        np.frombuffer(fp4_weight.raw_data, dtype=np.uint8),
+        eager_qtensor._quantized_data.cpu().numpy().reshape(-1),
+    )
+
+
+@pytest.mark.parametrize("scale", [np.nan, np.inf, -1.0])
+def test_nvfp4_rejects_invalid_block_scale(scale):
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        _encode_nvfp4_block_scale(np.array([scale], dtype=np.float32))
 
 
 def test_nvfp4_shared_activation_reuses_cast():


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

This PR updates `nvfp4_exporter.py` so NVFP4 ONNX weight compression quantizes FP4 weights with the same FP8-rounded per-block scales serialized in the exported graph. It aligns `quant_utils.py` scale arithmetic with eager ModelOpt's FP32 operation ordering and applies the same behavior to the deprecated `fp4qdq_to_2dq` compatibility path in `qdq_utils.py`.

`test_onnx_export_cpu.py` adds regression coverage comparing exported FP8 scale bytes and packed FP4 weights against `NVFP4QTensor` at FP8-rounding, per-tensor arithmetic, and per-block arithmetic boundaries. `CHANGELOG.rst` documents the fix.

### Usage

```python
from modelopt.onnx.export import NVFP4QuantExporter

converted_model = NVFP4QuantExporter.process_model(model)
```

### Testing

Ran:

```bash
CUDA_VISIBLE_DEVICES="" python -m pytest -q \
  tests/unit/torch/quantization/test_onnx_export_cpu.py \
  tests/unit/torch/quantization/test_nvfp4_tensor.py \
  tests/unit/onnx/quantization/test_qdq_utils.py \
  tests/unit/onnx/quantization/test_quant_utils.py
```

The focused suite reported 91 passed at `314829a5` after the review-feedback changes, and all applicable pre-commit hooks passed. The final wording-only commit was not rerun through this unit suite. Earlier randomized validation also confirmed exact FP8-scale and packed-FP4 parity against eager quantization for 8,000 tensors.

End-to-end validation was rerun against final head `894c9f7d8a915185e1c8351a29eea5ea991baeee`:

- Built the boundary `TRT_FP4QDQ` graph and ran `NVFP4QuantExporter.compute_scales` followed by `compress_weights` from the PR checkout.
- Compared the native exported FP8 block-scale bytes and packed FP4 bytes against eager `NVFP4QTensor` output.
- Observed 0 native-exporter versus eager packed-byte mismatches.
- Native exporter, explicit round-before-compression control, and eager packed FP4 outputs had the same SHA-256: `4b745ef652b49e2b82b2aef37a7d52aab9a74563c61eb1b53c7d2a5b57bdc0a3`.
- Exported and eager FP8 block scales had the same SHA-256: `f2d7e6732dac4df4194666bd17527f68d166788b26142cdd3f51855b1ce9dccc`.
- Confirmed that the native exporter no longer follows the unrounded-scale FP4 calculation path.

The standalone bug detector intentionally returns nonzero when its original mismatch predicate no longer holds; an outer validator asserted the fixed invariants and completed successfully. Its only compatibility update was moving the `_cast_fp8` harness import from the removed `nvfp4_exporter` helper to `qdq_utils._cast_fp8`; the model, weights, export flow, and parity assertions were unchanged. This validation covers the ONNX export and eager byte-parity boundary, not TensorRT engine compilation or inference.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅

> 🤖 _Generated by Codex (AI agent)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added calibration-free streaming conversion and checkpoint-mirroring workflows for Kimi-K3 NVFP4 models.
  - Added support for temporary weight-folding contexts, activation headroom calibration, distillation, per-expert quantization, grouped-linear compilation, MLflow logging, Hugging Face post-training quantization, and vLLM fake-quantized serving.

- **Bug Fixes**
  - Improved NVFP4 ONNX export accuracy and compatibility through precise FP32/FP8 scale handling.
  - Added validation for invalid, non-finite, and negative scaling values.
  - Avoided unnecessary GPU capability checks during CPU or disabled fast-path quantization.
  - Removed deprecated quantization options and legacy configuration interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->