### PR TITLE
Add end-to-end PuzzleTron GPU lifecycle coverage

### DIFF
--- a/examples/puzzletron/embedding_pipeline.py
+++ b/examples/puzzletron/embedding_pipeline.py
@@ -150,24 +150,24 @@ def _scenario_overrides(config: dict, scenario: Path) -> tuple[str, ...]:
         "bypass.enabled=false",
         "embedding_pruning.enabled=false",
         f"replacement_library_path={scenario / 'replacement_library.json'}",
-        f"build_replacement_library.source_checkpoint_dir={teacher}",
-        "calc_subblock_stats.runtime_stats.execution=inline",
+        f"build_library.source_checkpoint_dir={teacher}",
+        "++vllm_stats.runtime_stats.execution=inline",
         f"replacement_scoring.teacher_dir={teacher}",
-        f"replacement_scoring.source_checkpoint_dir={teacher}",
-        f"replacement_scoring.target_teacher_dir={teacher}",
+        f"++replacement_scoring.source_checkpoint_dir={teacher}",
+        f"++replacement_scoring.target_teacher_dir={teacher}",
         f"replacement_scoring.solutions_path={scoring_solutions}",
         f"replacement_scoring.output_dir={scoring_output}",
-        f"vllm_stats_diagnostic.stats_path={scenario / 'subblock_stats.json'}",
-        f"vllm_stats_diagnostic.output_dir={scenario / 'artifacts/vllm_stats_diagnostic'}",
-        f"scoring_diagnostic.scores_dir={scoring_output}",
-        f"scoring_diagnostic.output_dir={scenario / 'artifacts/scoring_diagnostic'}",
+        f"++vllm_stats_diagnostic.stats_path={scenario / 'subblock_stats.json'}",
+        f"++vllm_stats_diagnostic.output_dir={scenario / 'artifacts/vllm_stats_diagnostic'}",
+        f"++scoring_diagnostic.scores_dir={scoring_output}",
+        f"++scoring_diagnostic.output_dir={scenario / 'artifacts/scoring_diagnostic'}",
     ]
     packed_token_cache_path = replacement_scoring.get("packed_token_cache_path")
     if packed_token_cache_path:
-        overrides.append(f"replacement_scoring.packed_token_cache_path={packed_token_cache_path}")
+        overrides.append(f"++replacement_scoring.packed_token_cache_path={packed_token_cache_path}")
     if scenario_manifest.get("bypass_checkpoint") is not None:
         overrides.append(
-            f"replacement_scoring.bypass_checkpoint_dir={scenario / 'ckpts' / 'bypass_overlay'}"
+            f"++replacement_scoring.bypass_checkpoint_dir={scenario / 'ckpts' / 'bypass_overlay'}"
         )
     return tuple(overrides)
 

