### PR TITLE
examples/csx_qat: 3-bit CSX QAT for GPT-OSS-20B on tulu@8k

### DIFF
--- a/examples/csx_qat/README.md
+++ b/examples/csx_qat/README.md
@@ -1,0 +1,135 @@
+# 3-bit CSX QAT for GPT-OSS-20B on tulu@8k
+
+Recovers accuracy lost to 3-bit CSX post-training quantization by finetuning with
+the quantizer in the forward loop, then exports the result in QLab deploy format.
+
+The CSX scheme (rectangular `dH x dF` groups, per-PE codebooks, signed fp16
+scales) and the trainable FakeQuantize come from QLab; Model-Optimizer supplies
+the SFT pipeline and the MoE quantizer plumbing. **No Model-Optimizer source
+changes are needed** — this directory is only the example wiring.
+
+## Setup
+
+```bash
+pip install -U "nvidia-modelopt[hf]"
+pip install -e /path/to/quantization_tool     # QLab, branch ak/csx-fakequant-qat
+```
+
+Two GPT-OSS-specific notes:
+
+* It cannot use `flash_attention_2` or `sdpa` at all (learned attention sinks).
+  Use `kernels-community/vllm-flash-attn3`, which needs `kernels>=0.15.2` —
+  conflicting with the `<0.13` pin in `examples/gpt-oss/requirements.txt`.
+  `eager` also works but OOMs at larger eval batches.
+* Released `nvidia-modelopt` wheels may not ship the carrier recipe
+  `general/ptq/mxfp4_mlp_weight_only`; it is a thin wrapper over a preset that
+  *is* shipped, so copy it from `main` if `load_recipe` fails.
+
+## Run
+
+```bash
+# 0. corpus: 8,000 train / 500 held-out from allenai/tulu-3-sft-mixture (~5.7M tokens)
+python examples/csx_qat/prepare_tulu8k.py --out /scratch/tulu8k
+
+# 1. PTQ: fit the artifacts the QAT run will train under
+python examples/csx_qat/fit_csx.py --model openai/gpt-oss-20b --num-bits 3 \
+    --out artifacts/gptoss20b_csx3bit.pt
+
+# 2. the CEILING: high-precision SFT, no quantization
+accelerate launch --config_file examples/gpt-oss/configs/zero3.yaml \
+    examples/csx_qat/sft_csx.py \
+    --config examples/csx_qat/configs/sft_gptoss20b_tulu8k.yaml \
+    --dataset_name /scratch/tulu8k --csx_artifacts none \
+    --output_dir out/ceiling
+
+# 3. QAT
+accelerate launch --config_file examples/gpt-oss/configs/zero3.yaml \
+    examples/csx_qat/sft_csx.py \
+    --config examples/csx_qat/configs/sft_gptoss20b_tulu8k.yaml \
+    --dataset_name /scratch/tulu8k \
+    --csx_artifacts artifacts/gptoss20b_csx3bit.pt \
+    --output_dir out/csx3-qat
+
+# 4. the FLOOR: PTQ applied to the *ceiling* model, and the deployed QAT model.
+#    Consolidate each run's ZeRO shards first (see "Checkpoints" below).
+python examples/csx_qat/eval_csx.py --model out/ceiling-consolidated \
+    --dataset /scratch/tulu8k --label ceiling
+python examples/csx_qat/eval_csx.py --model out/ceiling-consolidated \
+    --dataset /scratch/tulu8k --csx-artifacts artifacts/ptq_on_ceiling.pt \
+    --csx-bake --label floor
+python examples/csx_qat/eval_csx.py --model out/csx3-qat-consolidated \
+    --dataset /scratch/tulu8k --csx-artifacts artifacts/gptoss20b_csx3bit.pt \
+    --csx-bake --label qat_deployed
+
+# 5. export for deployment
+python examples/csx_qat/export_qlab.py --model out/csx3-qat-consolidated \
+    --artifacts artifacts/gptoss20b_csx3bit.pt --out out/csx3-deploy
+```
+
+Note the floor is PTQ fitted on the **finetuned** model, not the base model — fit
+step 1 again against `out/ceiling-consolidated` to produce
+`artifacts/ptq_on_ceiling.pt`. That distinction is not cosmetic; see below.
+
+## Measured results
+
+1 node, 8x H100-80GB, ZeRO-3, 250 steps (1 epoch, effective batch 32). Corpus
+loss is token-weighted over the corpus's own 500-example held-out split
+(346,085 label tokens). PTQ fit SQNR 12.5-13.4 dB.
+
+| condition | loss | token acc |
+|---|---|---|
+| BF16 + SFT (ceiling) | 0.7917 | 0.7991 |
+| CSX 3-bit PTQ on the SFT model (floor) | 0.8717 | 0.7825 |
+| **CSX 3-bit QAT, deployed** | **0.8270** | **0.7926** |
+
+QAT closes **55.9%** of the loss gap and 60.8% of the accuracy gap. For contrast,
+4-bit on the same corpus closes 50.0% / 62.9% from a much smaller gap (0.0270 vs
+0.0800), and 3-bit QAT (0.8270) still does not beat plain 4-bit PTQ (0.8187) —
+3-bit's gap starts ~3x larger, so it recovers more but does not catch up.
+
+Peak memory 43.8 GiB/rank at `CSX_EXPERT_CHUNK=4` (3-bit; 45.3 GiB at 4-bit).
+`CSX_EXPERT_CHUNK` bounds the op's peak by chunking the expert dimension and is
+bit-identical for any value.
+
+## Parallelism
+
+| | peak/rank | notes |
+|---|---|---|
+| DeepSpeed ZeRO-3 | 43.8 GiB | `CSX_EXPERT_CHUNK=4`. Use `examples/gpt-oss/configs/zero3.yaml` — it sets `deepspeed_moe_layer_cls_names`, without which ZeRO-3 traces per-expert parameter access (which varies with routing) and ranks fail with "Detected a disagreement on list length" |
+| FSDP2 | 60.9 GiB | `configs/fsdp2.yaml`, needs `CSX_EXPERT_CHUNK=2`. Verified for 1 step, not a full equivalence run. Known issue: completes training, eval and save, then hangs at teardown on a stuck NCCL collective — kill it afterwards |
+
+## Checkpoints
+
+**Do not trust the trainer's own save.** On transformers <= 5.14,
+`save_pretrained` for an MXFP4-native model silently collapses every layer's
+expert weights into two prefix-less keys named `gate_up_proj$` / `down_proj$`,
+dropping 19.1B of 20.9B parameters with no error. Reconstruct from the ZeRO
+shards instead:
+
+```bash
+python out/csx3-qat/checkpoint-*/zero_to_fp32.py \
+    out/csx3-qat/checkpoint-250 out/csx3-qat-consolidated --safe_serialization
+```
+
+Then copy `config.json` and the tokenizer files across, and sanity-check that all
+24 layers' expert weights are present.
+
+## Pitfalls
+
+**A QAT checkpoint is only valid with its quantizer.** Straight-through training
+moves weights to positions that are good *after* snapping to the codebook, not in
+full precision. Measured at 3-bit: 1.0897 unquantized versus 0.8733 deployed —
+i.e. the bare weights are worse than the PTQ floor they started from. Always
+export before evaluating or shipping.
+
+**Do not measure quantization damage on a base model.** On a model not adapted to
+the eval distribution, cross-entropy and token accuracy move *opposite* to
+damage: CSX 3-bit (12.4 dB SQNR) scored better than 4-bit (18.7 dB), which scored
+better than BF16. Weight noise raises entropy on a format the base model was
+never trained on. Take the PTQ reference on the finetuned model, and cross-check
+with KL against the unquantized model plus top-1 agreement.
+
+**Quote recovery with its denominator.** How much of the gap QAT closes depends
+strongly on how quantization-sensitive the target distribution is: the same 4-bit
+scheme closes 17.5% on one corpus and 50.0% on another. Report the ceiling, the
+floor and the absolute recovery, not a bare percentage.

