### PR TITLE
Add Qwen 3.5 0.8B full lifecycle smoke

### DIFF
--- a/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
+++ b/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
@@ -1,0 +1,99 @@
+# @package _global_
+
+defaults:
+  - mip_smoke
+  - _self_
+
+# Extend the current real-checkpoint MIP smoke through the complete post-MIP
+# lifecycle. Evaluate the bounded MIP result set, then keep one candidate for
+# materialization, serving, distillation, and final selection.
+puzzle_dir: ${oc.env:PUZZLETRON_RUN_ROOT,puzzle_runs/qwen3p5_0p8b_full_smoke}
+
+# This route searches only FFN intermediate width. Keep attention and GDN
+# tensors in their original order so the full-width sanity gate isolates the
+# enabled axis instead of applying unrelated capability permutations.
+sort:
+  deferred_axes:
+    - kv_groups
+    - q_heads_per_group
+    - gdn_key_groups
+    - gdn_value_heads_per_group
+    - gdn_key_head_dim
+    - gdn_value_head_dim
+
+post_mip:
+  flows:
+    params-90:
+      source:
+        run: params-90
+        variants: all
+        objectives: all
+      nodes:
+        online_eval:
+          type: evaluation
+          config:
+            eval_samples: 2
+            block_size: 512
+        best_lm:
+          type: filter
+          input: online_eval
+          mode: top_k
+          metric: online_eval.lm_loss
+          direction: minimize
+          top_k: 1
+        materialized:
+          type: materialize
+          input: best_lm
+        serving:
+          type: aiperf
+          input: materialized
+          config:
+            input_tokens: 128
+            output_tokens: 32
+            concurrency: [1]
+            request_count: 4
+            use_server_token_count: true
+            benchmark_timeout: 900
+            allow_aiperf_v011_online_tokenizer_resolution: true
+            topology:
+              tensor_parallel_size: 1
+              pipeline_parallel_size: 1
+              data_parallel_size: 1
+              prefill_context_parallel_size: 1
+              decode_context_parallel_size: 1
+              enable_expert_parallel: false
+              distributed_executor_backend: mp
+              gpu_group_size: 1
+              extra_vllm_args:
+                - -cc.cudagraph_mode=NONE
+                - --no-enable-flashinfer-autotune
+                - --gpu-memory-utilization
+                - "0.5"
+        fastest:
+          type: filter
+          input: serving
+          mode: top_k
+          metric: serving.output_token_throughput
+          direction: maximize
+          top_k: 1
+        short_kd:
+          type: global_kd
+          input: fastest
+          config:
+            max_steps: 2
+            global_batch_size: 1
+            local_batch_size: 1
+            checkpoint_every_steps: 2
+        final_eval:
+          type: evaluation
+          input: short_kd
+          config:
+            eval_samples: 2
+            block_size: 512
+        best:
+          type: filter
+          input: final_eval
+          mode: top_k
+          metric: final_eval.lm_loss
+          direction: minimize
+          top_k: 1

--- a/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
+++ b/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
@@ -5,8 +5,8 @@ defaults:
   - _self_
 
 # Extend the current real-checkpoint MIP smoke through the complete post-MIP
-# lifecycle. Evaluate the bounded MIP result set, then keep one candidate for
-# materialization, serving, distillation, and final selection.
+# lifecycle. Evaluate the bounded MIP result set, benchmark the two strongest
+# quality candidates, then distill and re-evaluate the faster candidate.
 puzzle_dir: ${oc.env:PUZZLETRON_RUN_ROOT,puzzle_runs/qwen3p5_0p8b_full_smoke}
 
 # This route searches only FFN intermediate width. Keep attention and GDN
@@ -40,7 +40,7 @@ post_mip:
           mode: top_k
           metric: online_eval.lm_loss
           direction: minimize
-          top_k: 1
+          top_k: 2
         materialized:
           type: materialize
           input: best_lm

--- a/examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_smoke.yaml
+++ b/examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_smoke.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# One instance on one GPU for every model-backed stage. The post-MIP filters
+# remain single controller operations and do not introduce extra model copies.
+execution:
+  defaults:
+    failure_policy: strict
+    halt_policy: drain
+    gpus_per_node: 1
+  stages:
+    convert: {strategy: single, instances: 1}
+    tokenize_data: {strategy: single, instances: 1}
+    depth_importance: {strategy: single, instances: 1}
+    width_importance: {strategy: single, instances: 1}
+    sort: {strategy: single, instances: 1}
+    sort_sanity: {strategy: single, instances: 1}
+    width_sanity: {strategy: single, instances: 1}
+    slicing_sanity: {strategy: single, instances: 1}
+    build_library: {strategy: single, instances: 1}
+    replacement_scoring: {strategy: single, instances: 1}
+    mip: {strategy: single, instances: 1}
+    post.params-90.online_eval: {strategy: sharded, instances: 1}
+    post.params-90.best_lm: {strategy: single, instances: 1}
+    post.params-90.materialized: {strategy: sharded, instances: 1}
+    post.params-90.serving: {strategy: sharded, instances: 1}
+    post.params-90.fastest: {strategy: single, instances: 1}
+    post.params-90.short_kd: {strategy: sharded, instances: 1}
+    post.params-90.final_eval: {strategy: sharded, instances: 1}
+    post.params-90.best: {strategy: single, instances: 1}

--- a/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
@@ -19,6 +19,7 @@ EXPERIMENT=examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_s
 EXECUTION=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_smoke.yaml
 RUNNER_TEMPLATE=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/runner.slurm.yaml
 CAMPAIGN_DIR=/path/to/qwen3p5_0p8b_full_smoke
+export PUZZLETRON_RUN_ROOT="$CAMPAIGN_DIR"
 RUNNER="$CAMPAIGN_DIR/runner.slurm.yaml"
 
 mkdir -p "$CAMPAIGN_DIR"

--- a/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
@@ -10,30 +10,17 @@ evaluation, and final selection.
 
 Use the checked-in `full_smoke.yaml` experiment and
 `execution.full_smoke.yaml` execution config as the canonical inputs. The
-checked-in `runner.slurm.yaml` is a portable placeholder template. Copy it once
-to a campaign-local path, fill in the site contract there, and use that same
-materialized runner for the dry-run, launch, and resume.
+checked-in `runner.slurm.yaml` is a portable template, not a runnable site
+configuration. Copy it to a site-specific location once and replace its
+`REPLACE_WITH_` values before launching. Dry-run accepts the portable template
+for plan inspection, but the orchestrator rejects unresolved placeholders
+before submitting work.
 
 ```bash
 EXPERIMENT=examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
 EXECUTION=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_smoke.yaml
-RUNNER_TEMPLATE=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/runner.slurm.yaml
-CAMPAIGN_DIR=/path/to/qwen3p5_0p8b_full_smoke
-export PUZZLETRON_RUN_ROOT="$CAMPAIGN_DIR"
-RUNNER="$CAMPAIGN_DIR/runner.slurm.yaml"
-
-mkdir -p "$CAMPAIGN_DIR"
-if test -e "$RUNNER"; then
-  echo "runner already exists: $RUNNER" >&2
-  exit 1
-fi
-cp "$RUNNER_TEMPLATE" "$RUNNER"
-${EDITOR:-vi} "$RUNNER"
-
-if rg -n 'REPLACE_WITH_' "$RUNNER"; then
-  echo "replace every runner placeholder before continuing" >&2
-  exit 1
-fi
+RUNNER=/path/to/site-specific/runner.slurm.yaml
+export PUZZLETRON_RUN_ROOT=/path/to/qwen3p5_0p8b_full_smoke
 ```
 
 Inspect the complete one-GPU plan without submitting work:

--- a/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
@@ -3,8 +3,11 @@
 The checked-in Qwen 3.5 0.8B `full_smoke` recipe pins the public checkpoint revision and
 searches only the FFN intermediate sizes `[3072, 2048]`. The checked-in
 `full_smoke.yaml` experiment extends the bounded MIP smoke through evaluation,
-physical materialization, AIPerf, two global-distillation steps, final
-evaluation, and final selection.
+physical materialization, comparative AIPerf measurement, two
+global-distillation steps, final evaluation, and final selection. It keeps the
+two strongest candidates by language-model loss through materialization and
+AIPerf, then sends the candidate with higher measured output-token throughput
+to distillation.
 
 ## Run and resume the full lifecycle
 
@@ -55,8 +58,9 @@ python examples/puzzletron/orchestrate.py \
   --stage full
 ```
 
-The checked-in flow deliberately uses two evaluation samples, four AIPerf
-requests, and two distillation steps. These budgets validate lifecycle
-correctness and resumability; they are not quality or throughput claims. Final
-acceptance must reload the selected checkpoint, verify the cumulative report,
-and confirm that the resume submits no work for completed stages.
+The checked-in flow deliberately uses two evaluation samples per candidate,
+four AIPerf requests per serving candidate, and two distillation steps. These
+budgets validate lifecycle correctness, comparative serving selection, and
+resumability; they are not quality or throughput claims. Final acceptance must
+reload the selected checkpoint, verify the cumulative report, and confirm that
+the resume submits no work for completed stages.

--- a/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
@@ -1,44 +1,74 @@
-# Qwen 3.5 0.8B MIP smoke
+# Qwen 3.5 0.8B full-lifecycle smoke
 
-The focused Qwen 3.5 0.8B example pins the public checkpoint revision. Its
-default model config searches only the FFN intermediate sizes `[3072, 2048]`.
-The `mip_smoke.yaml` run enables the composite scenario route required by
-named-profile MIP while keeping depth, attention, GDN, and embedding width at
-their teacher values.
+The checked-in Qwen 3.5 0.8B `full_smoke` recipe pins the public checkpoint revision and
+searches only the FFN intermediate sizes `[3072, 2048]`. The checked-in
+`full_smoke.yaml` experiment extends the bounded MIP smoke through evaluation,
+physical materialization, AIPerf, two global-distillation steps, final
+evaluation, and final selection.
 
-The experimental `advanced.yaml` overlay covers more axes. Its target values
-were derived from the pinned 0.8B geometry rather than selected by a completed
-campaign, and the overlay has not been fully runtime-validated. In particular,
-the `gdn_key_head_dim` reduction from 128 to 96 does not yet have physical
-runtime equivalence evidence. This does not affect the FFN-only smoke route.
+## Run and resume the full lifecycle
 
-## Inspect the plan
+Use the checked-in `full_smoke.yaml` experiment and
+`execution.full_smoke.yaml` execution config as the canonical inputs. The
+checked-in `runner.slurm.yaml` is a portable placeholder template. Copy it once
+to a campaign-local path, fill in the site contract there, and use that same
+materialized runner for the dry-run, launch, and resume.
 
-The checked-in one-GPU execution plan ends at `mip`. It does not run bypass,
-vLLM serving statistics, evaluation, AIPerf, or distillation. Replace every
-site placeholder in the runner, then inspect the plan without launching work:
+```bash
+EXPERIMENT=examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
+EXECUTION=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_smoke.yaml
+RUNNER_TEMPLATE=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/runner.slurm.yaml
+CAMPAIGN_DIR=/path/to/qwen3p5_0p8b_full_smoke
+RUNNER="$CAMPAIGN_DIR/runner.slurm.yaml"
+
+mkdir -p "$CAMPAIGN_DIR"
+if test -e "$RUNNER"; then
+  echo "runner already exists: $RUNNER" >&2
+  exit 1
+fi
+cp "$RUNNER_TEMPLATE" "$RUNNER"
+${EDITOR:-vi} "$RUNNER"
+
+if rg -n 'REPLACE_WITH_' "$RUNNER"; then
+  echo "replace every runner placeholder before continuing" >&2
+  exit 1
+fi
+```
+
+Inspect the complete one-GPU plan without submitting work:
 
 ```bash
 python examples/puzzletron/orchestrate.py \
-  --experiment examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/mip_smoke.yaml \
-  --runner examples/puzzletron/configs/orchestration/qwen3p5_0p8b/runner.slurm.yaml \
-  --execution examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.smoke.yaml \
+  --experiment "$EXPERIMENT" \
+  --runner "$RUNNER" \
+  --execution "$EXECUTION" \
   --stage full --dry-run
 ```
 
-## Run the GPU acceptance test
-
-CPU plan tests cover composition and scheduling only. The real-checkpoint test
-is a manual gate and is not part of generic GPU CI. Run it from a reviewed,
-worker-visible checkout on one H100 80GB GPU with model access configured:
+After reviewing the dry-run, launch with the same three inputs and omit only
+`--dry-run`:
 
 ```bash