--- a/modelopt/torch/puzzletron/benchmarks/vllm_compat/sitecustomize.py
+++ b/modelopt/torch/puzzletron/benchmarks/vllm_compat/sitecustomize.py
@@ -1,12 +1,61 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Compatibility loaded only by Puzzletron-owned vLLM server subprocesses."""
 
+import importlib.machinery
 import importlib.util
 import os
 import sys
 import types
+from pathlib import Path
+
+
+def _vllm_package_has_extension(package_spec, module_name: str) -> bool:
+    """Return whether the installed vLLM package contains a native extension."""
+    package_paths = package_spec.submodule_search_locations or ()
+    return any(
+        (Path(package_path) / f"{module_name}{suffix}").is_file()
+        for package_path in package_paths
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES
+    )
+
+
+def _install_stable_libtorch_c_stub() -> None:
+    """Satisfy vllm._C imports when stable-libtorch owns operator registration."""
+    if "vllm._C" in sys.modules:
+        return
+    try:
+        package_spec = importlib.util.find_spec("vllm")
+    except (ImportError, AttributeError, ValueError):
+        return
+    if (
+        package_spec is None
+        or _vllm_package_has_extension(package_spec, "_C")
+        or not _vllm_package_has_extension(package_spec, "_C_stable_libtorch")
+    ):
+        return
+
+    # Stable-libtorch vLLM builds register their Torch operators through
+    # _C_stable_libtorch, but some runtime modules still import vllm._C for its
+    # registration side effect.  The stable extension is loaded independently;
+    # this empty module only preserves that companion import contract.
+    c_stub = types.ModuleType("vllm._C")
+    c_stub.__package__ = "vllm"
+    sys.modules["vllm._C"] = c_stub
+
 
 try:
     import torch
@@ -19,5 +68,7 @@ if torch is not None and importlib.util.find_spec("torch._opaque_base") is None:
     # class needed to import vLLM.  Newer Torch builds retain their native API.
     os.environ["VLLM_USE_LAYERNAME"] = "0"
     opaque_base = types.ModuleType("torch._opaque_base")
-    opaque_base.OpaqueBase = object
+    setattr(opaque_base, "OpaqueBase", object)
     sys.modules["torch._opaque_base"] = opaque_base
+
+_install_stable_libtorch_c_stub()

--- a/modelopt/torch/puzzletron/orchestration/adapters/pool.py
+++ b/modelopt/torch/puzzletron/orchestration/adapters/pool.py
@@ -138,7 +138,7 @@ def _replacement_overrides(plan: CampaignPlan, puzzle_dir: Path) -> tuple[str, .
         f"convert.teacher_dir={teacher}",
         "bypass.enabled=false",
         f"replacement_library_path={puzzle_dir / 'replacement_library.json'}",
-        f"++build_replacement_library.source_checkpoint_dir={teacher}",
+        f"build_library.source_checkpoint_dir={teacher}",
         f"replacement_scoring.teacher_dir={teacher}",
         f"++replacement_scoring.source_checkpoint_dir={teacher}",
         f"++replacement_scoring.target_teacher_dir={teacher}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -260,6 +260,7 @@ def gpu_puzzletron(session):
             "tests/gpu/torch/puzzletron/test_puzzletron.py::"
             "test_tiny_qwen_campaign_uses_current_public_route"
         ),
+        *_cov_args(),
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -223,7 +223,44 @@ def gpu(session):
         "mamba_ssm",
         "causal-conv1d",
     )
-    session.run("python", "-m", "pytest", "tests/gpu", *_cov_args())
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "tests/gpu",
+        "--ignore=tests/gpu/torch/puzzletron/test_puzzletron.py",
+        *_cov_args(),
+    )
+
+
+# Container: dedicated Puzzletron v2 GPU image with the pinned ci_environment.json runtime.
+@nox.session(venv_backend="none")
+def gpu_puzzletron(session):
+    """Run the focused Puzzletron suite in its pinned one-GPU image."""
+    _verify_puzzletron_v2_environment(session)
+    session.run(
+        "python",
+        "-c",
+        (
+            "import torch; "
+            "assert torch.cuda.is_available(), 'Puzzletron GPU CI requires CUDA'; "
+            "assert torch.cuda.device_count() == 1, "
+            "f'Puzzletron GPU CI requires exactly one visible GPU, got {torch.cuda.device_count()}'; "
+            "assert torch.version.cuda == '12.9', "
+            "f'Puzzletron GPU CI requires CUDA 12.9, got {torch.version.cuda}'"
+        ),
+    )
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        "-o",
+        "addopts=",
+        (
+            "tests/gpu/torch/puzzletron/test_puzzletron.py::"
+            "test_tiny_qwen_campaign_uses_current_public_route"
+        ),
+    )
 
 
 # Container: nvcr.io/nvidia/nemo:26.04 or later

--- a/tests/_test_utils/torch/puzzletron/tiny_qwen_experiment_overlay.yaml
+++ b/tests/_test_utils/torch/puzzletron/tiny_qwen_experiment_overlay.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep the generated smoke campaign small while exercising its complete DAG.
+tokenize_data:
+  workers: 1
+
+replacement_scoring:
+  automodel:
+    lm_head_backend: streaming
+
+post_mip:
+  flows:
+    params-90:
+      nodes:
+        online_eval:
+          config:
+            eval_samples: 2
+        best_lm:
+          top_k: 3
+        serving:
+          config:
+            request_count: 4
+            allow_aiperf_v011_online_tokenizer_resolution: true
+            topology:
+              extra_vllm_args:
+                - -cc.cudagraph_mode=NONE
+                - --no-enable-flashinfer-autotune
+                - --max-num-batched-tokens
+                - "128"
+                - --max-num-seqs
+                - "4"
+                - --gpu-memory-utilization
+                - "0.5"
+        fastest:
+          top_k: 2
+        short_kd:
+          config:
+            max_steps: 2
+            global_batch_size: 1
+            local_batch_size: 1
+            checkpoint_every_steps: 2
+        final_eval:
+          config:
+            eval_samples: 2

--- a/tests/_test_utils/torch/puzzletron/tiny_qwen_fixture.py
+++ b/tests/_test_utils/torch/puzzletron/tiny_qwen_fixture.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Materialize and inspect the tiny-Qwen Puzzletron integration fixture."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from _test_utils.torch.transformers_models import create_tiny_qwen3_5_dir
+from datasets import Dataset, DatasetDict
+
+from modelopt.torch.puzzletron.pipeline_config import pipeline_config_from_path
+from puzzletron_orchestrator.compiler import (
+    compile_campaign_plan,
+    load_execution_config,
+    load_runner_config,
+)
+from puzzletron_setup.v2.wizard import _DEFAULT_DATA_SOURCE, _DEFAULT_MODEL_SOURCE, run_wizard_v2
+
+__all__ = ["TinyQwenCampaign", "build_tiny_qwen_campaign"]
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from puzzletron_orchestrator.schema import CampaignPlan
+    from puzzletron_setup.v2.prompts import PromptChoice
+
+
+_SETUP_DEFAULTS = Path(__file__).with_name("tiny_qwen_setup_defaults.yaml")
+_EXPERIMENT_OVERLAY = Path(__file__).with_name("tiny_qwen_experiment_overlay.yaml")
+
+
+class _DefaultsBackend:
+    """Select resolved guided defaults while supplying the campaign directory."""
+
+    def __init__(self, campaign_dir: Path) -> None:
+        self.campaign_dir = campaign_dir
+
+    def text(self, message: str, default: str) -> Any:
+        if message == "Campaign directory:":
+            return str(self.campaign_dir)
+        return default
+
+    def select(
+        self,
+        message: str,
+        choices: Sequence[PromptChoice],
+        default: Any,
+    ) -> Any:
+        if message == "Model:":
+            return _DEFAULT_MODEL_SOURCE
+        if message == "Dataset:":
+            return _DEFAULT_DATA_SOURCE
+        if default is not None:
+            return default
+        return next(choice.value for choice in choices if choice.disabled is None)
+
+    def checkbox(
+        self,
+        message: str,
+        choices: Sequence[PromptChoice],
+        defaults: Sequence[Any],
+    ) -> Any:
+        del message, choices
+        return list(defaults)
+
+
+@dataclass(frozen=True)
+class TinyQwenCampaign:
+    """Generated campaign bundle plus its exact execution contract."""
+
+    project_root: Path
+    smoke_bundle: Path
+    smoke_root: Path
+    flow_id: str
+    overrides: tuple[str, ...]
+    environment: dict[str, str]
+    config: dict[str, Any]
+    compiled_plan: CampaignPlan
+
+    def run(self, *, timeout: int = 2100) -> subprocess.CompletedProcess[str]:
+        """Run or resume the full campaign through the public local orchestrator."""
+
+        command = [
+            sys.executable,
+            str(self.project_root / "examples/puzzletron/orchestrate.py"),
+            "--experiment",
+            str(self.smoke_bundle / "experiment.yaml"),
+            "--runner",
+            str(self.smoke_bundle / "runner.yaml"),
+            "--execution",
+            str(self.smoke_bundle / "execution.yaml"),
+            "--stage",
+            "full",
+            "--local",
+            "--poll-interval",
+            "0.05",
+            "--color",
+            "never",
+        ]
+        for override in self.overrides:
+            command.extend(("--override", override))
+        return subprocess.run(
+            command,
+            cwd=self.project_root,
+            env=self.environment,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    def require_success(self, completed: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+        """Return the controller result or raise with the most useful task log."""
+
+        if completed.returncode != 0:
+            logs = sorted(
+                self.smoke_root.glob("logs/**/*.log"),
+                key=lambda path: path.stat().st_mtime_ns,
+            )
+            log_tail = (
+                logs[-1].read_text(errors="replace")[-12000:] if logs else "no task log found"
+            )
+            raise AssertionError(
+                "Tiny Qwen Puzzletron campaign failed.\n"
+                f"stdout tail:\n{completed.stdout[-12000:]}\n"
+                f"stderr tail:\n{completed.stderr[-12000:]}\n"
+                f"latest task-log tail:\n{log_tail}"
+            )
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise AssertionError(
+                "Puzzletron orchestrator did not emit its JSON result.\n"
+                f"stdout tail:\n{completed.stdout[-12000:]}\n"
+                f"stderr tail:\n{completed.stderr[-12000:]}"
+            ) from error
+        if not isinstance(payload, dict):
+            raise AssertionError(f"unexpected Puzzletron result payload: {payload!r}")
+        return payload
+
+
+def _save_messages_dataset(path: Path) -> None:
+    response = (
+        "Compression removes redundant parameters while preserving useful model behavior. " * 16
+    ).strip()
+    messages = [
+        {"role": "user", "content": "What is model compression?"},
+        {"role": "assistant", "content": response},
+    ]
+    rows = [{"messages": messages}] * 8
+    DatasetDict(
+        {
+            "train": Dataset.from_list(rows),
+            "validation": Dataset.from_list(rows),
+        }
+    ).save_to_disk(str(path))
+
+
+def _merge_config(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively apply a declarative test overlay to a generated config."""
+
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _merge_config(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def _write_setup_defaults(
+    path: Path,
+    *,
+    model_dir: Path,
+    dataset_dir: Path,
+    result_root: Path,
+    project_root: Path,
+) -> None:
+    """Materialize the checked-in setup config with per-test runtime paths."""
+
+    defaults = yaml.safe_load(_SETUP_DEFAULTS.read_text())
+    defaults["model"]["source"] = str(model_dir)
+    defaults["data"]["source"] = str(dataset_dir)
+    defaults["output"]["result_root"] = str(result_root)
+    contract = defaults["infrastructure"]["execution_contract"]
+    contract["repository"] = str(project_root)
+    contract["venv"] = sys.prefix
+    path.write_text(yaml.safe_dump(defaults, sort_keys=False))
+
+
+def build_tiny_qwen_campaign(
+    project_root: Path,
+    tmp_path: Path,
+) -> TinyQwenCampaign:
+    """Generate the sole tiny-Qwen setup-to-resume Puzzletron E2E fixture."""
+
+    model_dir = create_tiny_qwen3_5_dir(
+        tmp_path / "model",
+        with_tokenizer=True,
+        hidden_size=512,
+        intermediate_size=768,
+        head_dim=16,
+        max_position_embeddings=128,
+        num_hidden_layers=2,
+        layer_types=["full_attention"] * 2,
+    )
+    dataset_dir = tmp_path / "dataset"
+    campaign_dir = tmp_path / "campaign"
+    result_root = tmp_path / "results"
+    cache_dir = tmp_path / "cache"
+    defaults_path = tmp_path / "defaults.yaml"
+    _save_messages_dataset(dataset_dir)
+    _write_setup_defaults(
+        defaults_path,
+        model_dir=model_dir,
+        dataset_dir=dataset_dir,
+        result_root=result_root,
+        project_root=project_root,
+    )
+
+    generated = run_wizard_v2(
+        resume=None,
+        defaults_path=defaults_path,
+        backend=_DefaultsBackend(campaign_dir),
+    )
+    smoke_bundle = generated / "smoke"
+    experiment_path = smoke_bundle / "experiment.yaml"
+    experiment = yaml.safe_load(experiment_path.read_text())
+    flows = dict((experiment.get("post_mip") or {}).get("flows") or {})
+    if len(flows) != 1:
+        raise AssertionError(f"expected one recommended post-MIP flow, found {sorted(flows)}")
+    flow_id = next(iter(flows))
+    overlay = yaml.safe_load(_EXPERIMENT_OVERLAY.read_text())
+    overlay_flows = dict(overlay["post_mip"]["flows"])
+    if tuple(overlay_flows) != (flow_id,):
+        raise AssertionError(
+            f"tiny-Qwen overlay targets {sorted(overlay_flows)}, generated flow is {flow_id!r}"
+        )
+    _merge_config(experiment, overlay)
+    experiment_path.write_text(yaml.safe_dump(experiment, sort_keys=False))
+    overrides: tuple[str, ...] = ()
+    config = pipeline_config_from_path(experiment_path, overrides=overrides)
+    compiled_plan = compile_campaign_plan(
+        experiment_config_path=experiment_path,
+        runner=load_runner_config(smoke_bundle / "runner.yaml"),
+        execution=load_execution_config(smoke_bundle / "execution.yaml"),
+        overrides=overrides,
+        stage_filter="full",
+    )
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")[0],
+            "HF_DATASETS_OFFLINE": "1",
+            "HF_HOME": str(cache_dir / "huggingface"),
+            "HF_HUB_OFFLINE": "1",
+            "HF_DATASETS_CACHE": str(cache_dir / "datasets"),
+            "AIPERF_TOKENIZER_ALIAS_DIR": str(cache_dir / "aiperf-tokenizers"),
+            "TOKENIZERS_PARALLELISM": "false",
+            "TORCH_HOME": str(cache_dir / "torch"),
+            "TRANSFORMERS_OFFLINE": "1",
+            "VLLM_CACHE_ROOT": str(cache_dir / "vllm"),
+            "WANDB_DISABLED": "true",
+            "XDG_CACHE_HOME": str(cache_dir / "xdg"),
+        }
+    )
+    return TinyQwenCampaign(
+        project_root=project_root,
+        smoke_bundle=smoke_bundle,
+        smoke_root=result_root / "smoke",
+        flow_id=flow_id,
+        overrides=overrides,
+        environment=environment,
+        config=config,
+        compiled_plan=compiled_plan,
+    )