--- a/examples/csx_qat/configs/fsdp2.yaml
+++ b/examples/csx_qat/configs/fsdp2.yaml
@@ -1,0 +1,30 @@
+# FSDP2 counterpart to the example's zero3.yaml, for plan item 2's parallelism
+# requirement. Mirrors the ZeRO-3 setup so the two are comparable:
+#   - transformer_cls_names_to_wrap: GptOssDecoderLayer is the FSDP analogue of
+#     zero3.yaml's deepspeed_moe_layer_cls_names, and matters for the same reason:
+#     the whole MoE block must be one wrap unit so the expert weights are fully
+#     unsharded inside its forward, where fake-quant needs them.
+#   - FULL_STATE_DICT so save_model produces a consolidated checkpoint.
+#   - bf16 mixed precision, matching the ZeRO-3 runs.
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+enable_cpu_affinity: false
+machine_rank: 0
+main_training_function: main
+mixed_precision: bf16
+num_machines: 1
+num_processes: gpu
+rdzv_backend: static
+same_network: true
+use_cpu: false
+fsdp_config:
+  fsdp_version: 2
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  fsdp_transformer_layer_cls_to_wrap: GptOssDecoderLayer
+  fsdp_reshard_after_forward: true
+  fsdp_state_dict_type: FULL_STATE_DICT
+  fsdp_cpu_ram_efficient_loading: false
+  fsdp_offload_params: false
+  fsdp_activation_checkpointing: false