-python -m pytest -v -s --run-manual \
-  tests/gpu/torch/puzzletron/test_qwen3p5_0p8b_smoke.py
+python examples/puzzletron/orchestrate.py \
+  --experiment "$EXPERIMENT" \
+  --runner "$RUNNER" \
+  --execution "$EXECUTION" \
+  --stage full
 ```
 
-Treat the route as runtime-validated only when the test passes and confirms a
-successful MIP manifest, the `params-90` active profile, and at least one
-feasible MIP scenario. Retain the source revision, environment or container,
-GPU model, command, and complete pytest log with the result. The test uses
-isolated temporary data and cache roots and does not submit scheduler work.
+Resume by rerunning that exact launch command with the same experiment,
+materialized runner, and execution config:
+
+```bash
+python examples/puzzletron/orchestrate.py \
+  --experiment "$EXPERIMENT" \
+  --runner "$RUNNER" \
+  --execution "$EXECUTION" \
+  --stage full
+```
+
+The checked-in flow deliberately uses two evaluation samples, four AIPerf
+requests, and two distillation steps. These budgets validate lifecycle
+correctness and resumability; they are not quality or throughput claims. Final
+acceptance must reload the selected checkpoint, verify the cumulative report,
+and confirm that the resume submits no work for completed stages.

--- a/examples/puzzletron/orchestrate.py
+++ b/examples/puzzletron/orchestrate.py
@@ -33,6 +33,7 @@ from puzzletron_orchestrator.compiler import (  # noqa: E402
     compile_campaign_plan,
     load_execution_config,
     load_runner_config,
+    validate_runner_ready,
 )
 from puzzletron_orchestrator.controller import CampaignController, dry_run_plan  # noqa: E402
 from puzzletron_orchestrator.logging import OrchestratorLogger  # noqa: E402
@@ -110,6 +111,8 @@ def main(argv: list[str] | None = None) -> int:
     logger = OrchestratorLogger(color=args.color)
     try:
         runner = load_runner_config(args.runner)
+        if not args.dry_run:
+            validate_runner_ready(runner)
         execution = load_execution_config(args.execution)
         plan = compile_campaign_plan(
             experiment_config_path=args.experiment,

--- a/modelopt/torch/puzzletron/orchestration/compiler.py
+++ b/modelopt/torch/puzzletron/orchestration/compiler.py
@@ -65,6 +65,7 @@ __all__ = [
     "load_runner_config",
     "plan_to_dict",
     "resolve_stage_execution_specs",
+    "validate_runner_ready",
 ]
 
 _CONTROLLER_REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
@@ -588,6 +589,38 @@ def load_runner_config(path: str | Path) -> RunnerEnvironment:
         slurm=environment.slurm,
         baremetal=environment.baremetal,
     )
+
+
+def _placeholder_paths(value: Any, *, path: str) -> list[str]:
+    if isinstance(value, str):
+        return [path] if "REPLACE_WITH_" in value else []
+    if isinstance(value, Mapping):
+        placeholders = []
+        for key, item in value.items():
+            display_key = (
+                {"contract": "execution_contract", "baremetal": "inventory"}.get(key, key)
+                if path == "runner"
+                else key
+            )
+            placeholders.extend(_placeholder_paths(item, path=f"{path}.{display_key}"))
+        return placeholders
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [
+            placeholder
+            for index, item in enumerate(value)
+            for placeholder in _placeholder_paths(item, path=f"{path}[{index}]")
+        ]
+    return []
+
+
+def validate_runner_ready(runner: RunnerEnvironment) -> None:
+    """Reject portable runner templates that still contain site placeholders."""
+
+    placeholders = _placeholder_paths(asdict(runner), path="runner")
+    if placeholders:
+        raise ValueError(
+            "runner contains unresolved REPLACE_WITH_ placeholders: " + ", ".join(placeholders)
+        )
 
 
 def load_execution_config(path: str | Path) -> dict[str, Any]:

--- a/modelopt/torch/puzzletron/orchestration/controller.py
+++ b/modelopt/torch/puzzletron/orchestration/controller.py
@@ -38,7 +38,13 @@ from .executors import BareMetalSSHExecutor, Executor, LocalExecutor, SlurmExecu
 from .identity import stable_hash
 from .logging import OrchestratorLogger
 from .progress import summarize_stage_artifacts
-from .reporting import FinalReportResult, build_final_report_attempt, final_report_paths
+from .reporting import (
+    FinalReportResult,
+    build_final_report_attempt,
+    completed_final_report,
+    final_report_paths,
+    record_completed_final_report,
+)
 from .schema import (
     AttemptSpec,
     CampaignPlan,
@@ -1203,6 +1209,10 @@ class CampaignController:
     def _generate_final_report(self) -> FinalReportResult:
         """Generate the canonical campaign report through the configured executor."""
 
+        completed = completed_final_report(self.plan)
+        if completed is not None:
+            self.logger.skip("final_report: completion artifacts validated")
+            return completed
         attempt = build_final_report_attempt(self.plan, attempt_id=str(uuid.uuid4()))
         fallback_logs = (attempt.command.log_path,) if attempt.command.log_path is not None else ()
         self.logger.stage("generating final campaign report")
@@ -1250,13 +1260,13 @@ class CampaignController:
                     + ", ".join(missing)
                 )
                 return FinalReportResult(status="failed", log_paths=tuple(log_paths))
+            try:
+                result = record_completed_final_report(self.plan, log_paths=tuple(log_paths))
+            except OSError as exc:
+                self.logger.error(f"final campaign report sealing failed: {exc}")
+                return FinalReportResult(status="failed", log_paths=tuple(log_paths))
             self.logger.success(f"final campaign report: {report_path}")
-            return FinalReportResult(
-                status="completed",
-                path=str(report_path),
-                manifest_path=str(manifest_path),
-                log_paths=tuple(log_paths),
-            )
+            return result
 
     def _prompt_shutdown_action(self) -> ShutdownAction:
         """Suspend live rendering and collect one interactive exit decision."""

--- a/modelopt/torch/puzzletron/orchestration/reporting.py
+++ b/modelopt/torch/puzzletron/orchestration/reporting.py
@@ -35,6 +35,8 @@ __all__ = [
     "record_completed_final_report",
 ]
 
+_MAX_COMPLETION_RECORD_BYTES = 1 << 20
+
 
 @dataclass(frozen=True)
 class FinalReportResult:
@@ -100,7 +102,11 @@ def completed_final_report(plan: CampaignPlan) -> FinalReportResult | None:
 
     report_path, manifest_path = final_report_paths(plan)
     try:
-        payload = json.loads(_completion_path(plan).read_text(encoding="utf-8"))
+        with _completion_path(plan).open("rb") as stream:
+            record_bytes = stream.read(_MAX_COMPLETION_RECORD_BYTES + 1)
+        if len(record_bytes) > _MAX_COMPLETION_RECORD_BYTES:
+            return None
+        payload = json.loads(record_bytes)
         log_paths = payload["log_paths"]
         if (
             payload["schema_version"] != 1
@@ -111,7 +117,7 @@ def completed_final_report(plan: CampaignPlan) -> FinalReportResult | None:
             or not all(isinstance(path, str) for path in log_paths)
         ):
             return None
-    except (FileNotFoundError, KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+    except (KeyError, OSError, TypeError, ValueError):
         return None
     return FinalReportResult(
         status="completed",

--- a/modelopt/torch/puzzletron/orchestration/reporting.py
+++ b/modelopt/torch/puzzletron/orchestration/reporting.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -28,7 +30,9 @@ from .schema import AttemptSpec, CampaignPlan, CommandSpec, TaskLauncher, TaskTo
 __all__ = [
     "FinalReportResult",
     "build_final_report_attempt",
+    "completed_final_report",
     "final_report_paths",
+    "record_completed_final_report",
 ]
 
 
@@ -76,6 +80,70 @@ def final_report_paths(plan: CampaignPlan) -> tuple[Path, Path]:
 
     output_dir = plan.puzzle_dir / "artifacts" / "campaign_report"
     return output_dir / "campaign_report.html", output_dir / "report_manifest.json"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _completion_path(plan: CampaignPlan) -> Path:
+    report_path, _ = final_report_paths(plan)
+    return report_path.parent / "completion.json"
+
+
+def completed_final_report(plan: CampaignPlan) -> FinalReportResult | None:
+    """Return a sealed final report when its contract and artifact hashes still match."""
+
+    report_path, manifest_path = final_report_paths(plan)
+    try:
+        payload = json.loads(_completion_path(plan).read_text(encoding="utf-8"))
+        log_paths = payload["log_paths"]
+        if (
+            payload["schema_version"] != 1
+            or payload["contract_hash"] != plan.contract_hash
+            or payload["report_sha256"] != _sha256(report_path)
+            or payload["manifest_sha256"] != _sha256(manifest_path)
+            or not isinstance(log_paths, list)
+            or not all(isinstance(path, str) for path in log_paths)
+        ):
+            return None
+    except (FileNotFoundError, KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return FinalReportResult(
+        status="completed",
+        path=str(report_path),
+        manifest_path=str(manifest_path),
+        log_paths=tuple(log_paths),
+    )
+
+
+def record_completed_final_report(
+    plan: CampaignPlan, *, log_paths: tuple[str, ...]
+) -> FinalReportResult:
+    """Atomically seal a completed final report for idempotent controller resumes."""
+
+    report_path, manifest_path = final_report_paths(plan)
+    payload = {
+        "schema_version": 1,
+        "contract_hash": plan.contract_hash,
+        "report_sha256": _sha256(report_path),
+        "manifest_sha256": _sha256(manifest_path),
+        "log_paths": list(log_paths),
+    }
+    completion_path = _completion_path(plan)
+    temporary = completion_path.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(completion_path)
+    return FinalReportResult(
+        status="completed",
+        path=str(report_path),
+        manifest_path=str(manifest_path),
+        log_paths=log_paths,
+    )
 
 
 def build_final_report_attempt(plan: CampaignPlan, *, attempt_id: str) -> AttemptSpec:

--- a/modelopt/torch/puzzletron/stages/diagnostics.py
+++ b/modelopt/torch/puzzletron/stages/diagnostics.py
@@ -34,7 +34,7 @@ import math
 import re
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 from omegaconf import OmegaConf
@@ -76,6 +76,7 @@ from .pipeline import (
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from ..anymodel.model_descriptor import ModelDescriptor
     from ..manifest import StageManifest
 
 __all__ = [
@@ -676,7 +677,7 @@ def _replace_axis(
     teacher_value = _teacher_axis_value(subblock, field, teacher_value_fallback)
     if teacher_value is None or int(target) >= int(teacher_value):
         return None
-    updates = {field: int(target)}
+    updates: dict[str, Any] = {field: int(target)}
     if subblock_kind == "mamba" and field == "gdn_key_groups":
         groups = int(getattr(subblock, "num_groups"))
         ratio = int(getattr(subblock, "num_heads")) // groups
@@ -701,7 +702,7 @@ def _replace_axis(
             "num_kv_heads": int(kv),
             "num_query_heads": int(kv) * int(target),
         }
-    child = dataclasses.replace(subblock, **updates)
+    child = dataclasses.replace(cast("Any", subblock), **updates)
     replace_kinds = {
         "attention": ("attention", "mamba"),
         "mamba": ("attention", "mamba"),
@@ -738,16 +739,18 @@ def _diagnostic_solutions(
         if target_info is None:
             continue
         subblock_kind, field = target_info
-        eligible = [
-            idx
-            for idx, block in enumerate(block_configs)
-            if block.get_subblock(subblock_kind) is not None
-            and not getattr(block.get_subblock(subblock_kind), "no_op", False)
-            and (
-                _teacher_axis_value(block.get_subblock(subblock_kind), field) is not None
-                or f"{subblock_kind}.{field}" in fallback_values
-            )
-        ]
+        eligible = []
+        for idx, block in enumerate(block_configs):
+            subblock = block.get_subblock(subblock_kind)
+            if (
+                subblock is not None
+                and not getattr(subblock, "no_op", False)
+                and (
+                    _teacher_axis_value(subblock, field) is not None
+                    or f"{subblock_kind}.{field}" in fallback_values
+                )
+            ):
+                eligible.append(idx)
         for layer_idx in _select_layers(
             eligible,
             layer_count,
@@ -758,13 +761,14 @@ def _diagnostic_solutions(
         ):
             base = block_configs[layer_idx]
             subblock = base.require_subblock(subblock_kind)
-            teacher_value = int(
-                _teacher_axis_value(
-                    subblock,
-                    field,
-                    fallback_values.get(f"{subblock_kind}.{field}"),
-                )
+            raw_teacher_value = _teacher_axis_value(
+                subblock,
+                field,
+                fallback_values.get(f"{subblock_kind}.{field}"),
             )
+            if raw_teacher_value is None:
+                continue
+            teacher_value = int(raw_teacher_value)
             configured_targets = target_values.get(axis)
             if configured_targets is None:
                 targets = _ratio_targets(teacher_value, ratios)
@@ -852,7 +856,9 @@ def _configured_bypass_block_targets(
         )
     ]
     requested = {
-        _axis_subblock_and_field(axis)[0] for axis in axes if _axis_subblock_and_field(axis)
+        target_info[0]
+        for axis in axes
+        if (target_info := _axis_subblock_and_field(axis)) is not None
     }
     use_ffn = bool(ffn_sizes) and (not requested or "ffn" in requested or "attention" in requested)
     use_attn = bool(attn_targets) and (not requested or "attention" in requested)
@@ -870,10 +876,11 @@ def _configured_bypass_block_targets(
         if use_attn and attn is not None and not getattr(attn, "no_op", False):
             teacher_q = _teacher_axis_value(attn, "num_query_heads")
             teacher_kv = _teacher_axis_value(attn, "num_kv_heads")
-            has_attn_target = any(
-                q <= teacher_q and kv <= teacher_kv and (q < teacher_q or kv < teacher_kv)
-                for q, kv in attn_targets
-            )
+            if teacher_q is not None and teacher_kv is not None:
+                has_attn_target = any(
+                    q <= teacher_q and kv <= teacher_kv and (q < teacher_q or kv < teacher_kv)
+                    for q, kv in attn_targets
+                )
         has_target = (
             has_attn_target if prefer_attention_layers else (has_ffn_target or has_attn_target)
         )
@@ -925,7 +932,7 @@ def _configured_bypass_block_targets(
                 if attn_target is not None:
                     q, kv = attn_target
                     child_attn = dataclasses.replace(
-                        child.require_subblock("attention"),
+                        cast("AttentionConfig", child.require_subblock("attention")),
                         num_query_heads=int(q),
                         num_kv_heads=int(kv),
                     )
@@ -994,9 +1001,10 @@ def _read_sorted_permutations(sorted_teacher_dir: Path) -> dict[str, Any]:
         sidecar_path = sorted_teacher_dir / str(value["sidecar"])
         if sidecar_path not in sidecars:
             sidecars[sidecar_path] = torch.load(sidecar_path, map_location="cpu", weights_only=True)
-        tensor = sidecars[sidecar_path].get(key)
-        if not torch.is_tensor(tensor):
+        raw_tensor = sidecars[sidecar_path].get(key)
+        if not torch.is_tensor(raw_tensor):
             raise KeyError(f"Missing permutation {key!r} in {sidecar_path}")
+        tensor = cast("torch.Tensor", raw_tensor)
         expected_shape = tuple(int(dim) for dim in value.get("shape", tensor.shape))
         if tuple(tensor.shape) != expected_shape:
             raise ValueError(f"Permutation {key!r} shape {tuple(tensor.shape)} != {expected_shape}")
@@ -1022,7 +1030,10 @@ def _annotate_solution_selections(
     permutations = _read_sorted_permutations(sorted_teacher_dir)
     for solution in solutions:
         diag = solution.get("diagnostic") or {}
-        layer_idx = int(diag.get("layer_idx"))
+        raw_layer_idx = diag.get("layer_idx")
+        if raw_layer_idx is None:
+            raise ValueError("Activation diagnostic is missing layer_idx")
+        layer_idx = int(raw_layer_idx)
         changed_layers = [
             idx
             for idx, child in enumerate(solution.get("block_configs") or [])
@@ -1050,7 +1061,10 @@ def _annotate_solution_selections(
             order = permutations.get(f"attn.q.{layer_idx}")
             teacher_attn = teacher_block_configs[layer_idx].get_subblock("attention")
             if order is not None and teacher_attn is not None:
+                teacher_attn = cast("AttentionConfig", teacher_attn)
                 order = [int(item) for item in order]
+                if teacher_attn.num_kv_heads is None or teacher_attn.num_query_heads is None:
+                    raise ValueError("Attention diagnostic requires query and KV head counts")
                 num_kv = int(teacher_attn.num_kv_heads)
                 heads_per_group = int(teacher_attn.num_query_heads) // num_kv
                 target = int(diag["target_value"])
@@ -1073,11 +1087,12 @@ def _annotate_solution_selections(
                 diag["removed_experts"] = order[target:]
                 diag["selection_basis"] = "ranked_original_expert_ids"
 
+        field = diag.get("field")
         gdn_perm_key = {
             "gdn_key_groups": "gdn.key_groups",
             "state_dim": "gdn.key_dim",
             "head_dim": "gdn.value_dim",
-        }.get(diag.get("field"))
+        }.get(str(field))
         if diag.get("subblock_kind") == "mamba" and gdn_perm_key is not None:
             order = permutations.get(f"{gdn_perm_key}.{layer_idx}")
             if order is not None:
@@ -1325,7 +1340,7 @@ def _run_hidden_width_diagnostic_at_width(
     dist.barrier()
 
     solution = _identity_width_solution(block_configs, width)
-    rows = []
+    rows: list[dict[str, Any]] = []
     parallel = _diagnostic_parallel(hydra_cfg, diag_cfg)
     runtime_sources = {
         "original": teacher_dir,
@@ -1424,9 +1439,10 @@ def _run_hidden_width_diagnostic_at_width(
     if dist.is_master():
         by_role = {row["role"]: row for row in rows}
         metric = str(diag_cfg.get("embedding_primary_metric", "raw_replacement_loss"))
-        values = {role: by_role[role]["metrics"].get(metric) for role in by_role}
-        if any(value is None or not math.isfinite(value) for value in values.values()):
-            raise RuntimeError(f"hidden-width diagnosis has invalid {metric}: {values}")
+        raw_values = {role: by_role[role]["metrics"].get(metric) for role in by_role}
+        if any(value is None or not math.isfinite(value) for value in raw_values.values()):
+            raise RuntimeError(f"hidden-width diagnosis has invalid {metric}: {raw_values}")
+        values = {role: float(value) for role, value in raw_values.items() if value is not None}
         tolerance = float(diag_cfg.get("comparison_tolerance", 0.0))
         verdict = _hidden_width_ranking_verdict(
             values,
@@ -1613,6 +1629,20 @@ def _merge_reused_sort_equivalence(
 
     merged = dict(existing)
     merged.update(reuse)
+    return merged
+
+
+def _write_reused_sort_equivalence(
+    sort_summary_path: Path,
+    reuse_summary_path: Path,
+    reuse: dict[str, Any],
+) -> dict[str, Any]:
+    """Write width-owned reuse evidence without mutating the completed sort artifact."""
+
+    existing = json.loads(sort_summary_path.read_text()) if sort_summary_path.is_file() else {}
+    merged = _merge_reused_sort_equivalence(existing, reuse)
+    reuse_summary_path.parent.mkdir(parents=True, exist_ok=True)
+    reuse_summary_path.write_text(json.dumps(merged, indent=2, sort_keys=True) + "\n")
     return merged
 
 
@@ -2309,7 +2339,9 @@ def _activation_diagnostic_parent_sweep(
             trust_remote_code=descriptor.requires_trust_remote_code(),
         )
         lm = descriptor.get_language_model_config(teacher_config)
-        block_configs = list(maybe_cast_block_configs(teacher_config.block_configs))
+        block_configs = cast(
+            "list[BlockConfig]", maybe_cast_block_configs(teacher_config.block_configs)
+        )
         head_dim = getattr(lm, "head_dim", None) or (lm.hidden_size // lm.num_attention_heads)
 
         needs_sorted_parent = _diagnostic_checkpoint_needs_rebuild(sorted_dir)
@@ -2410,6 +2442,7 @@ def _activation_diagnostic_parent_sweep(
                 is_master=dist.is_master(),
             )
             if dist.is_master():
+                assert hidden_width_summary is not None
                 parent_sweep = {
                     "version": 1,
                     "status": "not_applicable",
@@ -2687,9 +2720,7 @@ def _activation_diagnostic_parent_sweep(
             sort_equivalence_dir = puzzle_dir / "artifacts" / "sort_sanity"
             sort_equivalence_dir.mkdir(parents=True, exist_ok=True)
             sort_summary_path = sort_equivalence_dir / "summary.json"
-            existing_sort_summary = (
-                json.loads(sort_summary_path.read_text()) if sort_summary_path.is_file() else {}
-            )
+            reused_sort_summary_path = artifacts_dir / "reused_sort_equivalence.json"
             reuse_sort_summary = {
                 "passed": sort_passed,
                 "reused_parent_sweep": True,
@@ -2701,16 +2732,10 @@ def _activation_diagnostic_parent_sweep(
                 "verdict": "passed" if sort_passed else "failed",
                 "parent_sweep_manifest": str(load_manifest_path),
             }
-            sort_summary_path.write_text(
-                json.dumps(
-                    _merge_reused_sort_equivalence(
-                        existing_sort_summary,
-                        reuse_sort_summary,
-                    ),
-                    indent=2,
-                    sort_keys=True,
-                )
-                + "\n"
+            _write_reused_sort_equivalence(
+                sort_summary_path,
+                reused_sort_summary_path,
+                reuse_sort_summary,
             )
 
             cleanup_reverse = bool(diag_cfg.get("cleanup_reverse_on_success", True))
@@ -2731,8 +2756,8 @@ def _activation_diagnostic_parent_sweep(
 
     width_summary_path = puzzle_dir / "artifacts" / "width_sanity" / "summary.json"
     width_verdict = json.loads(width_summary_path.read_text(encoding="utf-8"))
-    sort_summary_path = puzzle_dir / "artifacts" / "sort_sanity" / "summary.json"
-    sort_verdict = json.loads(sort_summary_path.read_text(encoding="utf-8"))
+    reused_sort_summary_path = artifacts_dir / "reused_sort_equivalence.json"
+    sort_verdict = json.loads(reused_sort_summary_path.read_text(encoding="utf-8"))
 
     return complete_sanity_stage(
         config,
@@ -2754,6 +2779,7 @@ def _activation_diagnostic_parent_sweep(
                 artifacts_dir / "hidden_width_diagnostic_summary.json"
             ),
             "width_summary_path": str(width_summary_path),
+            "reused_sort_summary_path": str(reused_sort_summary_path),
             "slicing_summary_path": str(
                 puzzle_dir / "artifacts" / "slicing_sanity" / "summary.json"
             ),
@@ -2819,7 +2845,9 @@ def activation_diagnostic_stage(config: dict[str, Any], manifest: StageManifest)
             teacher_dir, trust_remote_code=descriptor.requires_trust_remote_code()
         )
         lm = descriptor.get_language_model_config(teacher_config)
-        block_configs = list(maybe_cast_block_configs(teacher_config.block_configs))
+        block_configs = cast(
+            "list[BlockConfig]", maybe_cast_block_configs(teacher_config.block_configs)
+        )
         head_dim = getattr(lm, "head_dim", None) or (lm.hidden_size // lm.num_attention_heads)
 
         for axis in axes:
@@ -3618,8 +3646,9 @@ def width_slice_equivalence_stage(config: dict[str, Any], manifest: StageManifes
     raw_batch = next(iter(dataloader))
     if isinstance(raw_batch, dict):
         input_ids = raw_batch.get("input_ids")
+        input_tensor = cast("torch.Tensor", input_ids) if torch.is_tensor(input_ids) else None
         batch_size = (
-            int(input_ids.shape[0]) if torch.is_tensor(input_ids) and input_ids.ndim > 1 else 1
+            int(input_tensor.shape[0]) if input_tensor is not None and input_tensor.ndim > 1 else 1
         )
     else:
         batch_size = raw_batch.batch_size
@@ -4001,7 +4030,9 @@ def bypass_diagnostic_stage(config: dict[str, Any], manifest: StageManifest):
             sorted_dir, trust_remote_code=descriptor.requires_trust_remote_code()
         )
         lm = descriptor.get_language_model_config(model_config)
-        block_configs = list(maybe_cast_block_configs(model_config.block_configs))
+        block_configs = cast(
+            "list[BlockConfig]", maybe_cast_block_configs(model_config.block_configs)
+        )
         head_dim = getattr(lm, "head_dim", None) or (lm.hidden_size // lm.num_attention_heads)
         overlay_layers = (
             layer_indices

--- a/modelopt/torch/puzzletron/stages/diagnostics.py
+++ b/modelopt/torch/puzzletron/stages/diagnostics.py
@@ -1639,7 +1639,15 @@ def _write_reused_sort_equivalence(
 ) -> dict[str, Any]:
     """Write width-owned reuse evidence without mutating the completed sort artifact."""
 
-    existing = json.loads(sort_summary_path.read_text()) if sort_summary_path.is_file() else {}
+    existing = (
+        json.loads(sort_summary_path.read_text(encoding="utf-8"))
+        if sort_summary_path.is_file()
+        else {}
+    )
+    if not isinstance(existing, dict):
+        raise ValueError(
+            f"invalid sort sanity artifact at {sort_summary_path}: expected a JSON object"
+        )
     merged = _merge_reused_sort_equivalence(existing, reuse)
     reuse_summary_path.parent.mkdir(parents=True, exist_ok=True)
     reuse_summary_path.write_text(json.dumps(merged, indent=2, sort_keys=True) + "\n")

--- a/modelopt/torch/puzzletron/stages/diagnostics.py
+++ b/modelopt/torch/puzzletron/stages/diagnostics.py
@@ -115,6 +115,7 @@ _PRIMARY_METRICS = (
     "token_accuracy_top_10_consistency",
 )
 _LAYER_RE = re.compile(r"(?:^|\.)(?:layers|blocks)\.(\d+)(?:\.|$)")
+_MAX_REUSED_SORT_SUMMARY_BYTES = 1 << 20
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -1639,11 +1640,16 @@ def _write_reused_sort_equivalence(
 ) -> dict[str, Any]:
     """Write width-owned reuse evidence without mutating the completed sort artifact."""
 
-    existing = (
-        json.loads(sort_summary_path.read_text(encoding="utf-8"))
-        if sort_summary_path.is_file()
-        else {}
-    )
+    if sort_summary_path.is_file():
+        with sort_summary_path.open("rb") as stream:
+            summary_bytes = stream.read(_MAX_REUSED_SORT_SUMMARY_BYTES + 1)
+        if len(summary_bytes) > _MAX_REUSED_SORT_SUMMARY_BYTES:
+            raise ValueError(
+                f"invalid sort sanity artifact at {sort_summary_path}: exceeds metadata size limit"
+            )
+        existing = json.loads(summary_bytes)
+    else:
+        existing = {}
     if not isinstance(existing, dict):
         raise ValueError(
             f"invalid sort sanity artifact at {sort_summary_path}: expected a JSON object"

--- a/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
+++ b/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
@@ -15,6 +15,8 @@
 
 import json
 
+import pytest
+
 from modelopt.torch.puzzletron.stages.diagnostics import (
     _diagnostic_checkpoint_needs_rebuild,
     _hidden_only_diagnostic_ready,
@@ -27,6 +29,7 @@ from modelopt.torch.puzzletron.stages.diagnostics import (
     _select_diagnostic_hidden_width,
     _select_layers,
     _write_hidden_only_diagnostic_artifacts,
+    _write_reused_sort_equivalence,
 )
 
 
@@ -135,14 +138,10 @@ def test_hidden_only_guard_allows_nonmaster_rank_without_summary():
         axes=["hidden_width"], hidden_width_summary=None, is_master=False
     )
 
-    try:
+    with pytest.raises(RuntimeError, match="rank 0"):
         _hidden_only_diagnostic_ready(
             axes=["hidden_width"], hidden_width_summary=None, is_master=True
         )
-    except RuntimeError as error:
-        assert "rank 0" in str(error)
-    else:
-        raise AssertionError("master rank without a width verdict should fail")
 
 
 def test_diagnostic_retry_rebuilds_partial_indexed_checkpoint(tmp_path):
@@ -241,6 +240,30 @@ def test_reused_parent_sweep_preserves_existing_sort_diagnosis_metrics():
     assert merged["teacher"] == existing["teacher"]
     assert merged["sorted_teacher"] == existing["sorted_teacher"]
     assert merged["reverse_sorted"] == existing["reverse_sorted"]
+    assert merged["reused_parent_sweep"] is True
+
+
+def test_reused_parent_sweep_does_not_mutate_completed_sort_artifact(tmp_path):
+    sort_summary_path = tmp_path / "sort_sanity" / "summary.json"
+    reuse_summary_path = tmp_path / "width_sanity" / "reused_sort_equivalence.json"
+    sort_summary_path.parent.mkdir()
+    original = {
+        "passed": True,
+        "teacher": {"lm_loss": 1.2},
+        "sorted_teacher": {"lm_loss": 1.2001},
+    }
+    sort_summary_path.write_text(json.dumps(original, indent=2, sort_keys=True) + "\n")
+    original_bytes = sort_summary_path.read_bytes()
+
+    merged = _write_reused_sort_equivalence(
+        sort_summary_path,
+        reuse_summary_path,
+        {"passed": True, "reused_parent_sweep": True},
+    )
+
+    assert sort_summary_path.read_bytes() == original_bytes
+    assert json.loads(reuse_summary_path.read_text()) == merged
+    assert merged["teacher"] == original["teacher"]
     assert merged["reused_parent_sweep"] is True
 
 

--- a/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
+++ b/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
@@ -267,6 +267,23 @@ def test_reused_parent_sweep_does_not_mutate_completed_sort_artifact(tmp_path):
     assert merged["reused_parent_sweep"] is True
 
 
+@pytest.mark.parametrize("invalid_summary", [None, [], "not-an-object"])
+def test_reused_parent_sweep_rejects_non_object_sort_artifacts(tmp_path, invalid_summary):
+    sort_summary_path = tmp_path / "sort_sanity" / "summary.json"
+    reuse_summary_path = tmp_path / "width_sanity" / "reused_sort_equivalence.json"
+    sort_summary_path.parent.mkdir()
+    sort_summary_path.write_text(json.dumps(invalid_summary))
+
+    with pytest.raises(ValueError, match="expected a JSON object"):
+        _write_reused_sort_equivalence(
+            sort_summary_path,
+            reuse_summary_path,
+            {"passed": True, "reused_parent_sweep": True},
+        )
+
+    assert not reuse_summary_path.exists()
+
+
 def test_parent_sweep_sort_miss_is_blocking_but_width_miss_remains_advisory():
     verdict = _parent_sweep_sanity_verdict(
         {

--- a/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
+++ b/tests/unit/torch/puzzletron/test_hidden_width_diagnostic.py
@@ -284,6 +284,22 @@ def test_reused_parent_sweep_rejects_non_object_sort_artifacts(tmp_path, invalid
     assert not reuse_summary_path.exists()
 
 
+def test_reused_parent_sweep_rejects_oversized_sort_artifact(tmp_path):
+    sort_summary_path = tmp_path / "sort_sanity" / "summary.json"
+    reuse_summary_path = tmp_path / "width_sanity" / "reused_sort_equivalence.json"
+    sort_summary_path.parent.mkdir()
+    sort_summary_path.write_bytes(b"{}" + b" " * (1 << 20))
+
+    with pytest.raises(ValueError, match="exceeds metadata size limit"):
+        _write_reused_sort_equivalence(
+            sort_summary_path,
+            reuse_summary_path,
+            {"passed": True, "reused_parent_sweep": True},
+        )
+
+    assert not reuse_summary_path.exists()
+
+
 def test_parent_sweep_sort_miss_is_blocking_but_width_miss_remains_advisory():
     verdict = _parent_sweep_sanity_verdict(
         {

--- a/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
@@ -360,6 +360,43 @@ def test_orchestrator_cli_reports_config_errors_without_traceback(tmp_path: Path
     assert "Traceback" not in result.stderr
 
 
+def test_orchestrator_cli_rejects_unresolved_runner_template(tmp_path: Path) -> None:
+    runner = tmp_path / "runner.yaml"
+    runner.write_text(
+        yaml.safe_dump(
+            {
+                "runner": {
+                    "kind": "slurm",
+                    "slurm": {"account": "REPLACE_WITH_SLURM_ACCOUNT", "partition": "gpu"},
+                }
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "examples/puzzletron/orchestrate.py",
+            "--experiment",
+            str(tmp_path / "experiment.yaml"),
+            "--runner",
+            str(runner),
+            "--execution",
+            str(tmp_path / "execution.yaml"),
+        ],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 2
+    assert "unresolved REPLACE_WITH_ placeholders" in result.stderr
+    assert "runner.slurm.account" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_orchestrator_cli_reports_dry_run_adapter_errors_without_traceback(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/torch/puzzletron/test_orchestration_reporting.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_reporting.py
@@ -203,6 +203,19 @@ def test_clean_completion_regenerates_tampered_final_report(tmp_path: Path):
     assert result["report_status"] == "completed"
 
 
+def test_clean_completion_regenerates_oversized_completion_record(tmp_path: Path):
+    plan = _plan(tmp_path)
+    executor = _ReportExecutor(JobState.COMPLETED)
+    CampaignController(plan, executor=executor, poll_interval_seconds=0).run()
+    completion_path = plan.puzzle_dir / "artifacts/campaign_report/completion.json"
+    completion_path.write_bytes(completion_path.read_bytes() + b" " * (1 << 20))
+
+    result = CampaignController(plan, executor=executor, poll_interval_seconds=0).run()
+
+    assert [attempt.stage_id for attempt in executor.submitted] == ["final_report", "final_report"]
+    assert result["report_status"] == "completed"
+
+
 def test_final_report_failure_is_nonfatal(tmp_path: Path):
     plan = _plan(tmp_path)
     executor = _ReportExecutor(JobState.FAILED)

--- a/tests/unit/torch/puzzletron/test_orchestration_reporting.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_reporting.py
@@ -179,6 +179,30 @@ def test_clean_completion_generates_and_returns_final_report(tmp_path: Path):
     assert result["report_log_paths"] == [executor.submitted[0].command.log_path]
 
 
+def test_clean_completion_reuses_sealed_final_report(tmp_path: Path):
+    plan = _plan(tmp_path)
+    executor = _ReportExecutor(JobState.COMPLETED)
+
+    first = CampaignController(plan, executor=executor, poll_interval_seconds=0).run()
+    resumed = CampaignController(plan, executor=executor, poll_interval_seconds=0).run()
+
+    assert [attempt.stage_id for attempt in executor.submitted] == ["final_report"]
+    assert resumed == first
+
+
+def test_clean_completion_regenerates_tampered_final_report(tmp_path: Path):
+    plan = _plan(tmp_path)
+    executor = _ReportExecutor(JobState.COMPLETED)
+    CampaignController(plan, executor=executor, poll_interval_seconds=0).run()
+    report_path = plan.puzzle_dir / "artifacts/campaign_report/campaign_report.html"
+    report_path.write_text("tampered\n")
+
+    result = CampaignController(plan, executor=executor, poll_interval_seconds=0).run()
+
+    assert [attempt.stage_id for attempt in executor.submitted] == ["final_report", "final_report"]
+    assert result["report_status"] == "completed"
+
+
 def test_final_report_failure_is_nonfatal(tmp_path: Path):
     plan = _plan(tmp_path)
     executor = _ReportExecutor(JobState.FAILED)

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_smoke_plan.py
@@ -121,7 +121,9 @@ def test_qwen3p5_0p8b_full_smoke_keeps_runtime_budgets_bounded(
     nodes = config["post_mip"]["flows"]["params-90"]["nodes"]
 
     assert nodes["online_eval"]["config"] == {"eval_samples": 2, "block_size": 512}
-    assert nodes["best_lm"]["top_k"] == 1
+    assert config["mip"]["runs"]["params-90"]["solver"]["num_solutions"] == 1
+    assert config["mip"]["runs"]["params-90"]["homogeneous"]["keep"] == 5
+    assert nodes["best_lm"]["top_k"] == 2
     assert nodes["serving"]["config"]["request_count"] == 4
     assert nodes["serving"]["config"]["concurrency"] == [1]
     assert nodes["fastest"]["top_k"] == 1

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_smoke_plan.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU plan contracts for the complete Qwen 3.5 0.8B smoke journey."""
+
+from itertools import pairwise
+from pathlib import Path
+
+import yaml
+
+from puzzletron_orchestrator.compiler import (
+    compile_campaign_plan,
+    load_execution_config,
+    load_runner_config,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+FAMILY_ROOT = REPOSITORY_ROOT / "examples/puzzletron/configs/families/qwen3_5"
+FAMILY_PRESETS_PATH = FAMILY_ROOT / "setup_v2_defaults.yaml"
+EXPLICIT_SETUP_DEFAULTS_PATH = (
+    REPOSITORY_ROOT / "tests/_test_utils/torch/puzzletron/tiny_qwen_setup_defaults.yaml"
+)
+RUN_PATH = FAMILY_ROOT / "qwen3p5_0p8b/runs/full_smoke.yaml"
+ORCHESTRATION_ROOT = REPOSITORY_ROOT / "examples/puzzletron/configs/orchestration/qwen3p5_0p8b"
+RUNNER_PATH = ORCHESTRATION_ROOT / "runner.slurm.yaml"
+EXECUTION_PATH = ORCHESTRATION_ROOT / "execution.full_smoke.yaml"
+
+
+def _compile_plan(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("PUZZLETRON_RUN_ROOT", str(tmp_path / "results"))
+    monkeypatch.setenv("PUZZLETRON_DATASET_PATH", str(tmp_path / "dataset"))
+    return compile_campaign_plan(
+        experiment_config_path=RUN_PATH,
+        runner=load_runner_config(RUNNER_PATH),
+        execution=load_execution_config(EXECUTION_PATH),
+        stage_filter="full",
+    )
+
+
+def test_qwen3p5_0p8b_setup_contracts_remain_distinct() -> None:
+    family_presets = yaml.safe_load(FAMILY_PRESETS_PATH.read_text())
+    explicit_defaults = yaml.safe_load(EXPLICIT_SETUP_DEFAULTS_PATH.read_text())
+
+    assert family_presets["schema_version"] == 2
+    assert explicit_defaults["schema_version"] == 1
+
+
+def test_qwen3p5_0p8b_full_smoke_declares_its_hydra_inheritance(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    run_config = yaml.safe_load(RUN_PATH.read_text())
+    config = _compile_plan(monkeypatch, tmp_path).experiment_config
+
+    assert run_config["defaults"] == ["mip_smoke", "_self_"]
+    assert config["model"]["revision"] == "2fc06364715b967f1860aea9cf38778875588b17"
+    assert config["mip"]["runs"]["params-90"]["search_space"] == {
+        "depth": [0],
+        "embedding": [1024],
+        "axes_default": "teacher",
+        "axes": {"ffn.intermediate_size": "all"},
+    }
+    assert config["sort"]["deferred_axes"] == [
+        "kv_groups",
+        "q_heads_per_group",
+        "gdn_key_groups",
+        "gdn_value_heads_per_group",
+        "gdn_key_head_dim",
+        "gdn_value_head_dim",
+    ]
+    assert config["post_mip"]["flows"]["params-90"]["source"] == {
+        "run": "params-90",
+        "variants": "all",
+        "objectives": "all",
+    }
+
+
+def test_qwen3p5_0p8b_full_smoke_compiles_the_complete_one_gpu_route(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plan = _compile_plan(monkeypatch, tmp_path)
+    stage_ids = tuple(stage.stage_id for stage in plan.stages)
+    post_stage_ids = tuple(stage_id for stage_id in stage_ids if stage_id.startswith("post."))
+
+    assert post_stage_ids == (
+        "post.params-90.online_eval",
+        "post.params-90.best_lm",
+        "post.params-90.materialized",
+        "post.params-90.serving",
+        "post.params-90.fastest",
+        "post.params-90.short_kd",
+        "post.params-90.final_eval",
+        "post.params-90.best",
+    )
+    post_nodes = tuple(stage for stage in plan.stages if stage.stage_id.startswith("post."))
+    assert post_nodes[0].parents == ("mip",)
+    for parent, node in pairwise(post_nodes):
+        assert node.parents == (parent.stage_id,)
+    assert stage_ids[-1] == "post.params-90.best"
+    assert all(stage.total_gpus == 1 for stage in plan.stages)
+
+
+def test_qwen3p5_0p8b_full_smoke_keeps_runtime_budgets_bounded(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = _compile_plan(monkeypatch, tmp_path).experiment_config
+    nodes = config["post_mip"]["flows"]["params-90"]["nodes"]
+
+    assert nodes["online_eval"]["config"] == {"eval_samples": 2, "block_size": 512}
+    assert nodes["best_lm"]["top_k"] == 1
+    assert nodes["serving"]["config"]["request_count"] == 4
+    assert nodes["serving"]["config"]["concurrency"] == [1]
+    assert nodes["fastest"]["top_k"] == 1
+    assert nodes["short_kd"]["config"] == {
+        "max_steps": 2,
+        "global_batch_size": 1,
+        "local_batch_size": 1,
+        "checkpoint_every_steps": 2,
+    }
+    assert nodes["final_eval"]["config"] == {"eval_samples": 2, "block_size": 512}
+    assert nodes["best"]["top_k"] == 1


### PR DESCRIPTION
### What does this PR do?

The checked-in Qwen 3.5 0.8B MIP smoke recipe stopped after MIP, so it did not exercise the downstream lifecycle or prove that completed sanity and reporting artifacts remain stable across resumes. This change adds a bounded one-GPU path through evaluation, materialization, AIPerf, short global distillation, final evaluation, and selection while preserving sealed evidence and reusing a validated final report.

Type of change: new example

The guide uses the checked-in full-smoke experiment and execution configs with one site-specific runner. The same three inputs drive dry-run, launch, and resume, with the runner-template placeholders replaced before launch.

The diagnostics cleanup also makes existing optional-value checks explicit so the touched module satisfies strict typing without changing the accepted runtime values.

### Usage

Prepare a site-specific runner from the checked-in `runner.slurm.yaml` template, then use it for both inspection and launch:

```bash
EXPERIMENT=examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_smoke.yaml
EXECUTION=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_smoke.yaml
RUNNER=/path/to/site-specific/runner.slurm.yaml
export PUZZLETRON_RUN_ROOT=/path/to/campaign