--- a/tests/_test_utils/torch/puzzletron/tiny_qwen_setup_defaults.yaml
+++ b/tests/_test_utils/torch/puzzletron/tiny_qwen_setup_defaults.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# The tiny model, dataset, result, checkout, and virtual-environment paths are
+# created per test and filled in by tiny_qwen_fixture.py before setup runs.
+schema_version: 1
+
+model:
+  source:
+  trust_remote_code: false
+  force_hf: false
+
+data:
+  source:
+  modality: text
+  layout: fixed
+  sequence_length: 32
+
+pruning:
+  depth_remove: 0
+  depth_importance_samples: 2
+  width_importance_samples: 2
+  replacement_samples: 2
+  sort_sanity: false
+  width_sanity: false
+  slicing_sanity: false
+  replacement_granularity: block
+  axes:
+    hidden_width:
+      values: [256]
+    kv_groups:
+      values: [2]
+    q_heads_per_group:
+      values: [2]
+    ffn_intermediate:
+      values: [768, 512, 256]
+    gdn_key_groups:
+      values: [2]
+    gdn_value_heads_per_group:
+      values: [2]
+    gdn_key_head_dim:
+      values: [8]
+    gdn_value_head_dim:
+      values: [8]
+  bypass:
+    enabled: false
+
+vllm:
+  enabled: false
+  prefill_seq_len: 32
+  generation_seq_len: 8
+  batch_size: 1
+  max_num_seqs: 1
+
+mip:
+  goal_metric: params
+  goal_value: 90%
+  num_solutions: 3
+
+stages:
+  width_importance:
+    batch: 1
+  replacement_scoring:
+    batch: 1
+    instances: 1
+
+output:
+  result_root:
+
+infrastructure:
+  gpus_per_node: 1
+  execution_contract:
+    repository:
+    venv:
+    container:
+    container_mounts:
+    prerun_commands: []
+    postrun_commands: []