--- a/examples/csx_qat/configs/sft_gptoss20b_tulu8k.yaml
+++ b/examples/csx_qat/configs/sft_gptoss20b_tulu8k.yaml
@@ -1,0 +1,30 @@
+# 3-bit CSX QAT for GPT-OSS-20B on tulu@8k.
+# Hyperparameters are examples/gpt-oss/configs/sft_full.yaml verbatim except for
+# the dataset, so results are comparable with the MXFP4 baseline there.
+model_name_or_path: openai/gpt-oss-20b
+attn_implementation: kernels-community/vllm-flash-attn3
+dtype: bfloat16
+
+# Built by examples/csx_qat/prepare_tulu8k.py -- override on the CLI.
+dataset_name: /scratch/tulu8k
+dataset_num_proc: 8
+dataset_test_split: test
+
+learning_rate: 2.0e-5
+gradient_checkpointing: true
+num_train_epochs: 1.0
+logging_steps: 1
+per_device_train_batch_size: 2
+per_device_eval_batch_size: 2
+gradient_accumulation_steps: 2        # 2 x 2 x 8 GPUs = effective batch 32
+max_length: 4096
+warmup_steps: 0.03
+lr_scheduler_type: cosine_with_min_lr
+lr_scheduler_kwargs:
+  min_lr_rate: 0.1
+output_dir: out/gptoss20b-csx3-qat
+report_to: []
+seed: 42
+eval_on_start: true
+eval_strategy: steps
+eval_steps: 50

