### PR TITLE
Pin nemo_automodel below 0.6 for the fastgen example

### DIFF
--- a/examples/diffusers/fastgen/requirements.txt
+++ b/examples/diffusers/fastgen/requirements.txt
@@ -7,7 +7,9 @@
 # multi_tier_bucketing,text_to_video_dataset}). The diffusion extras install diffusers +
 # accelerate with matching pins. Bounded to a tested range (0.4.0 == the validated commit);
 # fastgen_data/__init__.py adds a runtime guard with an actionable message if the helpers move.
-nemo_automodel[diffusion]>=0.4.0,<1.0
+# Capped below 0.6.0, which dropped ``recipes.diffusion.train.is_main_process`` (imported by
+# dmd2_recipe.py) without a replacement.
+nemo_automodel[diffusion]>=0.4.0,<0.6
 
 # Optional but recommended for the smoke logs.
 wandb


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`nemo_automodel` 0.6.0 removed `nemo_automodel.recipes.diffusion.train.is_main_process` without a replacement (it was a three-line rank-zero predicate in 0.5.0, and 0.6.0 defines no equivalent anywhere in the package). `examples/diffusers/fastgen/dmd2_recipe.py` imports it, so the example's import guard fires and **every** test in `tests/examples/diffusers/` errors at collection:

```
ImportError: cannot import name 'is_main_process' from 'nemo_automodel.recipes.diffusion.train'
  tests/examples/diffusers/fastgen/test_resume_dataloader.py
E   ImportError: The DMD2 fastgen example requires `nemo_automodel`. ...
collected 42 items / 1 error
```

The requirement was `>=0.4.0,<1.0`, so CI picked 0.6.0 as soon as it was published and the `onnx (diffusers)` job started failing on every PR (e.g. runs 33020467654, 33019418460, 33010815298, 33007613265, 33006944292 — all unrelated branches). Capping at `<0.6` restores the tested range.

Every other `nemo_automodel` symbol the example imports still exists in 0.6.0 (`_diffusers.auto_diffusion_pipeline.NeMoAutoDiffusionPipeline`, `recipes.diffusion.train.TrainDiffusionRecipe`, and the four `components.datasets.diffusion.*` helpers), so `is_main_process` is the only blocker; the alternative is defining that predicate locally and widening the cap again, which is worth doing separately if the example is meant to track 0.6.

### Usage

```bash
pip install -r examples/diffusers/fastgen/requirements.txt
```

### Testing

Reproduced the break by diffing the published wheels: `is_main_process` is defined at `nemo_automodel/recipes/diffusion/train.py:692` in 0.5.0 and absent from 0.6.0 (`grep -rn "def is_main_process"` over the unpacked 0.6.0 wheel returns nothing). Confirmed the remaining imported symbols are all still present in 0.6.0.

CI on this PR exercises the fix directly: the `onnx (diffusers)` job installs from this requirements file and is the job that has been failing.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A — existing dependency, tightened bound.
- Did you write any new necessary tests?: N/A — the existing `tests/examples/diffusers/` suite is what this unblocks.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — dependency-pin fix for a break introduced and fixed within the same unreleased cycle.
- Did you get Claude approval on this PR?: ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency compatibility for the FastGen diffusion example.
  * Prevented installation of versions that could cause the example to fail at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->