### PR TITLE
fix: make huggingface_hub plugin import optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Changelog
 - Update HuggingFace checkpoint export to use name-based tied-weight deduplication instead of the previous address-based approach. The address-based deduplication could incorrectly drop an untied weight that happened to share memory with a tied one, producing an incomplete checkpoint (observed as a false positive on MiniMax-M2.7).
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
 - Polygraphy minimum dependency upgraded to ``0.53.4`` to solve ONNX AutoCast failures when marking optional graph outputs.
+- Fix ``ModuleNotFoundError: No module named 'huggingface_hub'`` on any ``modelopt.torch`` import when the optional ``hf`` extra is not installed. ``modelopt.torch.opt.plugins`` imported the HuggingFace checkpointing plugin unconditionally; it is now guarded by ``import_plugin`` like the other third-party plugins. Affects 0.44 through 0.46.
 
 0.46 (2026-08-17)
 ^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,7 +43,7 @@ Changelog
 - Update HuggingFace checkpoint export to use name-based tied-weight deduplication instead of the previous address-based approach. The address-based deduplication could incorrectly drop an untied weight that happened to share memory with a tied one, producing an incomplete checkpoint (observed as a false positive on MiniMax-M2.7).
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
 - Polygraphy minimum dependency upgraded to ``0.53.4`` to solve ONNX AutoCast failures when marking optional graph outputs.
-- Fix ``ModuleNotFoundError: No module named 'huggingface_hub'`` on any ``modelopt.torch`` import when the optional ``hf`` extra is not installed. ``modelopt.torch.opt.plugins`` imported the HuggingFace checkpointing plugin unconditionally; it is now guarded by ``import_plugin`` like the other third-party plugins. Affects 0.44 through 0.46.
+- Fix ``ModuleNotFoundError: No module named 'huggingface_hub'`` when importing ``modelopt.torch`` without the optional ``hf`` extra. Install the ``hf`` extra to use Hugging Face checkpointing. Affects 0.44 through 0.46.
 
 0.46 (2026-08-17)
 ^^^^^^^^^^^^^^^^^

--- a/modelopt/torch/opt/plugins/__init__.py
+++ b/modelopt/torch/opt/plugins/__init__.py
@@ -17,7 +17,8 @@
 
 from modelopt.torch.utils import import_plugin
 
-from .huggingface import *
+with import_plugin("huggingface_hub"):
+    from .huggingface import *
 
 with import_plugin("megatron core dist checkpointing"):
     from .mcore_dist_checkpointing import *


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`modelopt/torch/opt/plugins/__init__.py` imports the HuggingFace checkpointing plugin unconditionally, while every other third-party plugin in the same file is wrapped in `import_plugin`:

```python
from .huggingface import *

with import_plugin("megatron core dist checkpointing"):
    from .mcore_dist_checkpointing import *
with import_plugin("transformers"):
    from .transformers import *
```

Since 0.44, `plugins/huggingface.py` imports `huggingface_hub` at module scope:

```python
from huggingface_hub import try_to_load_from_cache
from huggingface_hub.errors import HFValidationError
```

`huggingface_hub` is declared only under the optional `hf` extra, so on a plain `pip install nvidia-modelopt` any import under `modelopt.torch` fails:

```text
File ".../modelopt/torch/opt/plugins/huggingface.py", line 26, in <module>
    from huggingface_hub import try_to_load_from_cache
ModuleNotFoundError: No module named 'huggingface_hub'
```

This affects 0.44, 0.45 and 0.46. It hits users of the PyTorch quantization APIs who have no interest in HuggingFace checkpointing. The plugin only exports `enable_huggingface_checkpointing`, so guarding it leaves the rest of `modelopt.torch` working.

### Usage

```python
# pip install torch onnx nvidia-modelopt   (no `hf` extra, no huggingface_hub)
import modelopt.torch.quantization as mtq  # raises ModuleNotFoundError before this PR
```

### Testing

Fresh venv with `torch`, `onnx` and `nvidia-modelopt==0.46.0`, no `huggingface_hub`:

| | `import modelopt.torch.quantization` |
| --- | --- |
| before | `ModuleNotFoundError: No module named 'huggingface_hub'` |
| after | imports, `mtq.INT8_DEFAULT_CFG` available |

With `huggingface_hub` installed the plugin is imported as before.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when Hugging Face integration is not installed.
  - The optional Hugging Face checkpointing plugin now loads only when available, preventing related import errors.
- **Documentation**
  - Added installation guidance and release details for the optional dependency fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->