--- a/examples/csx_qat/eval_csx.py
+++ b/examples/csx_qat/eval_csx.py
@@ -1,0 +1,175 @@
+"""Common accuracy harness for the QAT experiment series.
+
+Corpus-level (token-weighted) loss / ppl / token-accuracy on the
+HuggingFaceH4/Multilingual-Thinking test split -- the same 100 examples the
+ModelOpt example evaluates on. Token-weighted so the number does NOT depend on
+batch size or world size, unlike Trainer's batch-averaged eval_loss.
+
+Usage:
+  python qeval.py --model <path|hub-id> [--label NAME]
+                  [--quantize-recipe general/ptq/mxfp4_mlp_weight_only]
+                  [--attn eager|kernels-community/vllm-flash-attn3]
+                  [--batch 4] [--json out.json]
+
+--quantize-recipe applies ModelOpt PTQ in-memory before evaluating (this is how
+the "PTQ reference" numbers are produced). Omit it to evaluate the checkpoint
+as-is; an existing modelopt_state.pth in the model dir is auto-restored.
+"""
+import argparse, json, os, sys, time
+import torch
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--model", required=True)
+ap.add_argument("--label", default=None)
+ap.add_argument("--quantize-recipe", default=None)
+ap.add_argument("--attn", default="kernels-community/vllm-flash-attn3")
+ap.add_argument("--batch", type=int, default=4)
+ap.add_argument("--dataset", default="HuggingFaceH4/Multilingual-Thinking",
+                help="Hub id or a load_from_disk path. A DatasetDict with an "
+                     "explicit test split is used as-is; otherwise train is "
+                     "split 90/10 with seed 42 (matching the example).")
+ap.add_argument("--max-length", type=int, default=4096)
+ap.add_argument("--json", default=None)
+ap.add_argument("--csx-bake", action="store_true",
+                help="For PTQ eval: write the fake-quantized values straight into "
+                     "the expert weights and evaluate a plain model. Exactly "
+                     "equivalent to a frozen quantizer (PTQ is static) but avoids "
+                     "ModelOpt's per-forward weight cache and all temporaries.")
+ap.add_argument("--csx-artifacts", default=None,
+                help="Path to csx_Nbit_artifacts.pt; installs CSX quantizers "
+                     "(implies the MXFP4 recipe as a carrier for the wrappers).")
+args = ap.parse_args()
+
+import modelopt.torch.opt as mto
+mto.enable_huggingface_checkpointing()
+import modelopt.torch.quantization as mtq
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig, Mxfp4Config
+from datasets import load_dataset
+from trl import SFTConfig, SFTTrainer
+
+def orig_quant_method(p):
+    c = AutoConfig.from_pretrained(p)
+    qc = getattr(c, "quantization_config", None)
+    return qc.get("quant_method") if qc else None
+
+# Pin to one device rather than device_map="auto": when other tenants occupy the
+# card, "auto" silently offloads part of the model to CPU and installs accelerate
+# hooks, which wrap forward in a functools.partial and break callers that
+# introspect model.forward.__func__. Better to fail loudly than measure a
+# half-offloaded model.
+kw = dict(dtype=torch.bfloat16, attn_implementation=args.attn,
+          device_map={"": 0}, use_cache=False)
+if orig_quant_method(args.model) == "mxfp4":
+    kw["quantization_config"] = Mxfp4Config(dequantize=True)
+
+t0 = time.time()
+model = AutoModelForCausalLM.from_pretrained(args.model, **kw).eval()
+tok = AutoTokenizer.from_pretrained(args.model)
+def _mem(tag):
+    if torch.cuda.is_available():
+        tot = sum(torch.cuda.memory_allocated(i) for i in range(torch.cuda.device_count()))
+        print(f"[qeval] mem after {tag}: {tot/2**30:.1f} GiB across "
+              f"{torch.cuda.device_count()} GPU(s)", flush=True)
+
+print(f"[qeval] loaded in {time.time()-t0:.0f}s", flush=True)
+_mem("load")
+
+def _load_eval_ds(name):
+    from datasets import load_from_disk
+    try:
+        d = load_from_disk(name)
+    except Exception:
+        d = load_dataset(name)
+    if "test" in d:
+        return d
+    return d["train"].train_test_split(test_size=0.1, seed=42)
+
+ds = _load_eval_ds(args.dataset)
+print(f"[qeval] eval split: {args.dataset} n={len(ds['test'])}", flush=True)
+
+if args.csx_artifacts and args.csx_bake:
+    # Static PTQ: bake fake-quantized weights in place, no wrappers needed.
+    from qlab.qat import csx_fake_quantize
+    blob = torch.load(args.csx_artifacts, map_location="cpu", weights_only=False)
+    geom, arts = blob["geometry"], blob["artifacts"]
+    baked = 0
+    with torch.no_grad():
+        for mname, mod in model.named_modules():
+            for proj, (dF, dH) in geom.items():
+                if not hasattr(mod, proj):
+                    continue
+                key = f"{mname}.{proj}"
+                if key not in arts:
+                    continue
+                w = getattr(mod, proj)
+                wt = w.detach().transpose(-1, -2).contiguous()
+                cb = arts[key]["codebook"].to(w.device)
+                qs = arts[key]["qscale"].to(w.device)
+                q = csx_fake_quantize(wt, cb, qs, dF, dH)
+                w.data.copy_(q.transpose(-1, -2))
+                del wt, cb, qs, q
+                baked += 1
+    sq = blob.get("sqnr_db", {})
+    gu = [v for k, v in sq.items() if "gate_up" in k]
+    dp = [v for k, v in sq.items() if "down_proj" in k]
+    print(f"[qeval] baked {baked} CSX {blob['num_bits']}-bit expert weights; "
+          f"fit SQNR gate_up={sum(gu)/max(len(gu),1):.2f} dB "
+          f"down_proj={sum(dp)/max(len(dp),1):.2f} dB", flush=True)
+    assert baked == 48, f"expected 48 baked tensors, got {baked}"
+    del blob, arts
+    _mem("CSX bake")
+    args.csx_artifacts = None      # don't also install live quantizers
+
+if args.quantize_recipe or args.csx_artifacts:
+    # PTQ reference: apply the recipe in-memory, no training. For CSX the MXFP4
+    # recipe is only a carrier -- it builds the _QuantGptOssExperts wrappers and
+    # selects exactly the expert weights, then we swap in CSX quantizers.
+    from modelopt.recipe import load_recipe
+    recipe = args.quantize_recipe or "general/ptq/mxfp4_mlp_weight_only"
+    cfg = load_recipe(recipe).quantize
+    model = mtq.quantize(model, cfg, None)   # weight-only + dynamic -> no calib
+    print(f"[qeval] applied PTQ recipe {recipe}", flush=True)
+    _mem("mtq.quantize")
+
+if args.csx_artifacts:
+    from qlab.qat import install_csx_quantizers
+    blob = torch.load(args.csx_artifacts, map_location="cpu", weights_only=False)
+    n = install_csx_quantizers(model, blob["artifacts"], blob["geometry"],
+                               trainable_scale=False, num_bits=blob["num_bits"])
+    sq = blob.get("sqnr_db", {})
+    gu = [v for k, v in sq.items() if "gate_up" in k]
+    dp = [v for k, v in sq.items() if "down_proj" in k]
+    print(f"[qeval] installed {n} CSX {blob['num_bits']}-bit quantizers; "
+          f"fit SQNR gate_up={sum(gu)/max(len(gu),1):.2f} dB "
+          f"down_proj={sum(dp)/max(len(dp),1):.2f} dB", flush=True)
+    del blob
+    _mem("CSX install")
+
+nq = sum(1 for n, _ in model.named_modules() if n.endswith("_weight_quantizer"))
+print(f"[qeval] weight quantizers active: {nq}", flush=True)
+
+sft = SFTConfig(output_dir="/tmp/qeval", per_device_eval_batch_size=args.batch,
+                max_length=args.max_length, bf16=True, report_to=[],
+                dataset_num_proc=8, eval_strategy="no", seed=42)
+tr = SFTTrainer(model=model, args=sft, train_dataset=ds["train"],
+                eval_dataset=ds["test"], processing_class=tok)
+
+tot_nll = torch.zeros((), dtype=torch.float64); tot_tok = 0; correct = 0
+with torch.no_grad():
+    for i, b in enumerate(tr.get_eval_dataloader()):
+        b = {k: v.to(model.device) for k, v in b.items() if isinstance(v, torch.Tensor)}
+        labels = b.pop("labels")
+        logits = model(**b).logits.float()
+        sl, sg = labels[:, 1:], logits[:, :-1]
+        m = sl != -100
+        tot_nll += torch.nn.functional.cross_entropy(sg[m], sl[m], reduction="sum").double().cpu()
+        tot_tok += int(m.sum()); correct += int((sg[m].argmax(-1) == sl[m]).sum())
+
+loss = tot_nll.item() / tot_tok
+res = dict(label=args.label or args.model, model=args.model, dataset=args.dataset,
+           recipe=args.quantize_recipe, csx=args.csx_artifacts, quantizers=nq, tokens=tot_tok,
+           loss=round(loss, 4), ppl=round(float(torch.tensor(loss).exp()), 4),
+           token_acc=round(correct / tot_tok, 4))
+print("[qeval] RESULT " + json.dumps(res), flush=True)
+if args.json:
+    with open(args.json, "w") as f: json.dump(res, f, indent=2)

