### PR TITLE
Guide users through a first Puzzletron campaign

### DIFF
--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -3,9 +3,18 @@
 Puzzletron v2 helps you explore model shapes and select a smaller, faster
 variant against your quality and deployment goals. Its guided setup creates a
 reproducible, resumable campaign that compares candidates and can optionally
-distill the selected model.
+evaluate, benchmark, materialize, or distill the selected model.
 
-## Run a campaign
+## Table of contents
+
+- [First campaign](#first-campaign)
+- [Understand the campaign stages](#understand-the-campaign-stages)
+- [Evaluate a checkpoint](#evaluate-a-checkpoint)
+- [Configure a campaign](#configure-a-campaign)
+- [Operate and recover a campaign](#operate-and-recover-a-campaign)
+- [Extend Puzzletron](#extend-puzzletron)
+
+## First campaign
 
 The supported path is to prepare the control and worker environments, generate
 a campaign, inspect and launch its smoke bundle, and then repeat the launch for
@@ -26,7 +35,7 @@ python -m pip install \
 
 GPU workers use the environment or container declared in the generated runner
 file. Prepare the [worker environment](docs/environment_setup.md) before
-launching; that guide covers the supported container, pinned CUDA and PyTorch
+launching. That guide covers supported containers, pinned CUDA and PyTorch
 packages, patched dependencies, model-specific kernels, and verification.
 
 ### 2. Generate a campaign
@@ -46,9 +55,11 @@ scheduler settings, and output directory.
 The wizard reads model configuration, not model weights, and does not submit
 jobs. It writes validated `smoke/` and `production/` bundles plus a generated
 `README.md`. Run any dataset preparation command in that generated README from
-the worker environment before launch.
+the worker environment before launch. See the
+[setup wizard guide](docs/setup_wizard.md) for profiles, hosted datasets, full
+configuration mode, generated files, and setup resume.
 
-### 3. Inspect and launch
+### 3. Inspect and launch smoke
 
 Activate the control environment and inspect the generated smoke plan:
 
@@ -64,16 +75,21 @@ python examples/puzzletron/orchestrate.py \
 
 Review the stage list, worker paths, execution strategies, resources, and
 artifact root. `--stage full` runs every stage enabled by the generated
-experiment in dependency order, including evaluation, materialization,
-benchmarking, or distillation when selected during setup. Remove `--dry-run`
-to launch the smoke campaign. After it succeeds, change `smoke` to
-`production`, inspect that plan, and launch it with the same command.
+experiment in dependency order. Remove `--dry-run` to launch the smoke
+campaign. The checked-in
+[Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md) provides a separate
+one-GPU MIP acceptance route when you need to validate that path directly.
+
+### 4. Launch production
+
+After smoke succeeds, change `smoke` to `production`, inspect that plan with
+`--dry-run`, and launch it with the same command.
 
 The experiment file owns model and algorithm choices, the runner file owns the
 worker environment, and the execution file owns per-stage orchestration. Keep
 all three together when launching or resuming a generated campaign.
 
-### 4. Resume and inspect results
+### 5. Resume and inspect results
 
 The controller shows live progress and stores durable state under
 `${puzzle_dir}/orchestration/`. Run the same command with the same three files
@@ -89,39 +105,93 @@ stages, `--once`, logging controls, security options, and recovery details, or
 [campaign reports](docs/campaign_reports.md) to regenerate and interpret a
 report.
 
-## Other workflows
+## Understand the campaign stages
 
-- **Evaluate a checkpoint without a campaign:** run
-  `python examples/puzzletron/evaluate_lmms_checkpoint.py --checkpoint
-  /path/to/checkpoint --output-dir /path/to/results/checkpoint-smoke`. See
-  [checkpoint evaluation](docs/checkpoint_evaluation.md) for task selection and
-  advanced options.
-- **Run the checked-in one-GPU MIP acceptance route:** follow the
-  [Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md). This is separate from
-  the generated end-to-end campaign above.
-- **Run with an agent:** ask an agent to use
-  [`running-puzzletron`](../../.agents/skills/running-puzzletron/SKILL.md) and
-  provide the model, dataset, compute environment, search space, resource
-  constraints, and required downstream stages.
+`--stage full` runs every stage enabled by the experiment in dependency order.
+The generated dry-run plan is the exact stage and resource list for a campaign.
+The complete pipeline is organized into these steps:
 
-## Customize and operate
+1. **Prepare inputs.** Convert the source checkpoint and, when configured,
+   tokenize the campaign dataset.
+2. **Measure pruning choices.** Collect width importance and optional depth
+   importance or vLLM runtime statistics, then sort the teacher checkpoint.
+3. **Validate and score.** Run the enabled sorting, width, slicing, and bypass
+   sanity checks; collect bypass observations; build the replacement library;
+   and score individual replacements.
+4. **Search.** Solve the configured MIP runs to select candidate model shapes
+   under parameter, memory, runtime, or quality constraints. See
+   [MIP runs](docs/mip_profiles.md) for profiles, objectives, constraints,
+   solution pools, and workload measurements.
+5. **Process selected candidates.** Configured post-MIP flows can filter,
+   evaluate, materialize, benchmark with AIPerf, and distill candidates. See
+   [post-MIP pipelines](docs/post_mip_pipeline.md) for node types, branching,
+   lineage, and downstream evaluation.
+6. **Report.** The cumulative report records completed, pending, disabled, and
+   optional work together with available results and warnings.
 
-The default route above is sufficient for a generated campaign. Use these
-focused guides only when you need to change or inspect a specific part:
+Sanity failures that show incorrect sorting or physical slicing block a valid
+campaign result. Ranking-quality misses can remain visible as warnings. See
+[sanity validation](docs/sanity_validation.md) for the checks, comparison
+controls, and tolerances.
 
-- [Setup wizard](docs/setup_wizard.md): profiles, full configuration mode,
-  hosted datasets, generated files, and setup resume.
-- [Configuration and overrides](docs/configuration_overrides.md): checked-in
-  config layout, run roots, and temporary campaign changes.
-- [Slurm configuration](docs/slurm_configuration.md): partitions, CPU-only
-  stages, logs, and compatibility fields.
-- [MIP runs](docs/mip_profiles.md): objectives, constraints, solution pools,
-  workload measurements, and search variants.
-- [Post-MIP pipelines](docs/post_mip_pipeline.md): evaluation, filtering,
-  materialization, AIPerf, and distillation.
-- [Sanity validation](docs/sanity_validation.md): correctness checks,
-  tolerances, ranking warnings, and qualification guidance.
-- [Legacy Nano campaign](docs/legacy_nano_campaign.md): the separate online
-  evaluation and finalist-materialization workflow.
-- [Architecture](docs/v2_architecture.md): stage registry, campaign DAG,
-  control plane, and maintainer guidance.
+Run one stage with `--stage <stage_id>` only when its parent artifacts already
+exist. It does not run missing prerequisites. Use `--stage full` for the normal
+dependency-ordered campaign and whole-campaign resume.
+
+## Evaluate a checkpoint
+
+Candidate evaluation can be part of a post-MIP campaign flow, where metrics,
+selection, materialization, and report lineage remain connected. Configure
+that route with the
+[post-MIP pipeline guide](docs/post_mip_pipeline.md#downstream-evaluation).
+
+To evaluate a compatible local Hugging Face checkpoint without creating a
+campaign, run the default one-GPU smoke in the Puzzletron worker environment:
+
+```bash
+python examples/puzzletron/evaluate_lmms_checkpoint.py \
+  --checkpoint /path/to/checkpoint \
+  --output-dir /path/to/results/checkpoint-smoke
+```
+
+The smoke evaluates eight samples each from IFEval and GSM8K. See
+[checkpoint evaluation](docs/checkpoint_evaluation.md) for task selection,
+full evaluation, model detection, runtime options, results, and troubleshooting.
+
+## Configure a campaign
+
+Generated bundles contain an experiment, runner, and execution file. The
+default route above is sufficient when their generated values match your model
+and infrastructure.
+
+- Use [configuration and overrides](docs/configuration_overrides.md) to inspect
+  the checked-in Hydra layout, choose artifact roots, or make temporary
+  experiment changes.
+- Use [Slurm configuration](docs/slurm_configuration.md) to change partitions,
+  CPU-only stages, log locations, and accepted compatibility fields.
+- Use the [setup wizard guide](docs/setup_wizard.md) to change profiles,
+  datasets, generated files, or setup automation.
+
+Run `--dry-run` after every configuration change. It resolves and validates
+the experiment, runner, and execution files before any job is submitted.
+
+## Operate and recover a campaign
+
+See [controller operations](docs/orchestration_operations.md) for individual
+stages, `--once`, non-interactive behavior, logging controls, security options,
+execution strategies, controller records, and recovery. Remote model code and
+online tokenizer resolution remain disabled by default and should be enabled
+only for trusted sources.
+
+To run with an agent, ask it to use
+[`running-puzzletron`](../../.agents/skills/running-puzzletron/SKILL.md) and
+provide the model, dataset, compute environment, search space, resource
+constraints, and required downstream stages.
+
+## Extend Puzzletron
+
+- [Architecture](docs/v2_architecture.md) describes the stage registry,
+  campaign DAG, scheduler-neutral control plane, and maintainer guidance.
+- [Legacy Nano campaign](docs/legacy_nano_campaign.md) describes the separate
+  online evaluation and finalist-materialization workflow used by the
+  checked-in Nano configuration.

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -1,9 +1,9 @@
 # Puzzletron v2
 
-Puzzletron v2 helps you explore model shapes and select a smaller, faster
-variant against your quality and deployment goals. Its guided setup creates a
-reproducible, resumable campaign that compares candidates and can optionally
-evaluate, benchmark, materialize, or distill the selected model.
+Puzzletron v2 helps you explore model architectures and find smaller, faster
+variants that meet your quality and deployment goals. Guided setup creates
+reproducible campaigns that find and compare candidates. Campaigns can
+evaluate, benchmark, materialize, or distill those candidates.
 
 ## Table of contents
 
@@ -16,27 +16,25 @@ evaluate, benchmark, materialize, or distill the selected model.
 
 ## First campaign
 
-The supported path is to prepare the control and worker environments, generate
-a campaign, inspect and launch its smoke bundle, and then repeat the launch for
-production. The same launch command resumes compatible work after an
-interruption.
+The usual path is to prepare Puzzletron, generate a campaign, inspect and run a
+small smoke campaign, and then repeat the run with production settings. The
+same command resumes compatible work after an interruption.
 
 ### 1. Prepare the environments
 
-Create a lightweight environment for the setup wizard and controller:
+Create one lightweight Python environment for the setup wizard and the command
+that launches campaigns:
 
 ```bash
-python3 -m venv .venv-puzzletron-control
-source .venv-puzzletron-control/bin/activate
-python -m pip install \
-  -r examples/puzzletron/requirements-setup.txt \
-  -r examples/puzzletron/requirements-orchestrator.txt
+python3 -m venv .venv-puzzletron
+source .venv-puzzletron/bin/activate
+python -m pip install -r examples/puzzletron/requirements-setup.txt
 ```
 
-GPU workers use the environment or container declared in the generated runner
-file. Prepare the [worker environment](docs/environment_setup.md) before
-launching. That guide covers supported containers, pinned CUDA and PyTorch
-packages, patched dependencies, model-specific kernels, and verification.
+This environment creates campaign files and runs `orchestrate.py`. Model
+conversion, training, evaluation, and benchmarking run in the worker
+environment or container selected during setup. Prepare the
+[worker environment](docs/environment_setup.md) before launching a campaign.
 
 ### 2. Generate a campaign
 
@@ -61,7 +59,7 @@ configuration mode, generated files, and setup resume.
 
 ### 3. Inspect and launch smoke
 
-Activate the control environment and inspect the generated smoke plan:
+Activate `.venv-puzzletron` and inspect the generated smoke plan:
 
 ```bash
 PUZZLETRON_BUNDLE=/path/to/generated/campaign/smoke
@@ -74,7 +72,7 @@ python examples/puzzletron/orchestrate.py \
 ```
 
 Review the stage list, worker paths, execution strategies, resources, and
-artifact root. `--stage full` runs every stage enabled by the generated
+output directory. `--stage full` runs every stage enabled by the generated
 experiment in dependency order. Remove `--dry-run` to launch the smoke
 campaign. The checked-in
 [Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md) provides a separate
@@ -85,22 +83,23 @@ one-GPU MIP acceptance route when you need to validate that path directly.
 After smoke succeeds, change `smoke` to `production`, inspect that plan with
 `--dry-run`, and launch it with the same command.
 
-The experiment file owns model and algorithm choices, the runner file owns the
-worker environment, and the execution file owns per-stage orchestration. Keep
-all three together when launching or resuming a generated campaign.
+The experiment file defines the model and algorithm choices, the runner file
+defines the worker environment, and the execution file says how each stage
+runs. Keep all three together when launching or resuming a generated campaign.
 
 ### 5. Resume and inspect results
 
-The controller shows live progress and stores durable state under
-`${puzzle_dir}/orchestration/`. Run the same command with the same three files
-to recover a detached or interrupted campaign; completed compatible stages are
-not submitted again.
+The experiment file calls the campaign output directory `puzzle_dir`.
+`orchestrate.py` shows live progress and stores resume information under
+`<puzzle-dir>/orchestration/`. Run the same command with the same three files to
+recover a detached or interrupted campaign; completed compatible stages are not
+submitted again.
 
-After the selected plan completes cleanly, the orchestrator attempts to write
-the final report to
+After the selected plan completes cleanly, `orchestrate.py` attempts to write the
+final report to
 `<puzzle-dir>/artifacts/campaign_report/campaign_report.html`. A report failure
-does not fail the completed campaign and is recorded in the controller result.
-See [controller operations](docs/orchestration_operations.md) for individual
+does not fail the completed campaign and is recorded in the run result. See
+[run and recovery options](docs/orchestration_operations.md) for individual
 stages, `--once`, logging controls, security options, and recovery details, or
 [campaign reports](docs/campaign_reports.md) to regenerate and interpret a
 report.
@@ -164,9 +163,9 @@ Generated bundles contain an experiment, runner, and execution file. The
 default route above is sufficient when their generated values match your model
 and infrastructure.
 
-- Use [configuration and overrides](docs/configuration_overrides.md) to inspect
-  the checked-in Hydra layout, choose artifact roots, or make temporary
-  experiment changes.
+- Use [configuration and overrides](docs/configuration_overrides.md) to find
+  the built-in configuration files, choose where campaign outputs are stored,
+  or temporarily change experiment settings.
 - Use [Slurm configuration](docs/slurm_configuration.md) to change partitions,
   CPU-only stages, log locations, and accepted compatibility fields.
 - Use the [setup wizard guide](docs/setup_wizard.md) to change profiles,
@@ -177,9 +176,9 @@ the experiment, runner, and execution files before any job is submitted.
 
 ## Operate and recover a campaign
 
-See [controller operations](docs/orchestration_operations.md) for individual
+See [run and recovery options](docs/orchestration_operations.md) for individual
 stages, `--once`, non-interactive behavior, logging controls, security options,
-execution strategies, controller records, and recovery. Remote model code and
+execution strategies, saved run state, and recovery. Remote model code and
 online tokenizer resolution remain disabled by default and should be enabled
 only for trusted sources.
 

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -5,47 +5,16 @@ variant against your quality and deployment goals. Its guided setup creates a
 reproducible, resumable campaign that compares candidates and can optionally
 distill the selected model.
 
-## Table of Contents
+## Run a campaign
 
-- [Start here](#start-here)
-- [Installation](#installation)
-- [Setup wizard](#setup-wizard)
-- [Evaluate a checkpoint](#evaluate-a-checkpoint)
-- [Run with an agent](#run-with-an-agent)
-- [Configuration](#configuration)
-- [Experiment overrides](#experiment-overrides)
-- [Slurm configuration](#slurm-configuration)
-- [Qwen 3.5 smoke test](#qwen-35-smoke-test)
-- [Run a campaign](#run-a-campaign)
-- [Controller operations](#controller-operations)
-- [MIP runs](#mip-runs)
-- [Post-MIP pipelines](#post-mip-pipelines)
-- [Sanity validation](#sanity-validation)
-- [Reports](#reports)
-- [Legacy Nano campaign](#legacy-nano-campaign)
-- [Architecture](#architecture)
+The supported path is to prepare the control and worker environments, generate
+a campaign, inspect and launch its smoke bundle, and then repeat the launch for
+production. The same launch command resumes compatible work after an
+interruption.
 
-## Start here
+### 1. Prepare the environments
 
-- **New campaign:** complete the [installation](#installation), then use the
-  [setup wizard](#setup-wizard) to generate validated smoke and production
-  bundles.
-- **Generated campaign:** complete the [installation](#installation), then
-  [run the campaign](#run-a-campaign) with its generated bundle.
-- **Checkpoint evaluation:** use [Evaluate a checkpoint](#evaluate-a-checkpoint)
-  for a local model without creating or running a pruning campaign.
-- **Agent-assisted campaign:** follow [Run with an agent](#run-with-an-agent)
-  with your model, data, compute environment, and deployment goals.
-- **Existing results:** see [Reports](#reports) to regenerate a campaign report
-  or inspect the retained examples.
-
-## Installation
-
-See [environment setup](docs/environment_setup.md) for worker containers,
-pinned CUDA and PyTorch packages, patched dependencies, model-specific kernels,
-bare-metal environments, and verification.
-
-Use a lightweight environment for the setup wizard and controller:
+Create a lightweight environment for the setup wizard and controller:
 
 ```bash
 python3 -m venv .venv-puzzletron-control
@@ -56,128 +25,32 @@ python -m pip install \
 ```
 
 GPU workers use the environment or container declared in the generated runner
-file. Prepare that environment before launch, then run the smoke bundle first.
+file. Prepare the [worker environment](docs/environment_setup.md) before
+launching; that guide covers the supported container, pinned CUDA and PyTorch
+packages, patched dependencies, model-specific kernels, and verification.
 
-## Setup wizard
+### 2. Generate a campaign
 
-See the [setup wizard guide](docs/setup_wizard.md) for profiles, hosted dataset
-handling, full configuration mode, generated files, and resuming an interrupted
-setup.
-
-The setup wizard reads a local checkpoint or Hugging Face model configuration
-and generates validated smoke and production bundles. It does not load model
-weights.
-
-Start the wizard with the repository's example defaults file:
+Start the guided setup with the repository defaults:
 
 ```bash
 python examples/puzzletron/puzzletron_setup_v2.py \
   --defaults examples/puzzletron/configs/setup/defaults.example.yaml
 ```
 
-Choose **Balanced pruning** for a first campaign, review the detected model and
-infrastructure settings, and select an output directory. The generated
-`README.md` contains any dataset preparation command and the exact paths for
-the smoke and production bundles. The wizard prepares files but does not submit
-jobs.
+Choose **Balanced pruning** for a first campaign. For the maintained Qwen text
+route, select `Qwen/Qwen3.5-0.8B` and the recommended Puzzle-KD v2 text dataset
+or an existing worker-visible dataset. Review the detected model, worker and
+scheduler settings, and output directory.
 
-## Evaluate a checkpoint
+The wizard reads model configuration, not model weights, and does not submit
+jobs. It writes validated `smoke/` and `production/` bundles plus a generated
+`README.md`. Run any dataset preparation command in that generated README from
+the worker environment before launch.
 
-See [checkpoint evaluation](docs/checkpoint_evaluation.md) for task selection,
-full evaluation, result locations, and model-detection overrides.
+### 3. Inspect and launch
 
-Basic evaluation is independent of MIP and the campaign DAG. In the Puzzletron
-worker environment, run any compatible local Hugging Face checkpoint directly:
-
-```bash
-python examples/puzzletron/evaluate_lmms_checkpoint.py \
-  --checkpoint /path/to/checkpoint \
-  --output-dir /path/to/results/checkpoint-smoke
-```
-
-The default one-GPU smoke evaluates eight samples each from IFEval and GSM8K.
-Qwen 3.5 checkpoints are configured automatically. For options not covered by
-the convenience command, append `--lmms-eval-args` followed by the native
-lmms-eval options.
-
-## Run with an agent
-
-The canonical agent workflow is
-[`running-puzzletron`](../../.agents/skills/running-puzzletron/SKILL.md). Ask an
-agent to use that skill and provide the model, dataset, compute environment,
-search space, resource constraints, and required downstream stages. For
-example:
-
-```text
-Use .agents/skills/running-puzzletron/SKILL.md to run the Puzzletron campaign
-at examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml.
-Validate the smoke path first, execute the enabled DAG, resume compatible
-artifacts, and regenerate and verify the report after every completed stage.
-```
-
-`.agents/` is the source of truth. Agent-specific paths such as
-`.claude/skills/running-puzzletron` are compatibility symlinks and should not
-be edited separately.
-
-## Configuration
-
-Configs use Hydra composition:
-
-```text
-examples/puzzletron/configs/
-├── base.yaml                         # pipeline-wide defaults
-└── families/
-    └── <family>/
-        ├── family.yaml               # descriptors, hooks, and family axes
-        └── <model>/
-            ├── model.yaml            # checkpoint metadata and legal domains
-            └── runs/<run>.yaml       # exact named campaign run
-```
-
-Site-specific paths can be overridden without editing the checked-in config:
-
-```bash
-export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
-```
-
-`PUZZLETRON_RUN_ROOT` is a convenience used by the checked-in experiment YAMLs
-to resolve `puzzle_dir`. Generated bundles write their chosen `puzzle_dir`
-directly. In both cases, `puzzle_dir` is the canonical location for artifacts,
-manifests, controller state, and logs unless `runner.slurm.log_dir` relocates
-attempt logs.
-
-## Experiment overrides
-
-See [experiment overrides](docs/configuration_overrides.md) for temporary
-changes without editing the checked-in YAML.
-
-Overrides can select another run root, adjust a campaign value, or change one
-stage while preserving the source configuration. Validate the resolved config
-before launch so misspelled or misplaced fields fail at the command boundary.
-
-## Slurm configuration
-
-See [Slurm configuration](docs/slurm_configuration.md) for partition lists,
-CPU-only stages, log directories, and accepted compatibility fields.
-
-Use the checked-in runner and execution examples as templates, replace their
-site placeholders, and inspect the plan with `--dry-run` before launch. Runner
-files own infrastructure; execution files own per-stage strategy and resource
-selection.
-
-## Qwen 3.5 smoke test
-
-See the [Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md) for the
-one-GPU route, dry run, and manual GPU acceptance test.
-
-This focused campaign checks the MIP path on a small public checkpoint before
-larger model or cluster runs.
-
-## Run a campaign
-
-Activate the control environment and run the generated smoke bundle first. The
-smoke run checks the worker environment and campaign wiring before the larger
-production run:
+Activate the control environment and inspect the generated smoke plan:
 
 ```bash
 PUZZLETRON_BUNDLE=/path/to/generated/campaign/smoke
@@ -186,90 +59,69 @@ python examples/puzzletron/orchestrate.py \
   --experiment "$PUZZLETRON_BUNDLE/experiment.yaml" \
   --runner "$PUZZLETRON_BUNDLE/runner.yaml" \
   --execution "$PUZZLETRON_BUNDLE/execution.yaml" \
-  --stage full
+  --stage full --dry-run
 ```
 
-After the smoke campaign succeeds, change `smoke` to `production` and run the
-same command. Add `--dry-run` before either launch to inspect the plan without
-submitting jobs.
+Review the stage list, worker paths, execution strategies, resources, and
+artifact root. `--stage full` runs every stage enabled by the generated
+experiment in dependency order, including evaluation, materialization,
+benchmarking, or distillation when selected during setup. Remove `--dry-run`
+to launch the smoke campaign. After it succeeds, change `smoke` to
+`production`, inspect that plan, and launch it with the same command.
 
-## Controller operations
+The experiment file owns model and algorithm choices, the runner file owns the
+worker environment, and the execution file owns per-stage orchestration. Keep
+all three together when launching or resuming a generated campaign.
 
+### 4. Resume and inspect results
+
+The controller shows live progress and stores durable state under
+`${puzzle_dir}/orchestration/`. Run the same command with the same three files
+to recover a detached or interrupted campaign; completed compatible stages are
+not submitted again.
+
+After the selected plan completes cleanly, the orchestrator attempts to write
+the final report to
+`<puzzle-dir>/artifacts/campaign_report/campaign_report.html`. A report failure
+does not fail the completed campaign and is recorded in the controller result.
 See [controller operations](docs/orchestration_operations.md) for individual
-stages, non-interactive behavior, logging options, execution strategies,
-recovery, and controller records.
+stages, `--once`, logging controls, security options, and recovery details, or
+[campaign reports](docs/campaign_reports.md) to regenerate and interpret a
+report.
 
-Remote model code and AIPerf v0.11 online tokenizer resolution are disabled by
-default. Enable remote code only for a trusted model source. The tokenizer
-compatibility option permits the AIPerf child process to resolve its tokenizer
-online even when the surrounding campaign is configured for offline loading.
+## Other workflows
 
-The controller shows live progress and keeps resume state under
-`${puzzle_dir}/orchestration/`. Press `q` or Ctrl-C in an interactive terminal
-to cancel, detach, or continue. Run the same command again to recover a detached
-campaign.
+- **Evaluate a checkpoint without a campaign:** run
+  `python examples/puzzletron/evaluate_lmms_checkpoint.py --checkpoint
+  /path/to/checkpoint --output-dir /path/to/results/checkpoint-smoke`. See
+  [checkpoint evaluation](docs/checkpoint_evaluation.md) for task selection and
+  advanced options.
+- **Run the checked-in one-GPU MIP acceptance route:** follow the
+  [Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md). This is separate from
+  the generated end-to-end campaign above.
+- **Run with an agent:** ask an agent to use
+  [`running-puzzletron`](../../.agents/skills/running-puzzletron/SKILL.md) and
+  provide the model, dataset, compute environment, search space, resource
+  constraints, and required downstream stages.
 
-## MIP runs
+## Customize and operate
 
-See [MIP runs](docs/mip_profiles.md) for variants, solution pools, objectives,
-resource constraints, workload measurements, and homogeneous search.
+The default route above is sufficient for a generated campaign. Use these
+focused guides only when you need to change or inspect a specific part:
 
-Named profiles let one campaign compare candidate architectures against
-different parameter, runtime, or memory goals without duplicating the earlier
-importance and scoring stages.
-
-## Post-MIP pipelines
-
-See [post-MIP pipelines](docs/post_mip_pipeline.md) for candidate evaluation,
-filtering, materialization, AIPerf, and distillation.
-
-These downstream nodes turn selected MIP solutions into evaluated or
-materialized checkpoints and can continue through serving measurements and
-global distillation.
-
-## Sanity validation
-
-See [sanity validation](docs/sanity_validation.md) for correctness checks,
-ranking warnings, comparison controls, tolerances, and qualification guidance.
-
-Sorting and slicing equivalence failures are correctness errors. Ranking
-quality misses are warnings unless strict warning handling is enabled.
-
-## Reports
-
-See [campaign reports](docs/campaign_reports.md) for cache controls and the
-evidence status of retained example reports.
-
-After the selected plan completes cleanly, the v2 orchestrator generates the
-final campaign report through the configured runner. Reporting is nonfatal to
-the completed campaign, but a failed report attempt is recorded in the
-controller result. The generator is read-only with respect to model artifacts
-and includes valid partial results without marking their stage complete.
-
-Regenerate without rerunning model work:
-
-```bash
-python examples/puzzletron/generate_campaign_progress_report.py \
-  --puzzle-dir /shared/puzzle_runs/my_campaign \
-  --model-name 'My model'
-```
-
-Open
-`<puzzle-dir>/artifacts/campaign_report/campaign_report.html` locally.
-
-## Legacy Nano campaign
-
-See the [legacy Nano campaign](docs/legacy_nano_campaign.md) for the separate
-online evaluation and finalist-materialization workflow used by the checked-in
-Nano configuration.
-
-That configuration uses `mode: online_solutions`; it does not use the generated
-campaign DAG's integrated evaluation and materialization nodes.
-
-## Architecture
-
-See the [v2 architecture](docs/v2_architecture.md) for the stage registry,
-campaign DAG, scheduler-neutral control plane, and maintainer guidance.
-
-The experiment config owns model and algorithm semantics, the runner owns the
-worker environment, and the execution config owns per-stage orchestration.
+- [Setup wizard](docs/setup_wizard.md): profiles, full configuration mode,
+  hosted datasets, generated files, and setup resume.
+- [Configuration and overrides](docs/configuration_overrides.md): checked-in
+  config layout, run roots, and temporary campaign changes.
+- [Slurm configuration](docs/slurm_configuration.md): partitions, CPU-only
+  stages, logs, and compatibility fields.
+- [MIP runs](docs/mip_profiles.md): objectives, constraints, solution pools,
+  workload measurements, and search variants.
+- [Post-MIP pipelines](docs/post_mip_pipeline.md): evaluation, filtering,
+  materialization, AIPerf, and distillation.
+- [Sanity validation](docs/sanity_validation.md): correctness checks,
+  tolerances, ranking warnings, and qualification guidance.
+- [Legacy Nano campaign](docs/legacy_nano_campaign.md): the separate online
+  evaluation and finalist-materialization workflow.
+- [Architecture](docs/v2_architecture.md): stage registry, campaign DAG,
+  control plane, and maintainer guidance.

--- a/examples/puzzletron/docs/campaign_reports.md
+++ b/examples/puzzletron/docs/campaign_reports.md
@@ -1,7 +1,10 @@
 # Puzzletron Campaign Reports
 
-The orchestrator generates a cumulative HTML report after a campaign. Regenerate
-it without rerunning model work:
+After a campaign completes cleanly, the orchestrator attempts to generate a
+cumulative HTML report through the configured runner. A report submission,
+polling, or artifact failure is recorded in the controller result but does not
+fail the completed campaign. Inspect the controller logs, then regenerate the
+report without rerunning model work:
 
 ```bash
 python examples/puzzletron/generate_campaign_progress_report.py \

--- a/examples/puzzletron/docs/campaign_reports.md
+++ b/examples/puzzletron/docs/campaign_reports.md
@@ -1,9 +1,9 @@
 # Puzzletron Campaign Reports
 
-After a campaign completes cleanly, the orchestrator attempts to generate a
+After a campaign completes cleanly, `orchestrate.py` attempts to generate a
 cumulative HTML report through the configured runner. A report submission,
-polling, or artifact failure is recorded in the controller result but does not
-fail the completed campaign. Inspect the controller logs, then regenerate the
+polling, or artifact failure is recorded in the run result but does not fail
+the completed campaign. Inspect the campaign logs, then regenerate the
 report without rerunning model work:
 
 ```bash

--- a/examples/puzzletron/docs/configuration_overrides.md
+++ b/examples/puzzletron/docs/configuration_overrides.md
@@ -24,6 +24,10 @@ Generated bundles write their selected `puzzle_dir` directly. In both cases,
 `puzzle_dir` is the canonical location for artifacts, manifests, controller
 state, and logs unless `runner.slurm.log_dir` relocates attempt logs.
 
+Run the orchestrator with `--dry-run` after any configuration change. It
+resolves and validates the experiment, runner, and execution files before job
+submission, so misspelled or misplaced fields fail at the command boundary.
+
 ## Command-line overrides
 
 Use command-line overrides for temporary experiment value changes. Append a

--- a/examples/puzzletron/docs/configuration_overrides.md
+++ b/examples/puzzletron/docs/configuration_overrides.md
@@ -1,6 +1,7 @@
 # Configuration and experiment overrides
 
-Checked-in experiment configs use Hydra composition:
+Puzzletron builds experiment settings from reusable YAML files in this
+directory:
 
 ```text
 examples/puzzletron/configs/
@@ -13,25 +14,25 @@ examples/puzzletron/configs/
             └── runs/<run>.yaml       # exact named campaign run
 ```
 
-Set a site-specific artifact root without editing a checked-in config:
+Choose where a built-in campaign stores its outputs without editing the YAML:
 
 ```bash
 export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
 ```
 
-Checked-in experiment YAMLs use `PUZZLETRON_RUN_ROOT` to resolve `puzzle_dir`.
-Generated bundles write their selected `puzzle_dir` directly. In both cases,
-`puzzle_dir` is the canonical location for artifacts, manifests, controller
-state, and logs unless `runner.slurm.log_dir` relocates attempt logs.
+Built-in experiment YAMLs use `PUZZLETRON_RUN_ROOT` as their `puzzle_dir`.
+Generated bundles write the selected `puzzle_dir` directly. This directory
+contains campaign outputs, manifests, resume information, and logs unless
+`runner.slurm.log_dir` sends job logs elsewhere.
 
-Run the orchestrator with `--dry-run` after any configuration change. It
+Run `orchestrate.py` with `--dry-run` after any configuration change. It
 resolves and validates the experiment, runner, and execution files before job
 submission, so misspelled or misplaced fields fail at the command boundary.
 
 ## Command-line overrides
 
 Use command-line overrides for temporary experiment value changes. Append a
-repeatable `--override KEY=VALUE` to the orchestrator command and inspect the
+repeatable `--override KEY=VALUE` to the campaign command and inspect the
 result with `--dry-run` before launch:
 
 ```bash
@@ -41,7 +42,8 @@ result with `--dry-run` before launch:
 ```
 
 Plain `KEY=VALUE` and explicit `++KEY=VALUE` both add or replace experiment
-values. The controller and GPU workers interpret these forms identically.
+values. The `orchestrate.py` command and GPU jobs interpret these forms
+identically.
 Single-plus add (`+KEY=VALUE`) and delete (`~KEY`) operators are not
 supported. Put structural changes in a copied run config so they remain easy to
 review.

--- a/examples/puzzletron/docs/configuration_overrides.md
+++ b/examples/puzzletron/docs/configuration_overrides.md
@@ -1,4 +1,30 @@
-# Experiment overrides
+# Configuration and experiment overrides
+
+Checked-in experiment configs use Hydra composition:
+
+```text
+examples/puzzletron/configs/
+├── base.yaml                         # pipeline-wide defaults
+└── families/
+    └── <family>/
+        ├── family.yaml               # descriptors, hooks, and family axes
+        └── <model>/
+            ├── model.yaml            # checkpoint metadata and legal domains
+            └── runs/<run>.yaml       # exact named campaign run
+```
+
+Set a site-specific artifact root without editing a checked-in config:
+
+```bash
+export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
+```
+
+Checked-in experiment YAMLs use `PUZZLETRON_RUN_ROOT` to resolve `puzzle_dir`.
+Generated bundles write their selected `puzzle_dir` directly. In both cases,
+`puzzle_dir` is the canonical location for artifacts, manifests, controller
+state, and logs unless `runner.slurm.log_dir` relocates attempt logs.
+
+## Command-line overrides
 
 Use command-line overrides for temporary experiment value changes. Append a
 repeatable `--override KEY=VALUE` to the orchestrator command and inspect the

--- a/examples/puzzletron/docs/environment_setup.md
+++ b/examples/puzzletron/docs/environment_setup.md
@@ -2,7 +2,8 @@
 
 Puzzletron uses two environments:
 
-- a lightweight control environment for the setup wizard and orchestrator;
+- one lightweight local Python environment for the setup wizard and campaign
+  commands; and
 - a GPU worker environment for ModelOpt, the patched vLLM fork, AutoModel, and
   AIPerf.
 
@@ -10,18 +11,22 @@ The runner file connects them. `runner.execution_contract.venv` selects the
 worker virtual environment, and `runner.execution_contract.container` selects
 an optional Slurm container.
 
-## Control environment
+## Local Puzzletron environment
 
-The setup wizard and orchestrator do not import PyTorch or initialize CUDA.
+The setup wizard and `orchestrate.py` do not import PyTorch or initialize CUDA.
 Create one environment for both:
 
 ```bash
-python3 -m venv .venv-puzzletron-control
-source .venv-puzzletron-control/bin/activate
-python -m pip install \
-  -r examples/puzzletron/requirements-setup.txt \
-  -r examples/puzzletron/requirements-orchestrator.txt
+python3 -m venv .venv-puzzletron
+source .venv-puzzletron/bin/activate
+python -m pip install -r examples/puzzletron/requirements-setup.txt
 ```
+
+Only one local virtual environment is needed for a first campaign.
+`requirements-setup.txt` includes the packages required to generate, launch,
+and monitor a campaign.
+`requirements-orchestrator.txt` is the smaller subset for a machine that only
+launches or monitors an existing campaign. Neither set requires PyTorch.
 
 A Slurm login node also needs `sbatch`, `squeue`, and `sacct`. It does not need
 ModelOpt, CUDA, the worker container, or the worker virtual environment.

--- a/examples/puzzletron/docs/legacy_nano_campaign.md
+++ b/examples/puzzletron/docs/legacy_nano_campaign.md
@@ -13,8 +13,8 @@ public model source and revision but inherits a repository-relative
 `dataset_path` from `base.yaml`. Override it with a materialized Hugging Face
 dataset directory that is visible at the same path on every worker.
 
-If needed, prepare Puzzle-KD from the full worker environment before starting
-the controller:
+If needed, prepare Puzzle-KD from the full worker environment before launching
+the campaign:
 
 ```bash
 export PUZZLETRON_DATASET=/shared/datasets/puzzle-kd-v2
@@ -26,7 +26,7 @@ python examples/puzzletron/materialize_dataset.py puzzle_kd_v2 \
   --seed 408
 ```
 
-Pass the same dataset override to every controller invocation. First run the
+Pass the same dataset override to every `orchestrate.py` command. First run the
 campaign through MIP with the downstream stages disabled:
 
 ```bash
@@ -98,7 +98,7 @@ Return to the login node and resume the remaining enabled stages:
 
 ```bash
 cd /path/to/modelopt
-source .venv-puzzletron-control/bin/activate
+source .venv-puzzletron/bin/activate
 PUZZLETRON_EXPERIMENT=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
 PUZZLETRON_RUNNER=/path/to/runner.yaml
 PUZZLETRON_EXECUTION=/path/to/execution.yaml

--- a/examples/puzzletron/docs/orchestration_operations.md
+++ b/examples/puzzletron/docs/orchestration_operations.md
@@ -1,4 +1,4 @@
-# Controller operation and recovery
+# Run and recover campaigns
 
 Run one stage with the same experiment, runner, and execution files used for a
 full campaign:
@@ -17,7 +17,7 @@ python examples/puzzletron/orchestrate.py \
 be complete; it does not run missing prerequisites. Use `--stage full` for the
 normal dependency-ordered campaign and whole-campaign resume.
 
-The launch command runs a foreground controller. It submits every
+The launch command runs in the foreground. It submits every
 dependency-ready branch concurrently, polls scheduler state, and exits when the
 selected plan completes or fails.
 
@@ -39,8 +39,8 @@ Redirected output uses timestamped one-line updates instead.
 
 Press `q` or Ctrl-C in an interactive terminal to cancel active jobs and quit,
 detach while leaving jobs running, or continue. Non-interactive Ctrl-C and
-SIGTERM cancel active work and quit. A detached controller preserves durable
-handles, so running the same command recovers the active jobs.
+SIGTERM cancel active work and quit. Detaching preserves saved job information,
+so running the same command recovers the active jobs.
 
 Redirect stderr before piping through `tee` (for example, append
 `2>&1 | tee run.log`) so progress output is captured. Use `--color always` for
@@ -49,10 +49,11 @@ to change the default five-second poll interval.
 
 ## State and execution records
 
-Durable controller state is written under `${puzzle_dir}/orchestration/`. The
-controller supports `single`, `sharded`, and `persistent_pool` strategies,
-Slurm and SSH executors, attempt recovery, and semantic stage validation. See
-the [`configs/orchestration/`](../configs/orchestration/) directory for starter
+The experiment file calls the campaign output directory `puzzle_dir`. Resume
+information is written under `<puzzle-dir>/orchestration/`. The command supports
+`single`, `sharded`, and `persistent_pool` strategies, Slurm and SSH executors,
+attempt recovery, and semantic stage validation. See the
+[`configs/orchestration/`](../configs/orchestration/) directory for starter
 runner and execution files.
 
 Accepted rank-zero stage results also write checksum-validated execution

--- a/examples/puzzletron/docs/orchestration_operations.md
+++ b/examples/puzzletron/docs/orchestration_operations.md
@@ -13,9 +13,22 @@ python examples/puzzletron/orchestrate.py \
   --stage width_importance
 ```
 
+`--stage <stage_id>` runs only that stage and requires its parent artifacts to
+be complete; it does not run missing prerequisites. Use `--stage full` for the
+normal dependency-ordered campaign and whole-campaign resume.
+
 The launch command runs a foreground controller. It submits every
 dependency-ready branch concurrently, polls scheduler state, and exits when the
 selected plan completes or fails.
+
+`--once` recovers and polls existing attempts, submits currently ready work,
+and exits after one scheduling iteration. Submitted jobs keep running. Invoke
+the same `--once` command again for the next recovery and scheduling iteration.
+
+Remote model code and AIPerf v0.11 online tokenizer resolution are disabled by
+default. Enable remote code only for a trusted model source. The tokenizer
+compatibility option permits the AIPerf child process to resolve its tokenizer
+online even when the surrounding campaign is configured for offline loading.
 
 ## Progress and interruption
 

--- a/examples/puzzletron/docs/post_mip_pipeline.md
+++ b/examples/puzzletron/docs/post_mip_pipeline.md
@@ -118,9 +118,48 @@ node where the transition is needed.
 ## Add downstream evaluation to an existing campaign
 
 Keep the campaign's `puzzle_dir` and add a `post_mip.flows` entry whose source
-selects the completed MIP run. See the
+selects the completed MIP run. Select the candidate, materialize it, and pass
+that checkpoint to `downstream_evaluation`:
+
+```yaml
+post_mip:
+  flows:
+    runtime-eval:
+      source:
+        run: runtime-075
+        variants: all
+        objectives: all
+      nodes:
+        best_mip:
+          type: filter
+          mode: top_k
+          metric: mip.score
+          direction: minimize
+          top_k: 1
+        materialized:
+          type: materialize
+          input: best_mip
+        lmms_eval:
+          type: downstream_evaluation
+          input: materialized
+          config:
+            tasks: [ifeval, gsm8k]
+            limit: 128
+            topology:
+              tensor_parallel_size: 8
+              pipeline_parallel_size: 1
+              data_parallel_size: 1
+              prefill_context_parallel_size: 1
+              decode_context_parallel_size: 1
+              enable_expert_parallel: false
+              gpu_group_size: 8
+```
+
+Replace `runtime-075` with a MIP run defined by the campaign and adjust the
+tasks, sample limit, and topology for the worker environment. A non-empty
+`post_mip.flows` mapping replaces the legacy fixed post-MIP stages. See the
 [lmms-eval run configuration](../configs/families/nemotron3/nano_30b_a3b_bf16/runs/lmms_eval.yaml)
-for a complete filter, materialization, and downstream-evaluation flow.
+for the complete configuration, including model and runtime settings.
 
 ## Lineage and model source
 

--- a/examples/puzzletron/docs/post_mip_pipeline.md
+++ b/examples/puzzletron/docs/post_mip_pipeline.md
@@ -5,7 +5,7 @@ from one MIP run and consists of named, single-input nodes. A node can branch fr
 any earlier node. Node IDs must be unique across the campaign because they are also
 stable metric namespaces.
 
-When at least one flow is configured, the campaign orchestrator replaces the
+When at least one flow is configured, Puzzletron replaces the
 legacy fixed post-MIP stages with these dynamic nodes. Run such campaigns through
 `examples/puzzletron/orchestrate.py`; the simple `main.py` stage runner does not
 schedule dynamic/manual nodes.
@@ -100,7 +100,7 @@ Later filters reference metrics as `mip.<metric>` or `<node_id>.<metric>`.
 
 - `filter`: metadata-only selection; modes are `top_k`, `threshold`, `pareto`,
   and `aggregate_rank`.
-- `manual_filter`: writes a durable review, asks in an interactive controller,
+- `manual_filter`: writes a durable review, asks through an interactive run,
   and pauses cleanly in non-interactive execution until a decision is supplied.
 - `materialize`: converts a config-only candidate into a checkpoint.
 - `evaluation`: evaluates either a config-only candidate or a checkpoint and

--- a/examples/puzzletron/orchestrate.py
+++ b/examples/puzzletron/orchestrate.py
@@ -39,12 +39,31 @@ from puzzletron_orchestrator.logging import OrchestratorLogger  # noqa: E402
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run the Puzzletron v2 campaign orchestrator.")
-    parser.add_argument("--experiment", required=True, help="Path to the experiment YAML.")
-    parser.add_argument("--runner", required=True, help="Path to the runner environment YAML.")
-    parser.add_argument("--execution", required=True, help="Path to the execution semantics YAML.")
+    parser = argparse.ArgumentParser(
+        description="Run or resume a Puzzletron v2 campaign from its three YAML contracts."
+    )
     parser.add_argument(
-        "--stage", default="full", help="Stage id or 'full' for all enabled stages."
+        "--experiment",
+        required=True,
+        help="Experiment YAML: model, data, enabled stages, and artifact root.",
+    )
+    parser.add_argument(
+        "--runner",
+        required=True,
+        help="Runner YAML: worker backend, repository, environment, container, and mounts.",
+    )
+    parser.add_argument(
+        "--execution",
+        required=True,
+        help="Execution YAML: per-stage strategy, instances, resources, and failure policy.",
+    )
+    parser.add_argument(
+        "--stage",
+        default="full",
+        help=(
+            "'full' runs every enabled stage in dependency order; a stage id runs only "
+            "that stage and requires its parent artifacts."
+        ),
     )
     parser.add_argument(
         "--override",
@@ -54,10 +73,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Repeatable config override; KEY=VALUE and ++KEY=VALUE are supported.",
     )
     parser.add_argument(
-        "--dry-run", action="store_true", help="Print packed submissions without submitting."
+        "--dry-run",
+        action="store_true",
+        help="Compile and print packed submissions without submitting jobs.",
     )
     parser.add_argument("--local", action="store_true", help="Use the local subprocess executor.")
-    parser.add_argument("--once", action="store_true", help="Run one controller iteration.")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help=(
+            "Recover, poll, and submit ready work once, then exit; jobs keep running and "
+            "the same command continues them."
+        ),
+    )
     parser.add_argument("--max-iterations", type=int, default=None)
     parser.add_argument(
         "--color",

--- a/examples/puzzletron/orchestrate.py
+++ b/examples/puzzletron/orchestrate.py
@@ -40,22 +40,25 @@ from puzzletron_orchestrator.logging import OrchestratorLogger  # noqa: E402
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Run or resume a Puzzletron v2 campaign from its three YAML contracts."
+        description="Run or resume a Puzzletron v2 campaign from its three configuration files."
     )
     parser.add_argument(
         "--experiment",
         required=True,
-        help="Experiment YAML: model, data, enabled stages, and artifact root.",
+        help="Experiment YAML: model, data, enabled stages, and output directory.",
     )
     parser.add_argument(
         "--runner",
         required=True,
-        help="Runner YAML: worker backend, repository, environment, container, and mounts.",
+        help=(
+            "Runner YAML: where and how worker jobs run, including repository, "
+            "environment, container, and mounts."
+        ),
     )
     parser.add_argument(
         "--execution",
         required=True,
-        help="Execution YAML: per-stage strategy, instances, resources, and failure policy.",
+        help="Execution YAML: how each stage runs, including resources and failure policy.",
     )
     parser.add_argument(
         "--stage",

--- a/examples/puzzletron/requirements-setup.txt
+++ b/examples/puzzletron/requirements-setup.txt
@@ -1,6 +1,7 @@
-# Lightweight, config-only Puzzletron setup environment. No PyTorch is required.
-questionary>=2.1,<3
-PyYAML>=6.0
-huggingface_hub>=0.24
-transformers>=4.56,<5.0
+# Setup wizard plus lightweight campaign commands. No PyTorch is required.
+-r requirements-orchestrator.txt
 datasets>=2.17,<5
+huggingface_hub>=0.24
+
+questionary>=2.1,<3
+transformers>=4.56,<5.0

--- a/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
@@ -35,6 +35,25 @@ from puzzletron_orchestrator.logging import OrchestratorLogger
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 
 
+def test_orchestrator_help_explains_first_run_contracts() -> None:
+    result = subprocess.run(
+        [sys.executable, "examples/puzzletron/orchestrate.py", "--help"],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    help_text = " ".join(result.stdout.split())
+    assert "Experiment YAML: model, data, enabled stages, and artifact root." in help_text
+    assert "Runner YAML: worker backend, repository, environment" in help_text
+    assert "Execution YAML: per-stage strategy, instances, resources" in help_text
+    assert "requires its parent artifacts" in help_text
+    assert "jobs keep running" in help_text
+
+
 def test_lightweight_package_does_not_import_torch() -> None:
     result = subprocess.run(
         [

--- a/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
@@ -47,9 +47,9 @@ def test_orchestrator_help_explains_first_run_contracts() -> None:
 
     assert result.returncode == 0, result.stderr
     help_text = " ".join(result.stdout.split())
-    assert "Experiment YAML: model, data, enabled stages, and artifact root." in help_text
-    assert "Runner YAML: worker backend, repository, environment" in help_text
-    assert "Execution YAML: per-stage strategy, instances, resources" in help_text
+    assert "Experiment YAML: model, data, enabled stages, and output directory." in help_text
+    assert "Runner YAML: where and how worker jobs run" in help_text
+    assert "Execution YAML: how each stage runs" in help_text
     assert "requires its parent artifacts" in help_text
     assert "jobs keep running" in help_text
 


### PR DESCRIPTION
### What does this PR do?

The Puzzletron README currently presents setup, configuration, launch, recovery, pipeline stages, and reports as separate entry points, so first-time users must reconstruct the normal campaign sequence and the boundary between local commands and GPU work. This PR reorganizes the README around one complete first campaign and moves advanced configuration and operations into linked guides.

Type of change: documentation

- **First campaign:** Uses one `.venv-puzzletron` environment and one installation command for setup, launch, and monitoring. The guide then covers campaign generation, dry-run inspection, smoke and production runs, resume, and reports, while GPU work remains in the selected worker environment.
- **Stages and evaluation:** Adds a compact map of the full campaign, keeps standalone checkpoint evaluation in the main README, and shows how a campaign can select and materialize a candidate before downstream evaluation.
- **Advanced guidance:** Links configuration, output location, Slurm, recovery, and reporting details from the relevant README sections. User-facing text replaces terms such as controller, Hydra layout, and artifact root with direct descriptions.
- **Command contract:** Expands `orchestrate.py --help` to explain the experiment, runner, and execution files plus full, single-stage, dry-run, and one-iteration behavior. The setup requirements now include the lightweight launch dependencies, and a focused test covers the help text.

### Testing

Repository hooks passed. Direct checks covered the CLI help text, README links, and the downstream-evaluation YAML example. The focused pytest module was not collected locally because the lightweight environment does not include PyTorch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized campaign guidance into a streamlined first-campaign workflow.
  - Clarified environment setup, configuration overrides, dry runs, campaign stages, checkpoint evaluation, resume/recovery, and orchestration operations.
  - Expanded post-MIP and downstream evaluation instructions.
  - Documented report-generation failures and recovery without rerunning completed model work.
  - Updated legacy campaign and command-line usage guidance.

- **User Experience**
  - Improved CLI help for configuration files, stage selection, dry runs, and recovery behavior.

- **Tests**
  - Added coverage confirming the orchestrator help documents first-run requirements and configuration contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->