--- a/tests/gpu/torch/puzzletron/test_puzzletron.py
+++ b/tests/gpu/torch/puzzletron/test_puzzletron.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hermetic GPU coverage for the public Puzzletron campaign route."""
+
+from __future__ import annotations
+
+import json
+import math
+from hashlib import sha256
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from _test_utils.torch.puzzletron.tiny_qwen_fixture import (
+    TinyQwenCampaign,
+    build_tiny_qwen_campaign,
+)
+
+from modelopt.torch.puzzletron.anymodel.registry import resolve_descriptor_from_pretrained
+from modelopt.torch.puzzletron.orchestration.adapters.stage_compat import stage_is_complete
+from modelopt.torch.puzzletron.orchestration.state import CampaignStateStore
+from modelopt.torch.puzzletron.plugins.automodel.load import load_anymodel_for_scoring
+from modelopt.torch.puzzletron.post_mip.records import CandidateLedger
+from puzzletron_orchestrator.adapters.registry import adapter_for_stage
+
+
+@pytest.mark.timeout(2400)
+def test_tiny_qwen_campaign_uses_current_public_route(
+    project_root_path: Path,
+    tmp_path: Path,
+) -> None:
+    """Run the full route in the pinned CUDA 12.9 image with one visible GPU."""
+
+    assert torch.cuda.is_available(), "Puzzletron GPU CI requires CUDA"
+    assert torch.cuda.device_count() == 1, "Puzzletron GPU CI requires one visible GPU"
+
+    campaign = build_tiny_qwen_campaign(project_root_path, tmp_path)
+    _assert_compiled_route(campaign)
+    completed = campaign.run()
+    result = campaign.require_success(completed)
+
+    stage_ids = tuple(node.stage_id for node in campaign.compiled_plan.stages)
+    _assert_completed_campaign(campaign, result, stage_ids)
+    manifest_paths = sorted(campaign.smoke_root.glob("manifests/*.json"))
+    assert manifest_paths
+    pruning_paths = _assert_pruning_and_mip_artifacts(campaign)
+    final_checkpoint, post_paths = _assert_post_mip_and_final_checkpoint(campaign)
+    _assert_selected_checkpoint_runs(final_checkpoint)
+    _assert_final_report(campaign, result)
+
+    state = CampaignStateStore(campaign.smoke_root)
+    attempts_before = {
+        (attempt["work_id"], attempt["attempt_id"]): attempt for attempt in state.list_attempts()
+    }
+    durable_paths = [*manifest_paths, *pruning_paths, *post_paths]
+    before_resume = _artifact_digests(durable_paths)
+
+    resumed = campaign.run()
+    resumed_result = campaign.require_success(resumed)
+
+    _assert_completed_campaign(campaign, resumed_result, stage_ids)
+    attempts_after = {
+        (attempt["work_id"], attempt["attempt_id"]): attempt for attempt in state.list_attempts()
+    }
+    assert attempts_after == attempts_before
+    assert _artifact_digests(durable_paths) == before_resume
+
+
+def _assert_compiled_route(campaign: TinyQwenCampaign) -> None:
+    """Verify the saved YAML bundle compiles to the intended one-GPU DAG."""
+
+    for name in ("experiment.yaml", "runner.yaml", "execution.yaml"):
+        assert (campaign.smoke_bundle / name).is_file()
+    serving = campaign.config["post_mip"]["flows"][campaign.flow_id]["nodes"]["serving"]
+    assert serving["config"]["allow_aiperf_v011_online_tokenizer_resolution"] is True
+    assert serving["config"]["topology"]["extra_vllm_args"] == [
+        "-cc.cudagraph_mode=NONE",
+        "--no-enable-flashinfer-autotune",
+        "--max-num-batched-tokens",
+        "128",
+        "--max-num-seqs",
+        "4",
+        "--gpu-memory-utilization",
+        "0.5",
+    ]
+
+    expected_nodes = (
+        "online_eval",
+        "best_lm",
+        "materialized",
+        "serving",
+        "fastest",
+        "short_kd",
+        "final_eval",
+        "best",
+    )
+    prefix = f"post.{campaign.flow_id}."
+    post_nodes = tuple(
+        node for node in campaign.compiled_plan.stages if node.stage_id.startswith(prefix)
+    )
+    assert tuple(node.stage_id.removeprefix(prefix) for node in post_nodes) == expected_nodes
+    assert post_nodes[0].parents == ("mip",)
+    for parent, node in pairwise(post_nodes):
+        assert node.parents == (parent.stage_id,)
+
+    replacement_node = next(
+        node for node in campaign.compiled_plan.stages if node.stage_id == "replacement_scoring"
+    )
+    replacement_work = adapter_for_stage(replacement_node).plan(
+        campaign.compiled_plan, replacement_node
+    )
+    assert (replacement_node.instances, replacement_node.gpus_per_instance) == (1, 1)
+    assert len(replacement_work.items) == 1
+    assert replacement_work.items[0].metadata["worker_count"] == 1
+
+
+def _assert_completed_campaign(
+    campaign: TinyQwenCampaign,
+    result: dict[str, Any],
+    stage_ids: tuple[str, ...],
+) -> None:
+    """Verify the controller and durable stage state agree on completion."""
+
+    assert tuple(result["completed"]) == stage_ids
+    assert all(stage_is_complete(campaign.config, stage_id) for stage_id in stage_ids)
+
+
+def _assert_pruning_and_mip_artifacts(campaign: TinyQwenCampaign) -> list[Path]:
+    """Verify pruning and MIP produced finite, feasible campaign artifacts."""
+
+    root = campaign.smoke_root
+    pass_manifests = list(
+        root.glob("pruning/pruning_scores/automodel/*/activation_passes_manifest.json")
+    )
+    assert len(pass_manifests) == 1
+    score_files = list(pass_manifests[0].parent.glob("*/rank_*.pth"))
+    assert score_files
+    score_tensors = [
+        tensor
+        for score_file in score_files
+        for tensor in _tensor_values(torch.load(score_file, map_location="cpu", weights_only=False))
+    ]
+    assert score_tensors
+    assert all(tensor.numel() and torch.isfinite(tensor).all() for tensor in score_tensors)
+
+    replacement_summary = _json(root / "artifacts/replacement_scoring/summary.json")
+    assert replacement_summary["widths"] == [256]
+    assert replacement_summary["scenario_count"] == 1
+    replacement_results = [
+        _json(path)
+        for path in root.glob(
+            "scenarios/width-*/depth-*/distributed_eval/replacement_scoring/results/**/*.json"
+        )
+    ]
+    assert replacement_results
+    provenances = [result["provenance"] for result in replacement_results]
+    assert {provenance["score_device_type"] for provenance in provenances} == {"cuda"}
+    assert {provenance["visible_cuda_device_count"] for provenance in provenances} == {1}
+
+    candidate_library = _json(root / "candidate_library.json")
+    assert 256 in _nested_values(candidate_library, "intermediate_size")
+    assert 512 in _nested_values(candidate_library, "intermediate_size")
+    active_profiles = _json(root / "mip/active_profiles.json")
+    assert active_profiles["status"] == "success"
+    grids = [
+        _json(root / "mip" / "profiles" / profile_id / "mip_grid.json")
+        for profile_id in active_profiles["profile_ids"]
+    ]
+    assert all(grid["status"] == "success" for grid in grids)
+    solution_paths = [
+        Path(scenario["solution_path"])
+        for grid in grids
+        for scenario in grid["scenarios"]
+        if scenario["status"] == "feasible"
+    ]
+    solutions = [solution for path in solution_paths for solution in _json(path)]
+    assert len(solutions) >= 3
+    solution_ffn_widths = {
+        int(width)
+        for solution in solutions
+        for width in _nested_values(solution["chosen_block_configs"], "intermediate_size")
+    }
+    assert solution_ffn_widths.intersection({256, 512})
+    return [*pass_manifests, *score_files, *solution_paths]
+
+
+def _assert_post_mip_and_final_checkpoint(
+    campaign: TinyQwenCampaign,
+) -> tuple[Path, list[Path]]:
+    """Verify the post-MIP flow selects and trains one usable final checkpoint."""
+
+    root = campaign.smoke_root
+    ledger = CandidateLedger(root / "artifacts/post_mip")
+    online = ledger.load_candidate_set("online_eval")
+    assert len(online.revision_ids) >= 3
+    online_observations = ledger.observations["online_eval"]
+    assert all(row.status == "success" for row in online_observations.values())
+    assert all(Path(row.artifacts["result_path"]).is_file() for row in online_observations.values())
+    online_losses = {
+        revision_id: _finite_metric(ledger, revision_id, "online_eval.lm_loss")
+        for revision_id in online.revision_ids
+    }
+
+    best_lm = ledger.load_candidate_set("best_lm")
+    assert len(best_lm.revision_ids) == 3
+    expected_best_lm = tuple(
+        revision_id
+        for _loss, revision_id in sorted(
+            (loss, revision_id) for revision_id, loss in online_losses.items()
+        )[:3]
+    )
+    assert best_lm.revision_ids == expected_best_lm
+    assert {
+        revision_id
+        for revision_id, row in ledger.observations["best_lm"].items()
+        if row.status == "selected"
+    } == set(best_lm.revision_ids)
+
+    materialized = ledger.load_candidate_set("materialized")
+    assert len(materialized.revision_ids) == 3
+    for revision_id in materialized.revision_ids:
+        revision = ledger.revisions[revision_id]
+        assert revision.parent_revision_id in set(best_lm.revision_ids)
+        checkpoint = Path(revision.artifact["checkpoint"])
+        assert (checkpoint / "config.json").is_file()
+        assert list(checkpoint.glob("*.safetensors"))
+    assert {
+        ledger.revisions[revision_id].parent_revision_id
+        for revision_id in materialized.revision_ids
+    } == set(best_lm.revision_ids)
+
+    serving = ledger.load_candidate_set("serving")
+    assert len(serving.revision_ids) >= 2
+    assert set(serving.revision_ids) <= set(materialized.revision_ids)
+    serving_throughputs = {
+        revision_id: _finite_metric(
+            ledger, revision_id, "serving.concurrency_1.output_token_throughput"
+        )
+        for revision_id in serving.revision_ids
+    }
+    assert all(throughput > 0 for throughput in serving_throughputs.values())
+    serving_observations = ledger.observations["serving"]
+    aiperf_paths = [
+        Path(path)
+        for row in serving_observations.values()
+        if row.status == "success"
+        for artifacts in row.artifacts["result_paths"]
+        for path in artifacts.values()
+    ]
+    assert aiperf_paths and all(path.is_file() for path in aiperf_paths)
+
+    fastest = ledger.load_candidate_set("fastest")
+    assert len(fastest.revision_ids) == 2
+    expected_fastest = tuple(
+        revision_id
+        for _throughput, revision_id in sorted(
+            (throughput, revision_id) for revision_id, throughput in serving_throughputs.items()
+        )[-2:][::-1]
+    )
+    assert fastest.revision_ids == expected_fastest
+    short_kd = ledger.load_candidate_set("short_kd")
+    assert len(short_kd.revision_ids) == 2
+    kd_paths = []
+    for revision_id in short_kd.revision_ids:
+        revision = ledger.revisions[revision_id]
+        assert revision.parent_revision_id in set(materialized.revision_ids)
+        checkpoint = Path(revision.artifact["checkpoint"])
+        summary_path = Path(revision.artifact["summary_path"])
+        kd_summary = _json(summary_path)
+        records = kd_summary["records"]
+        steps = {int(record.get("step", record.get("global_step"))) for record in records}
+        losses = [float(record.get("loss", record.get("train_loss"))) for record in records]
+        assert kd_summary["max_steps"] == 2
+        assert len(steps) >= 2
+        assert all(math.isfinite(loss) for loss in losses)
+        assert (checkpoint / "config.json").is_file()
+        assert list(checkpoint.glob("*.safetensors"))
+        parent = ledger.revisions[revision.parent_revision_id]
+        block_configs = _json(checkpoint / "config.json")["block_configs"]
+        parent_block_configs = _json(Path(parent.artifact["checkpoint"]) / "config.json")[
+            "block_configs"
+        ]
+        assert block_configs
+        assert block_configs == parent_block_configs
+        kd_paths.extend(
+            [
+                summary_path,
+                checkpoint.parents[2] / "training.jsonl",
+                checkpoint / "config.json",
+                *checkpoint.glob("*.safetensors"),
+            ]
+        )
+    assert {
+        ledger.revisions[revision_id].parent_revision_id for revision_id in short_kd.revision_ids
+    } == set(fastest.revision_ids)
+
+    final_eval = ledger.load_candidate_set("final_eval")
+    assert set(final_eval.revision_ids) == set(short_kd.revision_ids)
+    final_losses = {
+        revision_id: _finite_metric(ledger, revision_id, "final_eval.lm_loss")
+        for revision_id in final_eval.revision_ids
+    }
+    best = ledger.load_candidate_set("best")
+    assert len(best.revision_ids) == 1
+    selected_id = best.revision_ids[0]
+    assert final_losses[selected_id] == min(final_losses.values())
+    selected = ledger.revisions[selected_id]
+    final_checkpoint = Path(selected.artifact["checkpoint"])
+
+    post_paths = [root / "artifacts/post_mip/candidate_registry.json"]
+    post_paths.extend(root.glob("artifacts/post_mip/nodes/*/current.json"))
+    post_paths.extend(root.glob("artifacts/post_mip/nodes/*/index.json"))
+    post_paths.extend(root.glob("artifacts/post_mip/nodes/*/summary.json"))
+    post_paths.extend(root.glob("artifacts/post_mip/nodes/*/executions/*/candidate_set.json"))
+    post_paths.extend(root.glob("artifacts/post_mip/nodes/*/executions/*/observations.json"))
+    post_paths.extend(root.glob("artifacts/post_mip/nodes/*/executions/*/summary.json"))
+    return final_checkpoint, [*post_paths, *aiperf_paths, *kd_paths]
+
+
+def _assert_selected_checkpoint_runs(final_checkpoint: Path) -> None:
+    """Reload the selected physical checkpoint and run a finite CUDA forward pass."""
+
+    resolution = resolve_descriptor_from_pretrained(str(final_checkpoint))
+    selected_config = _json(final_checkpoint / "config.json")
+    widths_by_block = [
+        _nested_values(block_config, "intermediate_size")
+        for block_config in selected_config["block_configs"]
+    ]
+    assert all(len(widths) == 1 for widths in widths_by_block)
+    selected_widths = [int(widths[0]) for widths in widths_by_block]
+    model = load_anymodel_for_scoring(
+        str(final_checkpoint),
+        anymodel_descriptor=resolution.name,
+        force_hf=True,
+        torch_dtype=torch.bfloat16,
+        local_files_only=True,
+    ).cuda()
+
+    assert [layer.mlp.down_proj.in_features for layer in model.model.layers] == selected_widths
+    with torch.no_grad():
+        logits = model(torch.tensor([[1, 2, 3, 4]], device="cuda"), use_cache=False).logits
+    assert torch.isfinite(logits).all()
+
+
+def _assert_final_report(campaign: TinyQwenCampaign, result: dict[str, Any]) -> None:
+    """Verify the completed report links the key post-MIP stages."""
+
+    report_root = campaign.smoke_root / "artifacts/campaign_report"
+    html_path = report_root / "campaign_report.html"
+    manifest_path = report_root / "report_manifest.json"
+    assert result["report_status"] == "completed"
+    assert Path(result["report_path"]) == html_path
+    assert Path(result["report_manifest_path"]) == manifest_path
+    manifest = _json(manifest_path)
+    assert manifest["schema_version"] == 1
+    assert manifest["verification"] == "passed"
+    assert manifest["campaign_identity"]
+    html = html_path.read_text()
+    for node_id in ("online_eval", "serving", "short_kd", "final_eval"):
+        section_id = "post-" + "-".join(
+            part.replace("_", "-") for part in (campaign.flow_id, node_id)
+        )
+        assert f'id="{section_id}"' in html
+
+
+def _json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def _artifact_digests(paths: list[Path]) -> dict[str, str]:
+    return {str(path): sha256(path.read_bytes()).hexdigest() for path in sorted(set(paths))}
+
+
+def _nested_values(value: Any, key: str) -> list[Any]:
+    values = []
+    if isinstance(value, dict):
+        values.extend(item for name, item in value.items() if name == key)
+        for item in value.values():
+            values.extend(_nested_values(item, key))
+    elif isinstance(value, list):
+        for item in value:
+            values.extend(_nested_values(item, key))
+    return values
+
+
+def _tensor_values(value: Any):
+    if torch.is_tensor(value):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _tensor_values(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _tensor_values(item)
+
+
+def _finite_metric(ledger: CandidateLedger, revision_id: str, reference: str) -> float:
+    """Resolve one required finite candidate metric."""
+
+    value = ledger.resolve_metric(revision_id, reference)
+    assert value is not None and math.isfinite(value)
+    return value

--- a/tests/gpu/torch/puzzletron/test_puzzletron.py
+++ b/tests/gpu/torch/puzzletron/test_puzzletron.py
@@ -51,7 +51,7 @@ def test_tiny_qwen_campaign_uses_current_public_route(
 
     campaign = build_tiny_qwen_campaign(project_root_path, tmp_path)
     _assert_compiled_route(campaign)
-    completed = campaign.run()
+    completed = campaign.run(timeout=2100)
     result = campaign.require_success(completed)
 
     stage_ids = tuple(node.stage_id for node in campaign.compiled_plan.stages)
@@ -70,7 +70,7 @@ def test_tiny_qwen_campaign_uses_current_public_route(
     durable_paths = [*manifest_paths, *pruning_paths, *post_paths]
     before_resume = _artifact_digests(durable_paths)
 
-    resumed = campaign.run()
+    resumed = campaign.run(timeout=120)
     resumed_result = campaign.require_success(resumed)
 
     _assert_completed_campaign(campaign, resumed_result, stage_ids)
@@ -153,7 +153,7 @@ def _assert_pruning_and_mip_artifacts(campaign: TinyQwenCampaign) -> list[Path]:
     score_tensors = [
         tensor
         for score_file in score_files
-        for tensor in _tensor_values(torch.load(score_file, map_location="cpu", weights_only=False))
+        for tensor in _tensor_values(torch.load(score_file, map_location="cpu", weights_only=True))
     ]
     assert score_tensors
     assert all(tensor.numel() and torch.isfinite(tensor).all() for tensor in score_tensors)

--- a/tests/gpu/torch/puzzletron/test_puzzletron.py
+++ b/tests/gpu/torch/puzzletron/test_puzzletron.py
@@ -158,29 +158,33 @@ def _assert_pruning_and_mip_artifacts(campaign: TinyQwenCampaign) -> list[Path]:
     assert score_tensors
     assert all(tensor.numel() and torch.isfinite(tensor).all() for tensor in score_tensors)
 
-    replacement_summary = _json(root / "artifacts/replacement_scoring/summary.json")
+    replacement_summary_path = root / "artifacts/replacement_scoring/summary.json"
+    replacement_summary = _json(replacement_summary_path)
     assert replacement_summary["widths"] == [256]
     assert replacement_summary["scenario_count"] == 1
-    replacement_results = [
-        _json(path)
-        for path in root.glob(
+    replacement_result_paths = list(
+        root.glob(
             "scenarios/width-*/depth-*/distributed_eval/replacement_scoring/results/**/*.json"
         )
-    ]
+    )
+    replacement_results = [_json(path) for path in replacement_result_paths]
     assert replacement_results
     provenances = [result["provenance"] for result in replacement_results]
     assert {provenance["score_device_type"] for provenance in provenances} == {"cuda"}
     assert {provenance["visible_cuda_device_count"] for provenance in provenances} == {1}
 
-    candidate_library = _json(root / "candidate_library.json")
+    candidate_library_path = root / "candidate_library.json"
+    candidate_library = _json(candidate_library_path)
     assert 256 in _nested_values(candidate_library, "intermediate_size")
     assert 512 in _nested_values(candidate_library, "intermediate_size")
-    active_profiles = _json(root / "mip/active_profiles.json")
+    active_profiles_path = root / "mip/active_profiles.json"
+    active_profiles = _json(active_profiles_path)
     assert active_profiles["status"] == "success"
-    grids = [
-        _json(root / "mip" / "profiles" / profile_id / "mip_grid.json")
+    grid_paths = [
+        root / "mip" / "profiles" / profile_id / "mip_grid.json"
         for profile_id in active_profiles["profile_ids"]
     ]
+    grids = [_json(path) for path in grid_paths]
     assert all(grid["status"] == "success" for grid in grids)
     solution_paths = [
         Path(scenario["solution_path"])
@@ -196,7 +200,16 @@ def _assert_pruning_and_mip_artifacts(campaign: TinyQwenCampaign) -> list[Path]:
         for width in _nested_values(solution["chosen_block_configs"], "intermediate_size")
     }
     assert solution_ffn_widths.intersection({256, 512})
-    return [*pass_manifests, *score_files, *solution_paths]
+    return [
+        *pass_manifests,
+        *score_files,
+        replacement_summary_path,
+        *replacement_result_paths,
+        candidate_library_path,
+        active_profiles_path,
+        *grid_paths,
+        *solution_paths,
+    ]
 
 
 def _assert_post_mip_and_final_checkpoint(

--- a/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
+++ b/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
@@ -15,7 +15,10 @@
 
 """Tests for Puzzletron AIPerf context-capacity handling."""
 
+import importlib.machinery
+import importlib.util
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -64,6 +67,58 @@ def test_aiperf_server_environment_uses_the_active_vllm_package_source(monkeypat
 
     paths = env["PYTHONPATH"].split(":")
     assert paths[1] == str(active_source)
+
+
+@pytest.mark.parametrize(
+    ("extension_names", "expect_stub"),
+    [
+        pytest.param(("_C_stable_libtorch",), True, id="stable-only"),
+        pytest.param(("_C", "_C_stable_libtorch"), False, id="native-plus-stable"),
+        pytest.param((), False, id="neither"),
+    ],
+)
+def test_vllm_compat_stubs_c_only_for_stable_libtorch_layout(
+    monkeypatch, tmp_path, extension_names, expect_stub
+):
+    """Install an empty ``vllm._C`` companion only for the stable-only layout."""
+
+    extension_suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    vllm_package = tmp_path / "vllm"
+    vllm_package.mkdir()
+    for extension_name in extension_names:
+        (vllm_package / f"{extension_name}{extension_suffix}").touch()
+
+    real_find_spec = importlib.util.find_spec
+
+    def find_spec(name):
+        if name == "vllm":
+            return SimpleNamespace(submodule_search_locations=[str(vllm_package)])
+        if name == "torch._opaque_base":
+            return SimpleNamespace()
+        return real_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+    missing_module = object()
+    previous_module = sys.modules.pop("vllm._C", missing_module)
+    compatibility_path = (
+        Path(__file__).parents[4]
+        / "modelopt/torch/puzzletron/benchmarks/vllm_compat/sitecustomize.py"
+    )
+    module_spec = importlib.util.spec_from_file_location(
+        f"_test_vllm_compat_{len(extension_names)}", compatibility_path
+    )
+    assert module_spec is not None and module_spec.loader is not None
+    compatibility = importlib.util.module_from_spec(module_spec)
+    try:
+        module_spec.loader.exec_module(compatibility)
+
+        assert ("vllm._C" in sys.modules) is expect_stub
+        if expect_stub:
+            assert sys.modules["vllm._C"].__package__ == "vllm"
+    finally:
+        sys.modules.pop("vllm._C", None)
+        if previous_module is not missing_module:
+            sys.modules["vllm._C"] = previous_module
 
 
 def test_exact_length_defaults_to_ignore_eos_without_overriding_policy():

--- a/tests/unit/torch/puzzletron/test_orchestration_executors.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_executors.py
@@ -23,13 +23,13 @@ import pytest
 import yaml
 
 import puzzletron_orchestrator.adapters.sharded as sharded_module
+from modelopt.torch.puzzletron.distributed_eval.config import load_runtime_config
 from puzzletron_orchestrator.adapters.registry import adapter_for_stage
 from puzzletron_orchestrator.compiler import (
     compile_campaign_plan,
     load_execution_config,
     load_runner_config,
 )
-from puzzletron_orchestrator.config import load_experiment_config
 from puzzletron_orchestrator.executors.baremetal import BareMetalSSHExecutor
 from puzzletron_orchestrator.executors.local import LocalExecutor
 from puzzletron_orchestrator.executors.slurm import SlurmExecutor, render_sbatch_script
@@ -1018,19 +1018,22 @@ def test_replacement_pool_splits_workers_across_embedding_widths(tmp_path: Path)
     assert attempts[1].command.env["PUZZLE_DIR"].endswith("scenarios/width-1792/depth-00")
 
 
-def test_replacement_width_overrides_compose_with_base_config(tmp_path: Path):
+def test_replacement_width_overrides_reach_runtime_config(tmp_path: Path):
     _, _, attempts = _replacement_width_attempts(tmp_path, [2048])
     attempt = attempts[0]
 
-    config = load_experiment_config(
+    config = load_runtime_config(
         Path(__file__).parents[4] / "examples/puzzletron/configs/base.yaml",
-        overrides=attempt.command.env["DISTRIBUTED_EVAL_OVERRIDES"].splitlines(),
+        overrides=[
+            f"++input_hf_model_path={tmp_path / 'model'}",
+            *attempt.command.env["DISTRIBUTED_EVAL_OVERRIDES"].splitlines(),
+        ],
     )
 
     teacher = str(Path(attempt.command.env["PUZZLE_DIR"]) / "ckpts" / "sorted_teacher")
-    assert config["build_library"]["source_checkpoint_dir"] == teacher
-    assert config["replacement_scoring"]["source_checkpoint_dir"] == teacher
-    assert config["replacement_scoring"]["target_teacher_dir"] == teacher
+    assert config.build_replacement_library.source_checkpoint_dir == teacher
+    assert config.scoring.source_checkpoint_dir == teacher
+    assert config.scoring.target_teacher_dir == teacher
 
 
 def test_replacement_pool_completion_identity_changes_with_embedding_widths(tmp_path: Path):

--- a/tests/unit/torch/puzzletron/test_orchestration_executors.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_executors.py
@@ -1028,7 +1028,7 @@ def test_replacement_width_overrides_compose_with_base_config(tmp_path: Path):
     )
 
     teacher = str(Path(attempt.command.env["PUZZLE_DIR"]) / "ckpts" / "sorted_teacher")
-    assert config["build_replacement_library"]["source_checkpoint_dir"] == teacher
+    assert config["build_library"]["source_checkpoint_dir"] == teacher
     assert config["replacement_scoring"]["source_checkpoint_dir"] == teacher
     assert config["replacement_scoring"]["target_teacher_dir"] == teacher
 

--- a/tests/unit/torch/puzzletron/test_width_scenarios.py
+++ b/tests/unit/torch/puzzletron/test_width_scenarios.py
@@ -25,6 +25,7 @@ import pytest
 import examples.puzzletron.finalize_replacement_scoring as replacement_finalizer
 from examples.puzzletron.embedding_pipeline import (
     _project_vllm_stats_to_scenarios,
+    _scenario_overrides,
     _visible_gpu_count,
     finalize_replacement_scoring_diagnostics,
     run_embedding_stage,
@@ -38,6 +39,7 @@ from examples.puzzletron.prepare_width_scenarios import (
 from modelopt.torch.puzzletron.block_config import AttentionConfig, BlockConfig, FFNConfig
 from modelopt.torch.puzzletron.candidates import build_candidate_library, load_stats_identity_cache
 from modelopt.torch.puzzletron.depth.schema import DepthScenario
+from modelopt.torch.puzzletron.orchestration.config import _apply_override
 from modelopt.torch.puzzletron.replacement_library.build_replacement_library import (
     build_replacement_library_from_sorted_teacher,
 )
@@ -520,6 +522,8 @@ def test_embedding_build_library_projects_vllm_stats_before_and_after_workers(
 
 
 def test_embedding_pipeline_uses_public_subblock_replacement_scoring_contract(tmp_path):
+    """Build replacement-scoring commands with the current scenario-local config keys."""
+
     _write_scenario_manifest(tmp_path, 768)
     packed_token_cache = tmp_path / "dataset_cache" / "validation.tokens"
     (command,) = scenario_worker_commands(
@@ -541,20 +545,25 @@ def test_embedding_pipeline_uses_public_subblock_replacement_scoring_contract(tm
         command[command.index("--worker-stage") : command.index("--worker-stage") + 2]
     ) == ("--worker-stage", "replacement_scoring")
     overrides = [command[index + 1] for index, value in enumerate(command) if value == "--override"]
-    assert any(
-        override.endswith("/single_subblock_replacement_solutions.json")
-        and override.startswith("replacement_scoring.solutions_path=")
-        for override in overrides
+    overrides_by_key = dict(override.split("=", 1) for override in overrides)
+    assert Path(overrides_by_key["replacement_scoring.solutions_path"]).name == (
+        "single_subblock_replacement_solutions.json"
     )
-    assert any(
-        override.endswith("/single_subblock_replacement_solutions--validation")
-        and override.startswith("replacement_scoring.output_dir=")
-        for override in overrides
+    assert Path(overrides_by_key["replacement_scoring.output_dir"]).name == (
+        "single_subblock_replacement_solutions--validation"
     )
-    assert f"replacement_scoring.packed_token_cache_path={packed_token_cache}" in overrides
+    assert f"++replacement_scoring.packed_token_cache_path={packed_token_cache}" in overrides
+    assert {
+        "++replacement_scoring.source_checkpoint_dir",
+        "++replacement_scoring.target_teacher_dir",
+        "++scoring_diagnostic.scores_dir",
+        "++vllm_stats_diagnostic.stats_path",
+    } <= overrides_by_key.keys()
 
 
 def test_embedding_pipeline_launches_block_library_with_torchrun(tmp_path):
+    """Launch block-library work with one process and current runtime-stat keys."""
+
     _write_scenario_manifest(tmp_path, 768)
     (command,) = scenario_worker_commands(
         config_path="experiment.yaml",
@@ -570,6 +579,90 @@ def test_embedding_pipeline_launches_block_library_with_torchrun(tmp_path):
     assert "--nproc_per_node=1" in command
     overrides = [command[index + 1] for index, value in enumerate(command) if value == "--override"]
     assert "embedding_pruning.enabled=false" in overrides
+    scenario_teacher = tmp_path / "scenarios/width-0768/depth-00/ckpts/sorted_teacher"
+    assert f"build_library.source_checkpoint_dir={scenario_teacher}" in overrides
+    assert "++vllm_stats.runtime_stats.execution=inline" in overrides
+    assert "vllm_stats.runtime_stats.execution=inline" not in overrides
+    assert "calc_subblock_stats.runtime_stats.execution=inline" not in overrides
+
+
+def test_embedding_pipeline_scenario_overrides_compose_with_current_config(tmp_path):
+    """Apply every generated scenario override to a representative current config."""
+
+    scenario = tmp_path / "scenarios" / "width-0768" / "depth-00"
+    scenario.mkdir(parents=True)
+    (scenario / "scenario_manifest.json").write_text(
+        json.dumps({"width": 768, "bypass_checkpoint": str(tmp_path / "accepted-bypass")})
+    )
+    packed_token_cache = tmp_path / "dataset_cache" / "validation.tokens"
+    overrides = _scenario_overrides(
+        {
+            "replacement_scoring": {
+                "granularity": "subblock",
+                "packed_token_cache_path": str(packed_token_cache),
+            }
+        },
+        scenario,
+    )
+
+    config = {
+        "puzzle_dir": "/initial/puzzle",
+        "experiment": {"dir": "/initial/puzzle"},
+        "teacher_dir": "/initial/teacher",
+        "convert": {"teacher_dir": "/initial/teacher"},
+        "bypass": {"enabled": True},
+        "embedding_pruning": {"enabled": True},
+        "replacement_library_path": "/initial/replacement_library.json",
+        "build_library": {"source_checkpoint_dir": "/initial/teacher"},
+        "vllm_stats": {"runtime_stats": {"enabled": True}},
+        "replacement_scoring": {
+            "teacher_dir": "/initial/teacher",
+            "solutions_path": "/initial/solutions.json",
+            "output_dir": "/initial/scores",
+        },
+    }
+    for override in overrides:
+        _apply_override(config, override)
+
+    teacher = scenario / "ckpts" / "sorted_teacher"
+
+    # Scenario workers must use only scenario-local inputs and outputs.
+    assert config["puzzle_dir"] == str(scenario)
+    assert config["experiment"]["dir"] == str(scenario)
+    assert config["teacher_dir"] == str(teacher)
+    assert config["convert"]["teacher_dir"] == str(teacher)
+    assert config["replacement_library_path"] == str(scenario / "replacement_library.json")
+    assert config["build_library"]["source_checkpoint_dir"] == str(teacher)
+
+    # Composite workers disable stages already completed by the parent campaign.
+    assert config["bypass"]["enabled"] is False
+    assert config["embedding_pruning"]["enabled"] is False
+
+    # Runtime-stat and scoring artifacts remain isolated within the scenario.
+    assert config["vllm_stats"]["runtime_stats"]["execution"] == "inline"
+    assert config["replacement_scoring"]["teacher_dir"] == str(teacher)
+    assert config["replacement_scoring"]["source_checkpoint_dir"] == str(teacher)
+    assert config["replacement_scoring"]["target_teacher_dir"] == str(teacher)
+    assert config["replacement_scoring"]["solutions_path"] == str(
+        scenario / "single_subblock_replacement_solutions.json"
+    )
+    assert config["replacement_scoring"]["output_dir"] == str(
+        scenario / "single_subblock_replacement_solutions--validation"
+    )
+    assert config["replacement_scoring"]["packed_token_cache_path"] == str(packed_token_cache)
+    assert config["replacement_scoring"]["bypass_checkpoint_dir"] == str(
+        scenario / "ckpts" / "bypass_overlay"
+    )
+    assert config["vllm_stats_diagnostic"]["stats_path"] == str(scenario / "subblock_stats.json")
+    assert config["vllm_stats_diagnostic"]["output_dir"] == str(
+        scenario / "artifacts/vllm_stats_diagnostic"
+    )
+    assert config["scoring_diagnostic"]["scores_dir"] == str(
+        scenario / "single_subblock_replacement_solutions--validation"
+    )
+    assert config["scoring_diagnostic"]["output_dir"] == str(
+        scenario / "artifacts/scoring_diagnostic"
+    )
 
 
 def test_embedding_pipeline_skips_composite_work_on_nonzero_rank(tmp_path, monkeypatch):
@@ -614,7 +707,7 @@ def test_embedding_pipeline_routes_width_local_bypass_overlay(tmp_path):
 
     overrides = [command[index + 1] for index, value in enumerate(command) if value == "--override"]
     assert (
-        "replacement_scoring.bypass_checkpoint_dir="
+        "++replacement_scoring.bypass_checkpoint_dir="
         f"{tmp_path}/scenarios/width-0768/depth-00/ckpts/bypass_overlay"
     ) in overrides
 


### PR DESCRIPTION
### What does this PR do?

PuzzleTron lacks a repeatable GPU contract spanning campaign setup through resumed execution, so integration regressions otherwise surface only in manual runs. This change adds hermetic tiny-Qwen lifecycle coverage and a dedicated Nox entrypoint that validate setup, optimization, serving, evaluation, distillation, artifact publication, reporting, and a no-work resume.

Type of change: new tests

#### Review map

1. The lifecycle fixture creates local model, tokenizer, and dataset inputs, bounds the campaign for one GPU, and exercises the complete generated setup without external model downloads.
2. Runtime composition keeps the lifecycle in its own `gpu_puzzletron` Nox session, excludes it from generic GPU collection, and validates current scenario override keys and precedence.
3. Serving compatibility exposes `vllm._C` only for the stable-libtorch extension layout, preserves preexisting module state in compatibility tests, and lets AIPerf resolve the generated local tokenizer.

The container recipe, image resolution, and automatic CI workflow are separate infrastructure work. This PR provides the executable Nox contract without adding workflow scheduling.

### Testing

- `nox -s gpu_puzzletron` completed the full single-GPU lifecycle, including successful AIPerf requests and resume validation.
- Focused Python 3.12 unit validation covered compatibility-test state isolation for preexisting `vllm._C` modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running Puzzletron workflows with stable-libtorch vLLM builds.
  - Added compact Qwen configurations and local end-to-end campaign setup for pruning and serving smoke tests.
  - Added dedicated validation for single-GPU CUDA environments and campaign execution.

- **Bug Fixes**
  - Improved scenario configuration so scoring, diagnostics, caching, and runtime statistics use isolated paths.
  - Updated replacement-scoring configuration to use current library settings.

- **Tests**
  - Expanded coverage for campaign resumability, artifact integrity, checkpoint inference, reporting, and vLLM compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->