--- a/examples/csx_qat/export_qlab.py
+++ b/examples/csx_qat/export_qlab.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Put a post-QAT checkpoint into QLab deploy format.
+
+    python export_qlab.py --model <qat_ckpt_dir> \
+        --artifacts artifacts/csx_4bit.pt --out <deploy_dir>
+
+`--model` must be a loadable checkpoint. A sharded training run has to be
+consolidated first (for DeepSpeed, `checkpoint-N/zero_to_fp32.py`); note that
+transformers <=5.14 silently corrupts `save_pretrained` for MXFP4-native models,
+so prefer reconstructing from the shards over trusting the trainer's own save.
+"""
+import argparse
+import json
+
+import torch
+
+from qlab.qat import export_qat_model
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, help="QAT-trained checkpoint dir")
+    ap.add_argument("--artifacts", required=True, help=".pt from fit_artifacts.py")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--bake-weights", action="store_true",
+                    help="also write fake-quantized weight values (default: keep "
+                         "the trained weights and let the runtime apply the LUT)")
+    ap.add_argument("--device", default="cpu")
+    args = ap.parse_args()
+
+    blob = torch.load(args.artifacts, map_location="cpu", weights_only=False)
+    summary = export_qat_model(
+        args.model, blob["artifacts"], blob["geometry"], args.out,
+        num_bits=blob["num_bits"], bake_weights=args.bake_weights,
+        device=args.device,
+    )
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/csx_qat/fit_csx.py
+++ b/examples/csx_qat/fit_csx.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Fit CSX PTQ artifacts (per-PE codebook + per-block qscale) for GPT-OSS.
+
+These are the artifacts the QAT run trains under and the deploy export ships.
+The model is loaded on CPU and one expert slice at a time moves to the GPU, so
+peak GPU memory is one expert tensor rather than the whole model.
+
+    python fit_csx.py --model openai/gpt-oss-20b --num-bits 3 \
+        --out artifacts/gptoss20b_csx3bit.pt
+"""
+import argparse
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from qlab.qat import CSX_GEOMETRY, fit_csx_artifacts
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="openai/gpt-oss-20b")
+    ap.add_argument("--num-bits", type=int, default=3, choices=(3, 4))
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--outer-iters", type=int, default=3,
+                    help="joint codebook/scale rounds. Warm-started, so >1 helps: "
+                         "3 warm rounds gain ~2 dB, 3 COLD rounds lose ~1 dB.")
+    ap.add_argument("--lloyd-steps", type=int, default=50)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    kw = dict(dtype=torch.bfloat16)
+    qc = getattr(AutoConfig.from_pretrained(args.model), "quantization_config", None)
+    if qc and qc.get("quant_method") == "mxfp4":
+        # GPT-OSS ships MXFP4; dequantize so the CSX fit sees real weights.
+        from transformers import Mxfp4Config
+        kw["quantization_config"] = Mxfp4Config(dequantize=True)
+    model = AutoModelForCausalLM.from_pretrained(args.model, **kw)
+
+    artifacts, sqnrs = fit_csx_artifacts(
+        model, CSX_GEOMETRY, num_bits=args.num_bits,
+        outer_iters=args.outer_iters, lloyd_steps=args.lloyd_steps,
+        device=args.device, progress=False,
+    )
+    torch.save(
+        {"artifacts": artifacts, "num_bits": args.num_bits,
+         "geometry": CSX_GEOMETRY, "sqnr_db": sqnrs,
+         "outer_iters": args.outer_iters, "lloyd_steps": args.lloyd_steps},
+        args.out,
+    )
+    by_proj: dict = {}
+    for k, v in sqnrs.items():
+        by_proj.setdefault(k.rsplit(".", 1)[-1], []).append(v)
+    print(f"[fit] {len(artifacts)} expert tensors -> {args.out}")
+    for p, v in sorted(by_proj.items()):
+        print(f"[fit]   {p:<14} mean SQNR {sum(v)/len(v):.2f} dB  (n={len(v)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/csx_qat/prepare_tulu8k.py
+++ b/examples/csx_qat/prepare_tulu8k.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Build the tulu@8k SFT corpus used by the CSX QAT samples.
+
+8,000 training + 500 held-out examples from allenai/tulu-3-sft-mixture
+(~5.7M tokens at max_length 4096; 98.7% of examples fit without truncation).
+
+Evaluate in-domain on this corpus's own test split. A recovery number is only
+meaningful against a ceiling (no quantization) and a floor (PTQ applied to the
+*finetuned* model) measured on the same split -- see README.md.
+"""
+import argparse
+
+from datasets import DatasetDict, load_dataset
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--n-train", type=int, default=8000)
+    ap.add_argument("--n-test", type=int, default=500)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    d = load_dataset("allenai/tulu-3-sft-mixture")["train"].shuffle(seed=args.seed)
+    n = args.n_train + args.n_test
+    sub = d.select(range(n)).select_columns(["messages"])
+    DatasetDict(
+        {
+            "train": sub.select(range(args.n_train)),
+            "test": sub.select(range(args.n_train, n)),
+        }
+    ).save_to_disk(args.out)
+    print(f"saved {args.n_train} train / {args.n_test} test -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/csx_qat/sft_csx.py
+++ b/examples/csx_qat/sft_csx.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+"""QAT with SFT to recover accuracy lost to CSX PTQ.
+
+Runs the NVIDIA Model-Optimizer gpt-oss SFT recipe unchanged, except that the
+fake-quantization in the forward is QLab's CSX 4-/3-bit block-codebook scheme
+instead of MXFP4/NVFP4. Weights train through a straight-through estimator while
+the codebook and qscale stay frozen at their PTQ values, so the forward sees
+exactly the weights the deployed CSX kernel will produce.
+
+    accelerate launch --config_file <zero3.yaml|configs/fsdp2.yaml> sft_csx.py \
+        --config <ModelOpt>/examples/gpt-oss/configs/sft_full.yaml \
+        --model_name_or_path openai/gpt-oss-20b \
+        --csx_artifacts artifacts/csx_4bit.pt \
+        --output_dir <out>
+
+Modes for --csx_artifacts:
+    <path>   CSX QAT (the point of this script)
+    mxfp4    keep ModelOpt's MXFP4 quantizers -- the upstream baseline, useful as
+             a control since it isolates CSX from everything else in the pipeline
+    none     no quantization at all: high-precision SFT, i.e. the accuracy
+             CEILING that QAT is trying to reach
+
+Quantization happens through QATSFTTrainer's lazy path, i.e. after the
+parallelism engine has partitioned the parameters. See qlab.qat.csx_modelopt for
+why that ordering is load-bearing.
+"""
+import os
+import sys
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, Mxfp4Config
+from trl import ModelConfig, ScriptArguments, SFTConfig, SFTTrainer, TrlParser
+
+import modelopt.torch.opt as mto
+from modelopt.torch.quantization.plugins import QATSFTTrainer, QuantizationArguments
+
+from qlab.qat import CARRIER_RECIPE, install_csx_quantizers
+
+mto.enable_huggingface_checkpointing()
+
+
+class CSXQATSFTTrainer(QATSFTTrainer):
+    """QATSFTTrainer that swaps ModelOpt's weight quantizers for CSX ones.
+
+    The swap happens inside ``_quantize_model``, which the parent calls lazily
+    from ``training_step``/``prediction_step`` -- after ZeRO-3/FSDP has
+    partitioned the parameters. Quantizing before the engine is built turns the
+    expert weights into ModelOpt dynamic attributes the sharding cannot
+    partition, which on gpt-oss-20B pinned every rank at 74 GiB and OOMed.
+    """
+
+    def __init__(self, *args, csx_blob=None, csx_trainable_scale=False, **kwargs):
+        self._csx_blob = csx_blob
+        self._csx_trainable_scale = csx_trainable_scale
+        self._csx_installed = False
+        super().__init__(*args, **kwargs)
+
+    def _quantize_model(self):
+        super()._quantize_model()
+        if self._csx_blob is None or self._csx_installed:
+            return
+        blob = self._csx_blob
+        n = install_csx_quantizers(
+            self.model, blob["artifacts"], blob["geometry"],
+            trainable_scale=self._csx_trainable_scale, num_bits=blob["num_bits"],
+        )
+        self._csx_installed = True
+        if int(os.environ.get("RANK", "0")) == 0:
+            sq = blob.get("sqnr_db", {})
+            gu = [v for k, v in sq.items() if "gate_up" in k]
+            dp = [v for k, v in sq.items() if "down_proj" in k]
+            print(f"[csx-qat] {n} CSX {blob['num_bits']}-bit quantizers installed "
+                  f"(scale {'trainable' if self._csx_trainable_scale else 'frozen'}); "
+                  f"PTQ fit SQNR gate_up={sum(gu)/max(len(gu),1):.2f} dB "
+                  f"down_proj={sum(dp)/max(len(dp),1):.2f} dB", flush=True)
+
+
+def _load_dataset(script_args, training_args):
+    from datasets import load_dataset, load_from_disk
+    try:
+        ds = load_from_disk(script_args.dataset_name)
+    except Exception:
+        ds = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
+    if training_args.eval_strategy != "no" and script_args.dataset_test_split not in ds:
+        ds = ds[script_args.dataset_train_split].train_test_split(test_size=0.1, seed=42)
+    return ds
+
+
+def main(script_args, training_args, model_args, csx_artifacts, trainable_scale):
+    kw = {
+        "revision": model_args.model_revision,
+        "trust_remote_code": getattr(model_args, "trust_remote_code", False),
+        "attn_implementation": model_args.attn_implementation,
+        "dtype": getattr(model_args, "dtype", "bfloat16"),
+        "use_cache": not training_args.gradient_checkpointing,
+    }
+    from transformers import AutoConfig
+    qc = getattr(AutoConfig.from_pretrained(model_args.model_name_or_path),
+                 "quantization_config", None)
+    if qc and qc.get("quant_method") == "mxfp4":
+        kw["quantization_config"] = Mxfp4Config(dequantize=True)
+    if not (os.environ.get("WORLD_SIZE") or os.environ.get("RANK")):
+        kw["device_map"] = "auto"
+
+    model = AutoModelForCausalLM.from_pretrained(model_args.model_name_or_path, **kw)
+    tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
+    dataset = _load_dataset(script_args, training_args)
+    rank0 = int(os.environ.get("RANK", "0")) == 0
+
+    common = dict(
+        args=training_args,
+        train_dataset=dataset[script_args.dataset_train_split],
+        eval_dataset=dataset[script_args.dataset_test_split]
+        if training_args.eval_strategy != "no" else None,
+        processing_class=tokenizer,
+    )
+
+    if csx_artifacts == "none":
+        if rank0:
+            print("[csx-qat] no quantization: high-precision SFT (the ceiling)",
+                  flush=True)
+        trainer = SFTTrainer(model=model, **common)
+    else:
+        quant_args = QuantizationArguments(recipe=CARRIER_RECIPE)
+        if csx_artifacts == "mxfp4":
+            if rank0:
+                print("[csx-qat] MXFP4 QAT via QATSFTTrainer (no CSX)", flush=True)
+            trainer = QATSFTTrainer(model=model, quant_args=quant_args, **common)
+        else:
+            blob = torch.load(csx_artifacts, map_location="cpu", weights_only=False)
+            trainer = CSXQATSFTTrainer(
+                model=model, quant_args=quant_args, csx_blob=blob,
+                csx_trainable_scale=trainable_scale, **common)
+
+    trainer.train()
+    trainer.save_model(training_args.output_dir)
+    if rank0:
+        print("[csx-qat] NOTE: QAT weights are co-adapted to the quantizer and are "
+              "WORSE than PTQ when evaluated unquantized. Export with "
+              "examples/qat_sft/export_qlab.py before use.", flush=True)
+
+
+if __name__ == "__main__":
+    argv, csx_artifacts, trainable_scale = sys.argv[1:], None, False
+    rest, i = [], 0
+    while i < len(argv):
+        if argv[i] == "--csx_artifacts":
+            csx_artifacts = argv[i + 1]; i += 2
+        elif argv[i] == "--csx_trainable_scale":
+            trainable_scale = argv[i + 1].lower() in ("1", "true", "yes"); i += 2
+        else:
+            rest.append(argv[i]); i += 1
+    sys.argv = [sys.argv[0]] + rest
+    if not csx_artifacts:
+        raise SystemExit("--csx_artifacts is required (a path, 'mxfp4', or 'none')")
+
+    parser = TrlParser((ScriptArguments, SFTConfig, ModelConfig))
+    sa, ta, ma, _ = parser.parse_args_and_config(return_remaining_strings=True)
+    main(sa, ta, ma, csx_artifacts, trainable_scale)


### PR DESCRIPTION
Adds a worked example that recovers accuracy lost to CSX 3-bit post-training quantization by finetuning with the quantizer in the forward loop, then exports the result in QLab deploy format.

The CSX scheme (rectangular dH x dF groups, per-PE codebooks, signed fp16 scales) and the trainable FakeQuantize come from QLab, branch ak/csx-fakequant-qat; Model-Optimizer supplies the SFT pipeline and the MoE quantizer plumbing. No Model-Optimizer source changes are required -- this is example wiring only. The MXFP4 recipe is used as a carrier: it converts the MoE blocks and enables a weight quantizer on each expert projection, which is then given CSX semantics.

  prepare_tulu8k.py  8,000 train / 500 held-out from allenai/tulu-3-sft-mixture
  fit_csx.py         PTQ: per-PE codebook + per-block qscale
  sft_csx.py         QAT (CSX / mxfp4 baseline / no-quant ceiling)
  eval_csx.py        token-weighted corpus eval, with static-PTQ bake
  export_qlab.py     post-QAT -> QLab deploy layout
  configs/           tulu@8k SFT config and an FSDP2 accelerate config

Measured on 1 node x 8 H100-80GB, ZeRO-3, 250 steps at effective batch 32, and reproducible with eval_csx.py as shipped:

  BF16 + SFT (ceiling)                    0.7917 loss / 0.7991 acc
  CSX 3-bit PTQ on the SFT model (floor)  0.8717 / 0.7825
  CSX 3-bit QAT, deployed                 0.8270 / 0.7926   -> 55.9% of the gap

Three things the README documents because they are silent failures rather than crashes:

* A QAT checkpoint is only valid WITH its quantizer. Straight-through training leaves weights that score 1.0897 unquantized versus 0.8733 deployed, i.e. worse than the PTQ floor they started from.
* Quantization damage must not be measured on a base model: there, CE and token accuracy move opposite to damage, so 3-bit "beats" 4-bit "beats" BF16. Take the PTQ reference on the finetuned model.
* On transformers <= 5.14, save_pretrained for an MXFP4-native model collapses every layer's expert weights into two prefix-less keys named gate_up_proj$ / down_proj$, dropping 19.1B of 20.9B parameters with no error. Reconstruct from the ZeRO shards instead.

Also records that GPT-OSS cannot use flash_attention_2 or sdpa at all (attention sinks), so FA3 via kernels-community/vllm-flash-attn3 is required -- which needs kernels>=0.15.2, conflicting with the <0.13 pin in examples/gpt-oss.

### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Very short summary of changes only for new features, backward breaking changes, deprecations, or fixes for critical bugs present in previous releases. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete CSX quantization-aware training workflow for GPT-OSS-20B, including dataset preparation, model fitting, training, evaluation, and export.
  * Added support for 3-bit and 4-bit quantization, optional trainable scales, and high-precision training baselines.
  * Added evaluation reports for loss, perplexity, token accuracy, memory usage, and quantization quality.
  * Added multi-GPU training configuration and checkpoint consolidation guidance.

* **Documentation**
  * Added setup instructions, command examples, measured results, parallelism options, and troubleshooting guidance for the CSX QAT example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->