python examples/puzzletron/orchestrate.py --experiment "$EXPERIMENT" --runner "$RUNNER" --execution "$EXECUTION" --stage full --dry-run
python examples/puzzletron/orchestrate.py --experiment "$EXPERIMENT" --runner "$RUNNER" --execution "$EXECUTION" --stage full
```

Rerun the launch command with the same inputs to resume the campaign.

### Testing

- Focused unit suites covering the full-smoke plan, hidden-width diagnostic, and final-report resume passed for the source and config changes; these tests compile and inspect plans without launching jobs.
- The full 18-stage one-GPU lifecycle completed, and an identical controller rerun submitted no work.
- Project hooks, strict typing, and Markdown lint cover the restacked change. The focused plan test could not collect in the managed local environment because `torch` is not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete Qwen3.5 0.8B smoke workflow covering evaluation, candidate selection, serving, throughput comparison, distillation, and final evaluation.
  * Added runner configuration checks that identify unresolved setup placeholders before submission.
  * Added reliable completion tracking and validation for final campaign reports.

* **Bug Fixes**
  * Existing valid reports are now reused on reruns, while altered or invalid reports are regenerated.
  * Improved diagnostic artifact validation and protected completed summaries from unintended changes.
  * Added safer handling for missing or malformed diagnostic data.

* **Documentation**
  * Updated the smoke-test guide with throughput-based candidate selection, setup requirements, and budget guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->