### PR TITLE
MTP support in per-layer fused export

### DIFF
--- a/examples/hf_ptq/hf_ptq.py
+++ b/examples/hf_ptq/hf_ptq.py
@@ -78,6 +78,7 @@ from modelopt.torch.export import (
     has_spec_opt,
     save_expert_token_count_table,
 )
+from modelopt.torch.export.layerwise_export import MTP_EXTRA_STATE_ATTR
 from modelopt.torch.export.model_utils import get_language_model_from_vl, is_multimodal_model
 from modelopt.torch.quantization.config import need_calibration
 from modelopt.torch.quantization.plugins.accelerate import init_quantized_weights
@@ -771,7 +772,7 @@ def mono_quantize(
         warnings.warn("Skipping quantization: model is already quantized.")
 
 
-def assert_layerwise_export_compatible(args, full_model, mtp_layer_prefixes) -> None:
+def assert_layerwise_export_compatible(args, full_model) -> None:
     """Refuse layerwise export before calibration starts, not after it writes a checkpoint.
 
     Layerwise export writes the finished checkpoint during calibration, so anything that
@@ -784,13 +785,6 @@ def assert_layerwise_export_compatible(args, full_model, mtp_layer_prefixes) -> 
             "extracted language model, so the shards and config.json would describe that "
             "submodel rather than the full VLM, and the VLM export path would then "
             "overwrite config.json with the unquantized source config."
-        )
-
-    if mtp_layer_prefixes:
-        raise NotImplementedError(
-            f"layerwise.export_dir does not support models with MTP layers {mtp_layer_prefixes}: "
-            "their exclusions and any orphaned MTP weights are applied after calibration, by "
-            "which point every shard and the quant config are already written."
         )
 
     if has_spec_opt(full_model):
@@ -933,12 +927,13 @@ def export_quantized(
                     full_model._mtp_layer_prefixes = mtp_layer_prefixes
 
                 if args.layerwise_export:
-                    if mtp_state_dict:
+                    staged = getattr(full_model, MTP_EXTRA_STATE_ATTR, None) or {}
+                    if mtp_state_dict.keys() - staged.keys():
                         raise NotImplementedError(
-                            "layerwise.export_dir does not support models with MTP weights: "
-                            "they are loaded after calibration has already written every "
-                            "shard, so they would be missing from the checkpoint. Export "
-                            "without layerwise.export_dir."
+                            "layerwise.export_dir found MTP weights it did not stage before "
+                            f"calibration: {sorted(mtp_state_dict.keys() - staged.keys())[:4]}. "
+                            "Every shard is already written, so they cannot be added now. "
+                            "Export without layerwise.export_dir."
                         )
                     # Calibration already wrote every shard, the index and the configs.
                     print(f"Layerwise export already wrote the checkpoint to {export_path}")
@@ -1353,10 +1348,20 @@ def quantize_main(
                 quant_cfg["quant_cfg"].append({"quantizer_name": pattern, "enable": False})
                 print(f"Excluding MTP layer from quantization: {pattern}")
 
+        if args.layerwise_export and mtp_layer_prefixes:
+            # Per-layer export writes the checkpoint *during* calibration, so the MTP
+            # weights have to be in place first. load_mtp_weights only fills existing slots
+            # and hands back the rest, so running it early is safe; the orphans are stashed
+            # for finalize(), which owns the tail shard.
+            _, mtp_state_dict = load_mtp_weights(full_model, args.pyt_ckpt_path)
+            if mtp_state_dict:
+                setattr(full_model, MTP_EXTRA_STATE_ATTR, mtp_state_dict)
+                print(f"Layerwise export: staged {len(mtp_state_dict)} orphaned MTP tensors")
+
         # Before resolve_checkpoint_dir, which hashes the config: with the placeholder
         # still in it, two --export_path values would share one checkpoint dir.
         if args.layerwise_export:
-            assert_layerwise_export_compatible(args, full_model, mtp_layer_prefixes)
+            assert_layerwise_export_compatible(args, full_model)
             quant_cfg = set_layerwise_export_dir(quant_cfg, args.export_path)
             print(f"Layerwise export enabled: writing quantized shards to {args.export_path}")
             # The shards are only a resume artifact if the manifest that names the resume

--- a/modelopt/torch/export/layerwise_export.py
+++ b/modelopt/torch/export/layerwise_export.py
@@ -60,6 +60,12 @@ SUPPORTED_FORMATS = FUSION_FREE_FORMATS | _PER_LAYER_FUSABLE_FORMATS
 _TAIL_SHARD = "model-tail.safetensors"
 _INDEX_FILE = "model.safetensors.index.json"
 
+#: Set by the caller on the model, holding MTP tensors that have no slot in
+#: ``state_dict()``. finalize() runs inside calibration, so the caller cannot pass them as
+#: an argument; this follows the ``_mtp_layer_prefixes`` convention already used to hand
+#: MTP information across the same boundary.
+MTP_EXTRA_STATE_ATTR = "_mtp_extra_state_dict"
+
 
 def layer_shard_name(layer_idx: int) -> str:
     """Shard filename for one decoder layer, keyed by index so a re-export overwrites."""
@@ -353,6 +359,13 @@ class LayerwiseExporter:
             if name.startswith(skip_prefixes) or name in seen_keys:
                 continue
             self._collect(tail, name, tensor)
+
+        # Tensors the model never held (e.g. orphaned MTP weights), already in export
+        # form, so only the hub-name reversal applies. The stash is the layerwise route:
+        # calibration owns the finalize() call, so the caller cannot pass them directly.
+        for name, tensor in (getattr(model, MTP_EXTRA_STATE_ATTR, None) or {}).items():
+            mapped = self._name_mapper(name) if self._name_mapper is not None else name
+            tail.setdefault(mapped, tensor.detach().contiguous().cpu())
 
         save_file(tail, str(self._export_dir / _TAIL_SHARD))
         self._write_index()

--- a/tests/gpu/torch/export/test_layerwise_export.py
+++ b/tests/gpu/torch/export/test_layerwise_export.py
@@ -26,7 +26,11 @@ from _test_utils.torch.transformers_models import get_tiny_llama, get_tiny_qwen3
 from safetensors.torch import load_file
 
 import modelopt.torch.quantization as mtq
-from modelopt.torch.export.layerwise_export import LayerwiseExporter, layer_shard_name
+from modelopt.torch.export.layerwise_export import (
+    MTP_EXTRA_STATE_ATTR,
+    LayerwiseExporter,
+    layer_shard_name,
+)
 from modelopt.torch.export.unified_export_hf import export_hf_checkpoint
 
 NUM_LAYERS = 4
@@ -427,6 +431,32 @@ def test_moe_export_matches(tmp_path):
 
     _assert_same_checkpoint(_load_checkpoint(baseline_dir), _load_checkpoint(export_dir))
     _assert_same_quant_config(baseline_dir, export_dir)
+
+
+def test_orphaned_mtp_tensors_reach_the_tail_shard(tmp_path):
+    """MTP weights with no slot in state_dict() must still land in the checkpoint.
+
+    finalize() runs inside calibration, so hf_ptq cannot pass them as an argument; it
+    stashes them on the model and the exporter picks them up. Without that they are
+    silently absent from a checkpoint that otherwise looks complete.
+    """
+    export_dir = tmp_path / "fused"
+    model = _build_model()
+    orphans = {
+        "mtp.layers.0.weight": torch.ones(4, 4, dtype=torch.bfloat16),
+        "mtp.norm.weight": torch.ones(4, dtype=torch.bfloat16),
+    }
+    setattr(model, MTP_EXTRA_STATE_ATTR, orphans)
+
+    mtq.quantize(model, _layerwise_cfg(export_dir, tmp_path / "ckpt"), _calib)
+
+    exported = _load_checkpoint(export_dir)
+    for key, value in orphans.items():
+        assert key in exported, f"{key} missing from the exported checkpoint"
+        assert torch.equal(exported[key].cpu(), value)
+
+    weight_map = json.loads((export_dir / "model.safetensors.index.json").read_text())["weight_map"]
+    assert set(orphans) <= set(weight_map), "orphans written but left out of the index"
 
 
 def test_export_consumes_the_model_without_affecting_the_checkpoint(tmp_path):


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

Stacked on #2136, which refuses MTP models outright. This lifts that refusal.

**Why the refusal existed, and what changed.** It said MTP exclusions and orphaned MTP
weights are applied after calibration, by which point per-layer export has already written
every shard and the quant config. Two thirds of that stopped being true:

- **Exclusions** are applied by the pre-quantize loop in `hf_ptq.py`, which appends
  `{"quantizer_name": "*<prefix>*", "enable": False}` to `quant_cfg`. #2136 already derives
  those prefixes from the checkpoint index *before* calibration, so MTP modules are simply
  never quantized.
- **The exported quant config** already lists them: `finalize()` calls `_add_mtp_exclusions`.
- **Inlined MTP layers** (`model.layers.{N}`, GLM-5.1 / DeepSeek-V3) are returned by
  `get_homogeneous_hf_decoder_layers` like any other decoder layer, so they already get
  their own shard — unquantized, because they are excluded.

That leaves **orphans**: MTP tensors with no slot in `model.state_dict()`, which the
separate-file conventions produce. `load_mtp_weights()` only fills existing slots and hands
the rest back, so it is safe to run before `mtq.quantize`. Per-layer export now does that
and stashes the leftovers on the model under `MTP_EXTRA_STATE_ATTR`; `finalize()` feeds them
into the `extra_state_dict` path it already had.

The stash exists because **calibration owns the `finalize()` call**, so `hf_ptq` cannot pass
them as an argument. `_mtp_layer_prefixes` is already carried across that same boundary the
same way, so this follows an existing convention rather than inventing one.

The blanket refusal becomes a narrow one: if the post-calibration load finds keys that were
not staged, the run still fails, because the shards are written by then and nothing can be
added to them.

### Usage

No new flags. An MTP checkpoint with `layerwise.export_dir` set now exports instead of
raising `NotImplementedError`.

### Testing

`tests/gpu/torch/export/test_layerwise_export.py` — **25 passed**. One new test pins that
stashed orphans reach the tail shard *and* the index; it fails with
`mtp.layers.0.weight missing from the exported checkpoint` when the stash pickup is stubbed
out, so it is not vacuous.

`tests/unit/recipe` 282 · `tests/unit/torch/export` 172 · `tests/examples/hf_ptq` 36 ·
pre-commit clean.

**Draft, because the coverage is narrower than the feature.** The test exercises orphan
delivery, which is the mechanism this PR changes. It does not exercise the four conventions
`load_mtp_weights` supports — inlined (GLM-5.1, DeepSeek-V3), standalone `mtp.safetensors`
(GLM-4.7), indexed `mtp.*` tail shard (Qwen3-Next) — none of which has a local fixture.

Two risks I have not been able to close:

1. Running `load_mtp_weights` before quantization may split in-slot vs orphan differently
   than running it after, since `model.state_dict()` changes once quantizers are inserted.
   The late guard compares key sets precisely because of this, but a real MTP model should
   confirm the split is what we expect.
2. An inlined MTP layer surviving as a decoder layer should produce a correctly named shard;
   that path is reasoned about, not observed.

A full export on a real MTP checkpoint is the missing step before this leaves draft.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — only reachable with `layerwise.export_dir` set,
  which is opt-in. Non-layerwise MTP export is untouched.
- If you copied code from any other sources or added a new PIP dependency, did you follow
  guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ⚠️ — one, covering the mechanism; the conventions
  are unverified (see Testing).
- Did you update Changelog?: ❌ — #2136 carries the `layerwise.export_dir` entry and lists
  MTP as refused; it needs amending once merge order is settled.
- Did you get Claude approval on this PR?: ❌ — not yet run.

### Additional Information

Depends on #2136 and must not merge before it. #2136's refusal test and its real-checkpoint
verification both assert that MTP is refused, so whichever lands second needs them
reconciled.
