### PR TITLE
Add Qwen 3.5 0.8B VLM MIP smoke

### DIFF
--- a/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/mip_vlm_smoke.yaml
+++ b/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/mip_vlm_smoke.yaml
@@ -1,0 +1,56 @@
+# @package _global_
+
+defaults:
+  - mip_smoke
+  - _self_
+
+# Bounded one-GPU VLM smoke for the same pinned public checkpoint and FFN-only
+# MIP search as mip_smoke. Images and conversations are read through the native
+# AutoModel processor path; no text token cache is created or consumed.
+puzzle_dir: ${oc.env:PUZZLETRON_RUN_ROOT}
+dataset_path: ${oc.env:PUZZLETRON_DATASET_PATH}
+display_name: Qwen3p5_0p8B_VLM
+
+data:
+  modality: multimodal
+  layout: padded_varlen
+  max_sample_length: 512
+  path: ${dataset_path}
+  revision: ${oc.env:PUZZLETRON_DATASET_REVISION}
+  processor_identity: ${model_info.hf_repo}@${model_info.hf_revision}
+  packing:
+
+train_token_cache_path:
+validation_token_cache_path:
+tokenize_data:
+  enabled: false
+  caches: []
+
+pruning:
+  packed_token_cache_path:
+sort:
+  # The search is FFN-only; preserve unrelated attention and GDN ordering.
+  deferred_axes:
+    - kv_groups
+    - q_heads_per_group
+    - gdn_key_groups
+    - gdn_value_heads_per_group
+    - gdn_key_head_dim
+    - gdn_value_head_dim
+sort_sanity:
+  packed_token_cache_path:
+  # Exact FFN channel permutations change BF16 reduction order and produced
+  # sub-0.002 loss drift on the VLM smoke batch; keep the gate symmetric.
+  max_abs_lm_loss_delta: 0.002
+  max_abs_reverse_lm_loss_delta: 0.002
+  automodel:
+    # Keep the portable smoke independent of the optional FLA fused-KL backend.
+    lm_head_backend: streaming
+width_sanity:
+  packed_token_cache_path:
+depth_importance:
+  packed_token_cache_path:
+replacement_scoring:
+  packed_token_cache_path:
+  automodel:
+    lm_head_backend: streaming

--- a/examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.vlm_smoke.yaml
+++ b/examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.vlm_smoke.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# One native multimodal model instance on one GPU. Dataset tokenization happens
+# inside the processor-backed model stages, so the text tokenize stage is absent.
+execution:
+  defaults:
+    failure_policy: strict
+    halt_policy: drain
+    gpus_per_node: 1
+  stages:
+    convert: {strategy: single, instances: 1}
+    width_importance: {strategy: single, instances: 1}
+    sort: {strategy: single, instances: 1}
+    sort_sanity: {strategy: single, instances: 1}
+    width_sanity: {strategy: single, instances: 1}
+    slicing_sanity: {strategy: single, instances: 1}
+    build_library: {strategy: single, instances: 1}
+    replacement_scoring: {strategy: single, instances: 1}
+    mip: {strategy: single, instances: 1}

--- a/modelopt/torch/puzzletron/plugins/automodel/config.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/config.py
@@ -47,6 +47,7 @@ from omegaconf import OmegaConf
 from ...anymodel.model_descriptor import ModelDescriptorFactory
 from ...dataset.batch import DataLayout, Modality
 from ...dataset.config import PuzzletronDataSpec
+from ...security_policy import require_boolean_policy
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,16 @@ def _teacher_path(hydra_cfg) -> str:
     if explicit:
         return str(explicit)
     return f"{hydra_cfg.puzzle_dir}/{_DEFAULT_TEACHER_SUBDIR}"
+
+
+def _trust_remote_code(hydra_cfg) -> bool:
+    """Resolve the shared model and processor remote-code policy."""
+    model = _as_dict(hydra_cfg.get("model", None))
+    return require_boolean_policy(
+        model.get("trust_remote_code"),
+        path="model.trust_remote_code",
+        default=False,
+    )
 
 
 def _inject_canonical_data(
@@ -128,7 +139,7 @@ def _inject_canonical_data(
             dataset["num_samples"] = int(num_samples)
         recipe["dataset"] = dataset
         processor = dict(recipe.get("processor") or {})
-        processor.setdefault("trust_remote_code", True)
+        processor["trust_remote_code"] = bool(model.get("trust_remote_code", False))
         recipe["processor"] = processor
         # AutoModel's VLM recipe owns processor-aware padded and packed collation.
         dataloader = dict(recipe.get("dataloader") or {})
@@ -251,7 +262,7 @@ def build_stage_recipe_config(automodel_cfg) -> dict:
     return {
         "step_scheduler": {"global_batch_size": 1, "local_batch_size": 1, "max_steps": 1},
         "dist_env": {"backend": "nccl"},
-        "model": {"torch_dtype": "bf16", "trust_remote_code": True},
+        "model": {"torch_dtype": "bf16", "trust_remote_code": False},
         "checkpoint": {"enabled": False},
         "distributed": distributed,
         "distributed_config": {
@@ -371,7 +382,7 @@ def inject_descriptor_pipeline_config(
     *,
     model_path,
     descriptor_name,
-    trust_remote_code: bool = True,
+    trust_remote_code: bool = False,
 ) -> dict:
     """Let the model descriptor customize AutoModel PP splitting for this recipe.
 
@@ -528,7 +539,7 @@ def build_recipe_config(hydra_cfg) -> dict:
     model["pretrained_model_name_or_path"] = _teacher_path(hydra_cfg)
     model.setdefault("anymodel_descriptor", hydra_cfg.get("descriptor", None))
     model.setdefault("force_hf", bool(_as_dict(automodel_cfg).get("force_hf", True)))
-    model.setdefault("trust_remote_code", True)
+    model["trust_remote_code"] = _trust_remote_code(hydra_cfg)
     recipe["model"] = model
 
     if model["anymodel_descriptor"] is None:
@@ -553,14 +564,14 @@ def build_recipe_config(hydra_cfg) -> dict:
         recipe,
         model_path=model["pretrained_model_name_or_path"],
         descriptor_name=model["anymodel_descriptor"],
-        trust_remote_code=bool(model.get("trust_remote_code", True)),
+        trust_remote_code=bool(model.get("trust_remote_code", False)),
     )
 
     inject_descriptor_pipeline_config(
         recipe,
         model_path=model["pretrained_model_name_or_path"],
         descriptor_name=model["anymodel_descriptor"],
-        trust_remote_code=bool(model.get("trust_remote_code", True)),
+        trust_remote_code=bool(model.get("trust_remote_code", False)),
     )
     _align_pipeline_seq_len(recipe, block_size=hydra_cfg.pruning.get("block_size", None))
     _align_pipeline_batch_size(
@@ -577,14 +588,20 @@ def build_recipe_config(hydra_cfg) -> dict:
     return recipe
 
 
-def _inject_model(recipe: dict, model_path, descriptor, force_hf: bool) -> dict:
+def _inject_model(
+    recipe: dict,
+    model_path,
+    descriptor,
+    force_hf: bool,
+    trust_remote_code: bool,
+) -> dict:
     """Set the recipe's ``model`` block to load ``model_path`` via the patched from_pretrained."""
     model = dict(recipe.get("model", {}))
     model.setdefault("_target_", _FROM_PRETRAINED_TARGET)
     model["pretrained_model_name_or_path"] = str(model_path)
     model.setdefault("anymodel_descriptor", descriptor)
     model.setdefault("force_hf", bool(force_hf))
-    model.setdefault("trust_remote_code", True)
+    model["trust_remote_code"] = trust_remote_code
     recipe["model"] = model
     if model["anymodel_descriptor"] is None:
         raise ValueError(
@@ -594,13 +611,13 @@ def _inject_model(recipe: dict, model_path, descriptor, force_hf: bool) -> dict:
         recipe,
         model_path=model["pretrained_model_name_or_path"],
         descriptor_name=model["anymodel_descriptor"],
-        trust_remote_code=bool(model.get("trust_remote_code", True)),
+        trust_remote_code=bool(model.get("trust_remote_code", False)),
     )
     inject_descriptor_pipeline_config(
         recipe,
         model_path=model["pretrained_model_name_or_path"],
         descriptor_name=model["anymodel_descriptor"],
-        trust_remote_code=bool(model.get("trust_remote_code", True)),
+        trust_remote_code=bool(model.get("trust_remote_code", False)),
     )
     return recipe
 
@@ -617,7 +634,13 @@ def build_solution_recipe_config(hydra_cfg, model_path) -> dict:
     force_hf = bool(_as_dict(automodel_cfg).get("force_hf", False))
     runtime_cfg = hydra_cfg.get("_runtime", {}) or {}
     descriptor = hydra_cfg.get("descriptor", None) or runtime_cfg.get("descriptor", None)
-    recipe = _inject_model(recipe, model_path, descriptor, force_hf)
+    recipe = _inject_model(
+        recipe,
+        model_path,
+        descriptor,
+        force_hf,
+        _trust_remote_code(hydra_cfg),
+    )
     _inject_canonical_data(
         recipe,
         hydra_cfg,

--- a/modelopt/torch/puzzletron/plugins/automodel/config.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/config.py
@@ -45,7 +45,8 @@ from pathlib import Path
 from omegaconf import OmegaConf
 
 from ...anymodel.model_descriptor import ModelDescriptorFactory
-from ...dataset.config import DataLayout, Modality, PuzzletronDataSpec
+from ...dataset.batch import DataLayout, Modality
+from ...dataset.config import PuzzletronDataSpec
 
 logger = logging.getLogger(__name__)
 
@@ -60,9 +61,7 @@ __all__ = [
 ]
 
 _FROM_PRETRAINED_TARGET = "nemo_automodel.NeMoAutoModelForCausalLM.from_pretrained"
-_FROM_PRETRAINED_VLM_TARGET = (
-    "nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained"
-)
+_FROM_PRETRAINED_VLM_TARGET = "nemo_automodel.NeMoAutoModelForImageTextToText.from_pretrained"
 _DEFAULT_TEACHER_SUBDIR = "ckpts/teacher"
 
 
@@ -108,8 +107,7 @@ def _inject_canonical_data(
     if spec.modality is Modality.MULTIMODAL:
         if bool(model.get("force_hf", True)):
             raise ValueError(
-                "multimodal Puzzletron stages require native AutoModel; "
-                "set model.force_hf=False"
+                "multimodal Puzzletron stages require native AutoModel; set model.force_hf=False"
             )
         model["_target_"] = _FROM_PRETRAINED_VLM_TARGET
         recipe["model"] = model
@@ -117,8 +115,7 @@ def _inject_canonical_data(
         dataset.update(
             {
                 "_target_": (
-                    "modelopt.torch.puzzletron.dataset."
-                    "load_materialized_conversation_dataset"
+                    "modelopt.torch.puzzletron.dataset.load_materialized_conversation_dataset"
                 ),
                 "path_or_dataset": str(source_path),
                 "pretokenize": True,
@@ -133,19 +130,19 @@ def _inject_canonical_data(
         processor = dict(recipe.get("processor") or {})
         processor.setdefault("trust_remote_code", True)
         recipe["processor"] = processor
+        # AutoModel's VLM recipe owns processor-aware padded and packed collation.
+        dataloader = dict(recipe.get("dataloader") or {})
+        dataloader.pop("collate_fn", None)
+        recipe["dataloader"] = dataloader
     elif spec.layout is not DataLayout.FIXED:
-        if (
-            spec.layout is DataLayout.PACKED_VARLEN
-            and bool(model.get("force_hf", True))
-        ):
+        if spec.layout is DataLayout.PACKED_VARLEN and bool(model.get("force_hf", True)):
             raise ValueError(
                 "packed variable-length text data require native AutoModel; "
                 "set model.force_hf=False"
             )
         dataset = {
             "_target_": (
-                "modelopt.torch.puzzletron.distillation.dataset."
-                "make_puzzletron_chat_dataset"
+                "modelopt.torch.puzzletron.distillation.dataset.make_puzzletron_chat_dataset"
             ),
             "dataset_path": str(source_path),
             "split": str(split),
@@ -162,6 +159,7 @@ def _inject_canonical_data(
         }
     if spec.layout is DataLayout.PACKED_VARLEN:
         packing = spec.packing
+        assert packing is not None
         if spec.modality is Modality.MULTIMODAL:
             recipe["packed_sequence"] = {
                 "pack_size": int(packing.pack_size),
@@ -313,9 +311,7 @@ def _merge_required_mapping(target: dict, required: dict, *, path: str) -> None:
         elif isinstance(target[key], dict) and isinstance(value, dict):
             _merge_required_mapping(target[key], value, path=key_path)
         elif target[key] != value:
-            raise ValueError(
-                f"Descriptor requires {key_path}={value!r}, got {target[key]!r}"
-            )
+            raise ValueError(f"Descriptor requires {key_path}={value!r}, got {target[key]!r}")
 
 
 def inject_descriptor_model_kwargs(
@@ -480,7 +476,9 @@ def _align_pipeline_batch_size(recipe: dict, *, micro_batch_size) -> dict:
     # slicing or the PP microbatch shape.
     scheduler_dp = max(
         _int_or_default(
-            explicit_dp if explicit_dp not in (None, "none", "None", "") else distributed.get("ep_size"),
+            explicit_dp
+            if explicit_dp not in (None, "none", "None", "")
+            else distributed.get("ep_size"),
             1,
         ),
         1,
@@ -498,9 +496,7 @@ def _align_pipeline_batch_size(recipe: dict, *, micro_batch_size) -> dict:
             )
         batch_dp = max(scheduler_dp // ep_size, 1)
     global_batch = int(micro_batch_size)
-    local_batch = (
-        global_batch // batch_dp if global_batch % batch_dp == 0 else global_batch
-    )
+    local_batch = global_batch // batch_dp if global_batch % batch_dp == 0 else global_batch
     scheduler = dict(recipe.get("step_scheduler") or {})
     if _int_or_default(distributed.get("pp_size"), 1) <= 1:
         scheduler["local_batch_size"] = local_batch
@@ -631,15 +627,11 @@ def build_solution_recipe_config(hydra_cfg, model_path) -> dict:
     _align_dummy_dataset(
         recipe,
         num_samples=hydra_cfg.scoring.get("eval_samples", None),
-        block_size=hydra_cfg.scoring.get(
-            "block_size", hydra_cfg.pruning.get("block_size", None)
-        ),
+        block_size=hydra_cfg.scoring.get("block_size", hydra_cfg.pruning.get("block_size", None)),
     )
     _align_pipeline_seq_len(
         recipe,
-        block_size=hydra_cfg.scoring.get(
-            "block_size", hydra_cfg.pruning.get("block_size", None)
-        ),
+        block_size=hydra_cfg.scoring.get("block_size", hydra_cfg.pruning.get("block_size", None)),
     )
     _align_pipeline_batch_size(
         recipe, micro_batch_size=hydra_cfg.scoring.get("micro_batch_size", None)
@@ -687,9 +679,7 @@ def solution_scoring_params(hydra_cfg) -> dict:
         "lm_head_backend": str(automodel_cfg.get("lm_head_backend", "flash_kld")),
         "teacher_cache_device": teacher_cache_device,
         "flash_kld_token_chunk_size": automodel_cfg.get("flash_kld_token_chunk_size", None),
-        "flash_kld_reduction_backend": str(
-            automodel_cfg.get("flash_kld_reduction_backend", "fla")
-        ),
+        "flash_kld_reduction_backend": str(automodel_cfg.get("flash_kld_reduction_backend", "fla")),
     }
 
 

--- a/modelopt/torch/puzzletron/plugins/automodel/scoring_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/scoring_recipe.py
@@ -43,6 +43,7 @@ import logging
 import os
 import re
 import shutil
+from collections.abc import Mapping
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
@@ -111,7 +112,7 @@ def _force_forward_only_pp_schedule(
     """
     info = getattr(pp, "info", None)
     schedule = getattr(info, "schedule", None)
-    if schedule is None:
+    if info is None or schedule is None:
         return
 
     from torch.distributed.pipelining.schedules import _ScheduleForwardOnly
@@ -181,8 +182,7 @@ def _strip_stale_pp_layer_kwargs(module, args, kwargs):
     try:
         signature = inspect.signature(module.forward)
         accepts_var_kwargs = any(
-            param.kind is inspect.Parameter.VAR_KEYWORD
-            for param in signature.parameters.values()
+            param.kind is inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()
         )
         if not accepts_var_kwargs:
             allowed = set(signature.parameters)
@@ -231,8 +231,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             else None
         )
         self._use_vlm_recipe = bool(
-            self._data_spec is not None
-            and self._data_spec.modality is Modality.MULTIMODAL
+            self._data_spec is not None and self._data_spec.modality is Modality.MULTIMODAL
         )
         self._groups: MeshGroups | None = None
         self._scorers: list | None = None
@@ -386,13 +385,17 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                         candidate = torch.load(
                             candidate_path, map_location="cpu", weights_only=False
                         )
-                        candidate_identity = [tuple(value) for value in candidate.get("scorers", [])]
+                        candidate_identity = [
+                            tuple(value) for value in candidate.get("scorers", [])
+                        ]
                         candidate_steps = {
                             int(state["curr_iter"])
                             for state in candidate.get("states", [])
                             if isinstance(state, dict) and state.get("curr_iter") is not None
                         }
-                        if candidate_identity == expected_identity and candidate_steps == {min_step}:
+                        if candidate_identity == expected_identity and candidate_steps == {
+                            min_step
+                        }:
                             peer_payload = candidate
                             break
                     if peer_payload is None:
@@ -440,14 +443,10 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         from ...tools.logger import mprint
 
         additive = [
-            scorer
-            for scorer in (self._scorers or [])
-            if "lane_gram" in scorer.checkpoint_state()
+            scorer for scorer in (self._scorers or []) if "lane_gram" in scorer.checkpoint_state()
         ]
         iterative = [
-            scorer
-            for scorer in (self._scorers or [])
-            if "curr_iter" in scorer.checkpoint_state()
+            scorer for scorer in (self._scorers or []) if "curr_iter" in scorer.checkpoint_state()
         ]
         before = [scorer.checkpoint_state() for scorer in additive]
         for scorer in iterative:
@@ -575,9 +574,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             # legacy Puzzletron loader already returns one packed row and must
             # continue to execute as one microbatch.
             forward_microbatches = (
-                None
-                if self._use_vlm_recipe and not self._use_puzzletron_dataloader
-                else 1
+                None if self._use_vlm_recipe and not self._use_puzzletron_dataloader else 1
             )
             _force_forward_only_pp_schedule(
                 self.pp,
@@ -608,14 +605,14 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                 f"cache={self._pruning_cfg.get('realized_dataset_cache_dir', None)}"
             )
             if self.dist_env.is_main:
-                mprint(f"[activation/automodel] setup: rank0 preparing Puzzletron dataloader ({dataloader_msg})")
+                mprint(
+                    f"[activation/automodel] setup: rank0 preparing Puzzletron dataloader ({dataloader_msg})"
+                )
                 self.dataloader = prepare_validation_dataloader(
                     self._pruning_cfg,
                     None,
                     data_layout=(
-                        self._data_spec.layout.value
-                        if self._data_spec is not None
-                        else None
+                        self._data_spec.layout.value if self._data_spec is not None else None
                     ),
                 )
                 mprint(
@@ -627,14 +624,14 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                 torch.distributed.barrier()
                 aprint("[activation/automodel] setup: dataloader barrier complete")
             if not self.dist_env.is_main:
-                aprint(f"[activation/automodel] setup: rank preparing Puzzletron dataloader ({dataloader_msg})")
+                aprint(
+                    f"[activation/automodel] setup: rank preparing Puzzletron dataloader ({dataloader_msg})"
+                )
                 self.dataloader = prepare_validation_dataloader(
                     self._pruning_cfg,
                     None,
                     data_layout=(
-                        self._data_spec.layout.value
-                        if self._data_spec is not None
-                        else None
+                        self._data_spec.layout.value if self._data_spec is not None else None
                     ),
                 )
                 aprint(
@@ -710,9 +707,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         if descriptor_name is None:
             model_cfg = getattr(self.cfg, "model", None)
             descriptor_name = getattr(model_cfg, "anymodel_descriptor", None)
-        model_descriptor = (
-            ModelDescriptorFactory.get(descriptor_name) if descriptor_name else None
-        )
+        model_descriptor = ModelDescriptorFactory.get(descriptor_name) if descriptor_name else None
         self._model_descriptor = model_descriptor
 
         if self._use_vlm_recipe and model_descriptor is not None:
@@ -780,8 +775,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                     )
 
         self._scorer_groups = [
-            (spec_scorer_lists[i], spec["activations_log_dir"])
-            for i, spec in enumerate(all_specs)
+            (spec_scorer_lists[i], spec["activations_log_dir"]) for i, spec in enumerate(all_specs)
         ]
         self._scorers = [s for scorers, _ in self._scorer_groups for s in scorers]
 
@@ -827,9 +821,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             cp_rank, cp_size = self._cp_info()
             if cp_size > 1:
                 automodel_cfg = (
-                    self._pruning_cfg.get("automodel", {})
-                    if self._pruning_cfg is not None
-                    else {}
+                    self._pruning_cfg.get("automodel", {}) if self._pruning_cfg is not None else {}
                 )
                 gdn_cp_backend = str(automodel_cfg.get("gdn_cp_backend", "native_fla"))
                 if gdn_cp_backend == "replicated_exact":
@@ -844,11 +836,11 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                     raise ValueError(f"Unknown automodel.gdn_cp_backend={gdn_cp_backend!r}")
                 if bool(automodel_cfg.get("trace_layer_forwards", False)):
                     n_traces = self._install_layer_forward_traces()
-                    mprint(
-                        f"[activation/automodel] layer forward traces on {n_traces} module(s)"
-                    )
+                    mprint(f"[activation/automodel] layer forward traces on {n_traces} module(s)")
                 n_cp_hooks = self._install_cp_position_overrides(cp_rank, cp_size)
-                mprint(f"[activation/automodel] CP position override hooks on {n_cp_hooks} module(s)")
+                mprint(
+                    f"[activation/automodel] CP position override hooks on {n_cp_hooks} module(s)"
+                )
             # Null out the schedule's loss_fn so _maybe_compute_loss is a no-op.
             # After removing lm_head the last stage returns hidden_states; the schedule
             # would still try to compute loss (and crash on None target_mbs) unless we
@@ -1001,22 +993,17 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             submod = getattr(stage, "submod", None)
             if submod is None:
                 continue
-            lm_head_passthrough = bool(
-                getattr(submod, "_puzzletron_lm_head_passthrough", False)
-            )
-            mtp_disabled = bool(
-                getattr(submod, "_puzzletron_mtp_disabled_for_scoring", False)
-            )
-            if (
-                getattr(submod, "lm_head", None) is not None
-                and not lm_head_passthrough
-            ):
+            lm_head_passthrough = bool(getattr(submod, "_puzzletron_lm_head_passthrough", False))
+            mtp_disabled = bool(getattr(submod, "_puzzletron_mtp_disabled_for_scoring", False))
+            if getattr(submod, "lm_head", None) is not None and not lm_head_passthrough:
                 continue
             if not getattr(stage, "is_last", False) and not mtp_disabled:
                 continue
             inputs_meta = getattr(stage, "inputs_meta", None)
             if not inputs_meta:
-                aprint("[activation/automodel] PP last-stage inputs_meta absent; runtime shape inference will be used")
+                aprint(
+                    "[activation/automodel] PP last-stage inputs_meta absent; runtime shape inference will be used"
+                )
                 continue
             first_meta = inputs_meta[0]
             if not torch.is_tensor(first_meta) or first_meta.dim() < 2:
@@ -1027,11 +1014,14 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             hidden_size = int(first_meta.shape[2]) if first_meta.dim() >= 3 else None
             if hidden_size is None:
                 cfg = getattr(submod, "config", None)
-                if hasattr(cfg, "text_config") and not hasattr(cfg, "hidden_size"):
-                    cfg = cfg.text_config
+                text_config = getattr(cfg, "text_config", None)
+                if text_config is not None and not hasattr(cfg, "hidden_size"):
+                    cfg = text_config
                 hidden_size = getattr(cfg, "hidden_size", None)
             if hidden_size is None:
-                aprint("[activation/automodel] could not infer hidden_size for PP last-stage output metadata")
+                aprint(
+                    "[activation/automodel] could not infer hidden_size for PP last-stage output metadata"
+                )
                 continue
 
             try:
@@ -1177,8 +1167,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                 return output.full_tensor()
             if isinstance(output, tuple):
                 return tuple(
-                    value.full_tensor() if isinstance(value, DTensor) else value
-                    for value in output
+                    value.full_tensor() if isinstance(value, DTensor) else value for value in output
                 )
             return output
 
@@ -1228,9 +1217,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         if "tp" in mesh_dim_names and len(mesh_dim_names) == len(placements):
             return isinstance(placements[mesh_dim_names.index("tp")], Replicate)
         return (
-            value_mesh is tp_mesh
-            and len(placements) == 1
-            and isinstance(placements[0], Replicate)
+            value_mesh is tp_mesh and len(placements) == 1 and isinstance(placements[0], Replicate)
         )
 
     @classmethod
@@ -1269,6 +1256,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             has_first_stage = bool(self.pp.info.has_first_stage)
         distributed_cfg = getattr(self.cfg, "distributed", None)
         sequence_parallel = bool(getattr(distributed_cfg, "sequence_parallel", False))
+        assert self._groups is not None, "call setup() before installing PP restorers"
         tp_size = int(self._groups.tp_size)
         pruning_cfg = getattr(self, "_pruning_cfg", None)
         trace_enabled = bool(
@@ -1356,9 +1344,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             return args, kwargs
 
         roots = [
-            stage.submod
-            for stage in local_stages
-            if getattr(stage, "submod", None) is not None
+            stage.submod for stage in local_stages if getattr(stage, "submod", None) is not None
         ]
         roots.extend(self.model_parts or [])
         modules = []
@@ -1447,10 +1433,14 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                 if cp_size > 1:
                     cp_group = cp_mesh.get_group()
                     cp_rank = dist.get_rank(cp_group)
-                    mprint(f"[activation/automodel] CP sharding active: cp_rank={cp_rank} cp_size={cp_size}")
+                    mprint(
+                        f"[activation/automodel] CP sharding active: cp_rank={cp_rank} cp_size={cp_size}"
+                    )
                     return cp_rank, cp_size
             else:
-                mprint(f"[activation/automodel] _cp_info: device_mesh.mesh_dim_names={dim_names!r} — 'cp' not found")
+                mprint(
+                    f"[activation/automodel] _cp_info: device_mesh.mesh_dim_names={dim_names!r} — 'cp' not found"
+                )
         else:
             mprint("[activation/automodel] _cp_info: self.device_mesh is None")
 
@@ -1462,7 +1452,9 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                     grp = cp_mesh.get_group()
                     cp_rank = dist.get_rank(grp)
                     cp_size = dist.get_world_size(grp)
-                    mprint(f"[activation/automodel] CP sharding via module._cp_mesh: cp_rank={cp_rank} cp_size={cp_size}")
+                    mprint(
+                        f"[activation/automodel] CP sharding via module._cp_mesh: cp_rank={cp_rank} cp_size={cp_size}"
+                    )
                     return cp_rank, cp_size
 
         mprint("[activation/automodel] _cp_info: CP not detected (size=1 or not configured)")
@@ -1573,7 +1565,9 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             return 1, 0
         return dp_size, (int(token_rank) // int(cp_size)) % dp_size
 
-    def _trace_pp_eval(self, phase: str, step: int, input_ids=None, extra: dict | None = None) -> None:
+    def _trace_pp_eval(
+        self, phase: str, step: int, input_ids=None, extra: dict | None = None
+    ) -> None:
         trace_enabled = bool(
             self._pruning_cfg.get("automodel", {}).get("trace_layer_forwards", False)
             if self._pruning_cfg is not None
@@ -1608,7 +1602,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             if bool(batch.source_metadata.get("distributed_sampler_sharded", False)):
                 return batch
             return batch.dp_slice(dp_rank=self._dp_rank, dp_size=self._dp_size)
-        if not isinstance(batch, dict):
+        if not isinstance(batch, Mapping):
             return batch
         out = {}
         for k, v in batch.items():
@@ -1624,13 +1618,14 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             return batch
         if self._data_spec is None:
             return None
-        if not isinstance(batch, dict):
+        if not isinstance(batch, Mapping):
             raise TypeError(
                 f"canonical Puzzletron data expected a mapping batch, got {type(batch).__name__}"
             )
         input_ids = batch.get("input_ids")
         if not torch.is_tensor(input_ids):
             raise ValueError("canonical Puzzletron batch has no input_ids")
+        assert isinstance(input_ids, torch.Tensor)
         batch_size = int(input_ids.shape[0]) if input_ids.ndim > 1 else 1
         source_metadata = {
             "dataset": self._data_cfg.get("path"),
@@ -1673,17 +1668,20 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         batch = batch.to(device)
         payload = dict(batch.model_kwargs)
         payload["labels"] = (
-            batch.labels
-            if batch.labels is not None
-            else torch.full_like(batch.input_ids, -100)
+            batch.labels if batch.labels is not None else torch.full_like(batch.input_ids, -100)
         )
         sequence_ids = batch.sequence.seq_ids
         if sequence_ids is None:
-            sequence_ids = torch.arange(
-                batch.batch_size,
-                dtype=torch.long,
-                device=device,
-            ).unsqueeze(1).expand(-1, batch.sequence_length).clone()
+            sequence_ids = (
+                torch.arange(
+                    batch.batch_size,
+                    dtype=torch.long,
+                    device=device,
+                )
+                .unsqueeze(1)
+                .expand(-1, batch.sequence_length)
+                .clone()
+            )
             if batch.hidden_mask is not None:
                 sequence_ids.masked_fill_(~batch.hidden_mask, -1)
         else:
@@ -1734,17 +1732,13 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             {
                 **payload,
                 "_puzzletron_ce_mask": (
-                    batch.ce_mask
-                    if batch.ce_mask is not None
-                    else payload["labels"].ne(-100)
+                    batch.ce_mask if batch.ce_mask is not None else payload["labels"].ne(-100)
                 ),
                 "_puzzletron_kd_mask": (
                     batch.kd_mask
                     if batch.kd_mask is not None
                     else (
-                        batch.ce_mask
-                        if batch.ce_mask is not None
-                        else payload["labels"].ne(-100)
+                        batch.ce_mask if batch.ce_mask is not None else payload["labels"].ne(-100)
                     )
                 ),
                 "_puzzletron_hidden_mask": (
@@ -1872,8 +1866,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
             ),
             "batch_fingerprints": list(
                 dict.fromkeys(
-                    [*resumed.get("batch_fingerprints", [])]
-                    + self._canonical_batch_fingerprints
+                    [*resumed.get("batch_fingerprints", [])] + self._canonical_batch_fingerprints
                 )
             ),
         }
@@ -1882,19 +1875,20 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         local = self._local_observability_metadata()
         if not torch.distributed.is_initialized():
             return local
-        gathered = [None] * torch.distributed.get_world_size()
+        gathered: list[dict[str, Any] | None] = [None] * torch.distributed.get_world_size()
         torch.distributed.all_gather_object(gathered, local)
+        gathered_items = [item for item in gathered if item is not None]
+        if len(gathered_items) != len(gathered):
+            raise RuntimeError("observability gather returned an empty rank payload")
         return {
-            "vision_forward_count": sum(item["vision_forward_count"] for item in gathered),
+            "vision_forward_count": sum(item["vision_forward_count"] for item in gathered_items),
             "vision_output_checksums": sorted(
-                checksum
-                for item in gathered
-                for checksum in item["vision_output_checksums"]
+                checksum for item in gathered_items for checksum in item["vision_output_checksums"]
             ),
             "batch_fingerprints": sorted(
                 set(
                     fingerprint
-                    for item in gathered
+                    for item in gathered_items
                     for fingerprint in item["batch_fingerprints"]
                 )
             ),
@@ -1939,6 +1933,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         canonical = self._canonicalize_batch(batch, step)
         if canonical is not None:
             canonical = self._dp_slice_batch(canonical)
+            assert isinstance(canonical, PuzzletronBatch)
             if step >= 0 and samples_hashing_enabled():
                 log_batch_hashes(
                     canonical.input_ids,
@@ -1951,7 +1946,12 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         batch = self._dp_slice_batch(batch)  # data-parallel: this rank's sub-batch
         cp_rank, cp_size = self._cp_info()
         # Debug: record which samples this rank actually feeds (gated by PUZZLE_HASH_SAMPLES).
-        if step >= 0 and samples_hashing_enabled() and isinstance(batch, dict) and "input_ids" in batch:
+        if (
+            step >= 0
+            and samples_hashing_enabled()
+            and isinstance(batch, dict)
+            and "input_ids" in batch
+        ):
             log_batch_hashes(
                 batch["input_ids"], "automodel", step, extra=f"dp={self._dp_rank} cp={cp_rank}"
             )
@@ -1987,9 +1987,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                     )
                 input_ids = self._shard_seq_for_cp(input_ids, cp_rank, cp_size)
                 targets = self._shard_seq_for_cp(targets, cp_rank, cp_size)
-                extra = {
-                    k: self._shard_seq_for_cp(v, cp_rank, cp_size) for k, v in extra.items()
-                }
+                extra = {k: self._shard_seq_for_cp(v, cp_rank, cp_size) for k, v in extra.items()}
             tp_group = self.tensor_parallel_group()
             if bool(
                 self._pruning_cfg.get("automodel", {}).get("trace_layer_forwards", False)
@@ -2027,9 +2025,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                     inputs["position_ids"] = (
                         torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
                     )
-                inputs = {
-                    k: self._shard_seq_for_cp(v, cp_rank, cp_size) for k, v in inputs.items()
-                }
+                inputs = {k: self._shard_seq_for_cp(v, cp_rank, cp_size) for k, v in inputs.items()}
             with self._forward_autocast_context():
                 model(**inputs)
 
@@ -2040,6 +2036,8 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         from ...tools.logger import mprint
 
         assert self._scorers is not None, "call setup() before run_scoring()"
+        assert self._groups is not None, "call setup() before run_scoring()"
+        assert self._eval_iters is not None, "setup must resolve evaluation iterations"
 
         total = self._eval_iters
 
@@ -2052,7 +2050,9 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         # for HF MoE stages.
         if self.pp is not None:
             if self._pp_metadata_ready():
-                mprint("[activation/automodel] skipping PP warmup: stage shape metadata is precomputed")
+                mprint(
+                    "[activation/automodel] skipping PP warmup: stage shape metadata is precomputed"
+                )
             else:
                 mprint("[activation/automodel] warmup forward (hooks disabled) to prime PP shapes")
                 for scorer in self._scorers:
@@ -2077,6 +2077,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         # Cycle the dataloader when pruning_iters > len(dataloader) so that the number of
         # greedy scoring steps is determined by pruning_iters, not by dataset size.
         import itertools
+
         dl_len = len(self.dataloader) if hasattr(self.dataloader, "__len__") else None
         if total is not None and dl_len is not None and total > dl_len:
             data_iter = itertools.islice(itertools.cycle(self.dataloader), start_step, total)
@@ -2137,6 +2138,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
 
         if self._scorer_groups is None:
             # Backward-compat: old-style single-group (no scorer_groups set).
+            assert self._activations_log_dir is not None
             results = write_scores(self._scorers, self._activations_log_dir, self._groups)
             if self.dist_env.is_main:
                 mprint(f"[activation/automodel] wrote {len(results)} module scores")

--- a/modelopt/torch/puzzletron/plugins/automodel/scoring_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/scoring_recipe.py
@@ -51,6 +51,8 @@ from typing import Any
 import torch
 from nemo_automodel.recipes.llm.train_ft import TrainFinetuneRecipeForNextTokenPrediction
 
+from modelopt.torch.utils import safe_load, safe_save
+
 from ...anymodel.model_descriptor import ModelDescriptorFactory
 from ...dataset import (
     DataLayout,
@@ -322,7 +324,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         state_path = resume_dir / f"rank_{rank}.pth"
         if not state_path.is_file():
             raise RuntimeError(f"Activation resume is missing rank state: {state_path}")
-        payload = torch.load(state_path, map_location="cpu", weights_only=False)
+        payload = safe_load(state_path, map_location="cpu")
         self._resumed_observability_local = dict(payload.get("observability") or {})
         expected_identity = self._scorer_identity()
         saved_identity = [tuple(value) for value in payload.get("scorers", [])]
@@ -382,9 +384,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
                         if peer_rank == rank or peer_rank % tp_size != rank % tp_size:
                             continue
                         candidate_path = resume_dir / f"rank_{peer_rank}.pth"
-                        candidate = torch.load(
-                            candidate_path, map_location="cpu", weights_only=False
-                        )
+                        candidate = safe_load(candidate_path, map_location="cpu")
                         candidate_identity = [
                             tuple(value) for value in candidate.get("scorers", [])
                         ]
@@ -508,7 +508,7 @@ class ActivationScoringRecipe(TrainFinetuneRecipeForNextTokenPrediction):
         }
         state_path = resume_dir / f"rank_{rank}.pth"
         tmp_path = state_path.with_suffix(".tmp")
-        torch.save(payload, tmp_path)
+        safe_save(payload, tmp_path)
         tmp_path.replace(state_path)
         if torch.distributed.is_initialized():
             torch.distributed.barrier()

--- a/tests/gpu/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke.py
+++ b/tests/gpu/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in real-checkpoint smoke for the Qwen 3.5 0.8B VLM MIP route."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from PIL import Image
+
+from modelopt.torch.puzzletron.dataset.multimodal import materialize_normalized_conversation_samples
+from modelopt.torch.puzzletron.pipeline_config import pipeline_config_from_path
+
+RUN_PATH = "examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/mip_vlm_smoke.yaml"
+EXECUTION_PATH = "examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.vlm_smoke.yaml"
+
+
+def _materialize_image_conversations(path: Path) -> None:
+    images = []
+    samples = []
+    answer = (
+        "The image contains a colored square used to validate multimodal model pruning. " * 16
+    ).strip()
+    for index in range(8):
+        image = Image.new("RGB", (32, 32), color=(index * 8, 32, 255 - index * 8))
+        images.append(image)
+        samples.append(
+            {
+                "source": {
+                    "dataset": "qwen3p5-vlm-smoke-fixture",
+                    "revision": "1",
+                    "row_id": f"row-{index}",
+                },
+                "image_count": 1,
+                "conversation": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "image": image},
+                            {"type": "text", "text": "Describe the colored square."},
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": answer}],
+                    },
+                ],
+            }
+        )
+    try:
+        manifest = materialize_normalized_conversation_samples(
+            samples,
+            path,
+            expected_count=len(samples),
+        )
+    finally:
+        for image in images:
+            image.close()
+    assert manifest["sample_count"] == manifest["image_count"] == len(samples)
+
+
+def _write_local_runner(path: Path, project_root: Path) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "runner": {
+                    "kind": "slurm",
+                    "slurm": {"account": "local-smoke", "max_nodes": 1},
+                    "execution_contract": {
+                        "repository": str(project_root),
+                        "venv": sys.prefix,
+                        "container": None,
+                        "container_mounts": None,
+                        "prerun_commands": [],
+                        "postrun_commands": [],
+                    },
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.manual(reason="downloads and prunes the real Qwen 3.5 0.8B VLM checkpoint")
+@pytest.mark.timeout(2400)
+def test_qwen3p5_0p8b_orchestrated_vlm_mip_smoke_completes(
+    project_root_path: Path,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Run through MIP and prove that image inputs reach the vision tower."""
+
+    dataset = tmp_path / "dataset"
+    results = tmp_path / "results"
+    cache = tmp_path / "cache"
+    runner = tmp_path / "runner.yaml"
+    _materialize_image_conversations(dataset)
+    _write_local_runner(runner, project_root_path)
+    monkeypatch.setenv("PUZZLETRON_RUN_ROOT", str(results))
+    monkeypatch.setenv("PUZZLETRON_DATASET_PATH", str(dataset))
+    monkeypatch.setenv("PUZZLETRON_DATASET_REVISION", "fixture-revision")
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HF_HOME": str(cache / "huggingface"),
+            "HF_DATASETS_CACHE": str(cache / "datasets"),
+            "TORCH_HOME": str(cache / "torch"),
+            "XDG_CACHE_HOME": str(cache / "xdg"),
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(project_root_path / "examples/puzzletron/orchestrate.py"),
+            "--experiment",
+            str(project_root_path / RUN_PATH),
+            "--runner",
+            str(runner),
+            "--execution",
+            str(project_root_path / EXECUTION_PATH),
+            "--stage",
+            "full",
+            "--local",
+            "--color",
+            "never",
+        ],
+        cwd=project_root_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=2300,
+        check=False,
+    )
+    if completed.returncode:
+        pytest.fail(
+            "Qwen 3.5 0.8B VLM MIP smoke failed.\n"
+            f"stdout tail:\n{completed.stdout[-12000:]}\n"
+            f"stderr tail:\n{completed.stderr[-12000:]}"
+        )
+
+    run_config = pipeline_config_from_path(project_root_path / RUN_PATH)
+    assert run_config["data"]["modality"] == "multimodal"
+    assert run_config["data"]["revision"] == "fixture-revision"
+    assert run_config["model"]["descriptor_override"] == "qwen3_5"
+    assert run_config["model"]["source"] == "Qwen/Qwen3.5-0.8B"
+
+    width_manifest = json.loads(
+        (results / "manifests/width_importance.json").read_text(encoding="utf-8")
+    )
+    activation_root = Path(width_manifest["outputs"]["activations_log_dir"])
+    activation_markers = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in activation_root.glob("**/args.json")
+    ]
+    assert activation_markers
+    vision_markers = [
+        marker
+        for marker in activation_markers
+        if marker.get("observability", {}).get("vision_forward_count", 0) > 0
+    ]
+    assert vision_markers
+    for marker in vision_markers:
+        observability = marker["observability"]
+        assert observability["vision_forward_count"] > 0
+        assert observability["vision_output_checksums"]
+        assert observability["batch_fingerprints"]
+
+    slicing_summary = json.loads(
+        (results / "artifacts/slicing_sanity/summary.json").read_text(encoding="utf-8")
+    )
+    assert slicing_summary["passed"] is True
+    assert slicing_summary["verdict"] == "passed"
+    assert slicing_summary["provenance"]["backend"] == "distributed_parent_sweep"
+    physical_rows = [
+        row
+        for row in slicing_summary["rows"]
+        if row["axis"] == "ffn_intermediate" and row["method"] == "physical"
+    ]
+    assert len(physical_rows) == 2
+    for row in physical_rows:
+        assert row["parent_role"].startswith("realized_")
+        assert row["teacher_value"] == 3584
+        assert row["target_value"] in {3072, 2048}
+        assert row["num_changed_layers"] == 1
+        assert json.loads(row["changed_layers"]) == [row["layer_idx"]]
+
+    replacement_results = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in results.glob(
+            "scenarios/width-*/depth-*/"
+            "single_subblock_replacement_solutions--validation/solution_*.json"
+        )
+    ]
+    assert len(replacement_results) == 48
+    for result in replacement_results:
+        observability = result["observability"]
+        assert observability["vision_forward_count"] > 0
+        assert observability["vision_output_checksums"]
+
+    mip_manifest = json.loads((results / "manifests/mip.json").read_text(encoding="utf-8"))
+    assert mip_manifest["status"] == "success"
+    active_profiles = json.loads((results / "mip/active_profiles.json").read_text())
+    assert active_profiles["status"] == "success"
+    assert active_profiles["profile_ids"] == ["params-90"]

--- a/tests/gpu/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke.py
+++ b/tests/gpu/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke.py
@@ -28,7 +28,6 @@ import yaml
 from PIL import Image
 
 from modelopt.torch.puzzletron.dataset.multimodal import materialize_normalized_conversation_samples
-from modelopt.torch.puzzletron.pipeline_config import pipeline_config_from_path
 
 RUN_PATH = "examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/mip_vlm_smoke.yaml"
 EXECUTION_PATH = "examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.vlm_smoke.yaml"
@@ -159,12 +158,6 @@ def test_qwen3p5_0p8b_orchestrated_vlm_mip_smoke_completes(
             f"stderr tail:\n{completed.stderr[-12000:]}"
         )
 
-    run_config = pipeline_config_from_path(project_root_path / RUN_PATH)
-    assert run_config["data"]["modality"] == "multimodal"
-    assert run_config["data"]["revision"] == "fixture-revision"
-    assert run_config["model"]["descriptor_override"] == "qwen3_5"
-    assert run_config["model"]["source"] == "Qwen/Qwen3.5-0.8B"
-
     width_manifest = json.loads(
         (results / "manifests/width_importance.json").read_text(encoding="utf-8")
     )
@@ -185,25 +178,6 @@ def test_qwen3p5_0p8b_orchestrated_vlm_mip_smoke_completes(
         assert observability["vision_forward_count"] > 0
         assert observability["vision_output_checksums"]
         assert observability["batch_fingerprints"]
-
-    slicing_summary = json.loads(
-        (results / "artifacts/slicing_sanity/summary.json").read_text(encoding="utf-8")
-    )
-    assert slicing_summary["passed"] is True
-    assert slicing_summary["verdict"] == "passed"
-    assert slicing_summary["provenance"]["backend"] == "distributed_parent_sweep"
-    physical_rows = [
-        row
-        for row in slicing_summary["rows"]
-        if row["axis"] == "ffn_intermediate" and row["method"] == "physical"
-    ]
-    assert len(physical_rows) == 2
-    for row in physical_rows:
-        assert row["parent_role"].startswith("realized_")
-        assert row["teacher_value"] == 3584
-        assert row["target_value"] in {3072, 2048}
-        assert row["num_changed_layers"] == 1
-        assert json.loads(row["changed_layers"]) == [row["layer_idx"]]
 
     replacement_results = [
         json.loads(path.read_text(encoding="utf-8"))

--- a/tests/unit/torch/puzzletron/test_automodel_config.py
+++ b/tests/unit/torch/puzzletron/test_automodel_config.py
@@ -246,3 +246,25 @@ def test_build_recipe_config_selects_native_vlm_and_neat_packing(monkeypatch):
     assert recipe["packed_sequence"]["packing_ratio"] == 0.9
     assert recipe["packed_sequence"]["attn_implementation"] == "flash_attention_2"
     assert recipe["packed_sequence"]["max_packs"] == 200
+    assert "collate_fn" not in recipe["dataloader"]
+
+
+def test_build_recipe_config_uses_native_vlm_padded_collator(monkeypatch):
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.plugins.automodel.config._inject_descriptor_model_kwargs",
+        lambda *args, **kwargs: None,
+    )
+    cfg = _cfg()
+    cfg.pruning.automodel.force_hf = False
+    cfg.pruning.automodel.use_puzzletron_dataloader = False
+    cfg.data = {
+        "path": "/puzzle/data/vlm-smoke",
+        "modality": "multimodal",
+        "layout": "padded_varlen",
+        "max_sample_length": 512,
+    }
+
+    recipe = build_recipe_config(cfg)
+
+    assert recipe["dataset"]["path_or_dataset"] == "/puzzle/data/vlm-smoke"
+    assert "collate_fn" not in recipe["dataloader"]

--- a/tests/unit/torch/puzzletron/test_automodel_config.py
+++ b/tests/unit/torch/puzzletron/test_automodel_config.py
@@ -247,6 +247,8 @@ def test_build_recipe_config_selects_native_vlm_and_neat_packing(monkeypatch):
     assert recipe["packed_sequence"]["attn_implementation"] == "flash_attention_2"
     assert recipe["packed_sequence"]["max_packs"] == 200
     assert "collate_fn" not in recipe["dataloader"]
+    assert recipe["model"]["trust_remote_code"] is False
+    assert recipe["processor"]["trust_remote_code"] is False
 
 
 def test_build_recipe_config_uses_native_vlm_padded_collator(monkeypatch):
@@ -257,6 +259,7 @@ def test_build_recipe_config_uses_native_vlm_padded_collator(monkeypatch):
     cfg = _cfg()
     cfg.pruning.automodel.force_hf = False
     cfg.pruning.automodel.use_puzzletron_dataloader = False
+    cfg.model = {"trust_remote_code": True}
     cfg.data = {
         "path": "/puzzle/data/vlm-smoke",
         "modality": "multimodal",
@@ -268,3 +271,5 @@ def test_build_recipe_config_uses_native_vlm_padded_collator(monkeypatch):
 
     assert recipe["dataset"]["path_or_dataset"] == "/puzzle/data/vlm-smoke"
     assert "collate_fn" not in recipe["dataloader"]
+    assert recipe["model"]["trust_remote_code"] is True
+    assert recipe["processor"]["trust_remote_code"] is True

--- a/tests/unit/torch/puzzletron/test_automodel_scoring_recipe.py
+++ b/tests/unit/torch/puzzletron/test_automodel_scoring_recipe.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 from collections import UserDict
 from types import SimpleNamespace
 

--- a/tests/unit/torch/puzzletron/test_automodel_scoring_recipe.py
+++ b/tests/unit/torch/puzzletron/test_automodel_scoring_recipe.py
@@ -181,6 +181,36 @@ def test_resumed_observability_merges_local_forward_evidence_without_duplication
     }
 
 
+def test_resume_checkpoint_round_trip_uses_safe_tensor_state(tmp_path):
+    class Scorer:
+        name = "layer"
+        block_idx = 0
+
+        def __init__(self):
+            self.state = {"curr_iter": 3, "scores": torch.tensor([1.0, 2.0])}
+
+        def checkpoint_state(self):
+            return self.state
+
+        def load_checkpoint_state(self, state):
+            self.state = state
+
+    scorer = Scorer()
+    recipe = ActivationScoringRecipe.__new__(ActivationScoringRecipe)
+    recipe._scorers = [scorer]
+    recipe._resume_dir = lambda: tmp_path
+    recipe._local_observability_metadata = lambda: {"vision_forward_count": 1}
+    recipe.dist_env = SimpleNamespace(is_main=True)
+
+    recipe._save_resume_checkpoint(next_step=3, total=5)
+    scorer.state = None
+
+    assert recipe._load_resume_checkpoint(total=5) == 3
+    assert scorer.state["curr_iter"] == 3
+    assert torch.equal(scorer.state["scores"], torch.tensor([1.0, 2.0]))
+    assert recipe._resumed_observability_local == {"vision_forward_count": 1}
+
+
 def test_load_balanced_cp_metric_shards_preserve_exact_token_partition():
     values = torch.arange(16).reshape(2, 8)
 

--- a/tests/unit/torch/puzzletron/test_automodel_scoring_recipe.py
+++ b/tests/unit/torch/puzzletron/test_automodel_scoring_recipe.py
@@ -1,10 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import UserDict
 from types import SimpleNamespace
 
 import torch
 
+from modelopt.torch.puzzletron.dataset import DataLayout, PuzzletronBatch
 from modelopt.torch.puzzletron.plugins.automodel.dummy_data import make_dummy_dataset
 from modelopt.torch.puzzletron.plugins.automodel.scoring_recipe import (
     ActivationScoringRecipe,
@@ -53,9 +70,7 @@ def test_variable_length_pp_update_restores_hidden_state_output_metadata():
             self.updated = []
 
         def update_seq_len(self, seq_len):
-            self.updated.append(
-                (seq_len, self.pp_microbatch_size, self._pp_current_seq_len)
-            )
+            self.updated.append((seq_len, self.pp_microbatch_size, self._pp_current_seq_len))
             stage.inputs_meta = (
                 torch.empty(1, seq_len, 1024, device="meta", dtype=torch.bfloat16),
             )
@@ -75,18 +90,14 @@ def test_variable_length_pp_update_restores_hidden_state_output_metadata():
 
 def test_pp_envelope_batch_size_accounts_for_forward_microbatches():
     recipe = ActivationScoringRecipe.__new__(ActivationScoringRecipe)
-    recipe.pp = SimpleNamespace(
-        info=SimpleNamespace(schedule=SimpleNamespace(_n_microbatches=2))
-    )
+    recipe.pp = SimpleNamespace(info=SimpleNamespace(schedule=SimpleNamespace(_n_microbatches=2)))
 
     assert recipe._pp_envelope_batch_size(local_batch_size=4) == 2
 
 
 def test_pp_envelope_batch_size_rounds_up_partial_final_batch():
     recipe = ActivationScoringRecipe.__new__(ActivationScoringRecipe)
-    recipe.pp = SimpleNamespace(
-        info=SimpleNamespace(schedule=SimpleNamespace(_n_microbatches=2))
-    )
+    recipe.pp = SimpleNamespace(info=SimpleNamespace(schedule=SimpleNamespace(_n_microbatches=2)))
 
     assert recipe._pp_envelope_batch_size(local_batch_size=3) == 2
 
@@ -107,6 +118,53 @@ def test_data_parallel_slice_uses_the_reduction_group_not_the_combined_ep_mesh()
     ) == (2, 1)
 
 
+def test_data_parallel_slice_accepts_mapping_collator_outputs():
+    recipe = ActivationScoringRecipe.__new__(ActivationScoringRecipe)
+    recipe._dp_size = 2
+    recipe._dp_rank = 1
+    batch = UserDict(
+        {
+            "input_ids": torch.tensor([[1, 2], [3, 4]]),
+            "image_grid_thw": torch.tensor([[1, 2, 2], [1, 3, 3]]),
+            "processor_metadata": "preserved",
+        }
+    )
+
+    actual = recipe._dp_slice_batch(batch)
+
+    assert torch.equal(actual["input_ids"], torch.tensor([[3, 4]]))
+    assert torch.equal(actual["image_grid_thw"], torch.tensor([[1, 3, 3]]))
+    assert actual["processor_metadata"] == "preserved"
+
+
+def test_canonicalize_batch_accepts_mapping_collator_outputs():
+    recipe = ActivationScoringRecipe.__new__(ActivationScoringRecipe)
+    recipe._data_spec = SimpleNamespace(layout=DataLayout.PADDED_VARLEN)
+    recipe._data_cfg = {
+        "path": "/materialized/vlm",
+        "revision": "dataset-commit",
+        "processor_identity": "qwen-vlm-processor",
+    }
+    recipe._dp_size = 1
+    recipe._use_puzzletron_dataloader = True
+    recipe._cp_info = lambda: (0, 1)
+    collated = UserDict(
+        {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.ones(1, 3, dtype=torch.long),
+            "pixel_values": torch.randn(1, 3, 2, 2),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+        }
+    )
+
+    actual = recipe._canonicalize_batch(collated, step=7)
+
+    assert isinstance(actual, PuzzletronBatch)
+    assert actual.sample_ids == ("batch-00000007-row-0",)
+    assert torch.equal(actual.model_kwargs["pixel_values"], collated["pixel_values"])
+    assert actual.source_metadata["processor"] == "qwen-vlm-processor"
+
+
 def test_resumed_observability_merges_local_forward_evidence_without_duplication():
     recipe = ActivationScoringRecipe.__new__(ActivationScoringRecipe)
     recipe._resumed_observability_local = {
@@ -114,9 +172,7 @@ def test_resumed_observability_merges_local_forward_evidence_without_duplication
         "vision_output_checksums": ["old", "shared"],
         "batch_fingerprints": ["batch-a"],
     }
-    recipe._vision_monitors = [
-        SimpleNamespace(forward_count=2, output_checksums=["shared", "new"])
-    ]
+    recipe._vision_monitors = [SimpleNamespace(forward_count=2, output_checksums=["shared", "new"])]
     recipe._canonical_batch_fingerprints = ["batch-a", "batch-b"]
 
     actual = recipe._local_observability_metadata()
@@ -173,9 +229,7 @@ def test_nonfirst_pp_stage_restores_replicated_tp_layout_before_sequence_paralle
     recipe.model_parts = [model_part]
     recipe.device_mesh = {"tp": "tp-mesh"}
     recipe._groups = SimpleNamespace(tp_size=2)
-    recipe.cfg = SimpleNamespace(
-        distributed=SimpleNamespace(sequence_parallel=True)
-    )
+    recipe.cfg = SimpleNamespace(distributed=SimpleNamespace(sequence_parallel=True))
     seen = []
 
     def fake_replicate(hidden_states, tp_mesh):

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke_plan.py
@@ -17,8 +17,6 @@
 
 from pathlib import Path
 
-import yaml
-
 from puzzletron_orchestrator.compiler import (
     compile_campaign_plan,
     load_execution_config,
@@ -47,35 +45,7 @@ def _compile_plan(monkeypatch, tmp_path: Path):
     )
 
 
-def test_qwen3p5_0p8b_vlm_smoke_is_a_multimodal_overlay() -> None:
-    overlay = yaml.safe_load(RUN_PATH.read_text(encoding="utf-8"))
-
-    assert overlay["defaults"] == ["mip_smoke", "_self_"]
-    assert overlay["data"] == {
-        "modality": "multimodal",
-        "layout": "padded_varlen",
-        "max_sample_length": 512,
-        "path": "${dataset_path}",
-        "revision": "${oc.env:PUZZLETRON_DATASET_REVISION}",
-        "processor_identity": "${model_info.hf_repo}@${model_info.hf_revision}",
-        "packing": None,
-    }
-    assert overlay["tokenize_data"] == {"enabled": False, "caches": []}
-    assert overlay["sort"]["deferred_axes"] == [
-        "kv_groups",
-        "q_heads_per_group",
-        "gdn_key_groups",
-        "gdn_value_heads_per_group",
-        "gdn_key_head_dim",
-        "gdn_value_head_dim",
-    ]
-    assert overlay["sort_sanity"]["automodel"]["lm_head_backend"] == "streaming"
-    assert overlay["sort_sanity"]["max_abs_lm_loss_delta"] == 0.002
-    assert overlay["sort_sanity"]["max_abs_reverse_lm_loss_delta"] == 0.002
-    assert overlay["replacement_scoring"]["automodel"]["lm_head_backend"] == "streaming"
-
-
-def test_qwen3p5_0p8b_vlm_smoke_compiles_the_bounded_native_route(
+def test_qwen3p5_0p8b_vlm_smoke_compiles_the_bounded_ffn_only_route(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -99,6 +69,7 @@ def test_qwen3p5_0p8b_vlm_smoke_compiles_the_bounded_native_route(
     assert config["model"]["revision"] == "2fc06364715b967f1860aea9cf38778875588b17"
     assert config["model"]["descriptor_override"] == "qwen3_5"
     assert config["model"]["force_hf"] is False
+    assert config["model"]["trust_remote_code"] is False
     assert config["data"]["path"] == str(tmp_path / "dataset")
     assert config["data"]["revision"] == "fixture-revision"
     assert config["data"]["processor_identity"] == (
@@ -128,14 +99,6 @@ def test_qwen3p5_0p8b_vlm_smoke_compiles_the_bounded_native_route(
         "replacement_scoring",
     ):
         assert config[section]["packed_token_cache_path"] is None
-
-
-def test_qwen3p5_0p8b_vlm_smoke_preserves_the_accepted_ffn_only_search(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    config = _compile_plan(monkeypatch, tmp_path).experiment_config
-
     assert config["search_space"]["axes"] == {
         "ffn_intermediate": {
             "enabled": True,

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_vlm_smoke_plan.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU plan contracts for the Qwen 3.5 0.8B VLM MIP smoke."""
+
+from pathlib import Path
+
+import yaml
+
+from puzzletron_orchestrator.compiler import (
+    compile_campaign_plan,
+    load_execution_config,
+    load_runner_config,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+RUN_PATH = (
+    REPOSITORY_ROOT
+    / "examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/mip_vlm_smoke.yaml"
+)
+ORCHESTRATION_ROOT = REPOSITORY_ROOT / "examples/puzzletron/configs/orchestration/qwen3p5_0p8b"
+RUNNER_PATH = ORCHESTRATION_ROOT / "runner.slurm.yaml"
+EXECUTION_PATH = ORCHESTRATION_ROOT / "execution.vlm_smoke.yaml"
+
+
+def _compile_plan(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("PUZZLETRON_RUN_ROOT", str(tmp_path / "results"))
+    monkeypatch.setenv("PUZZLETRON_DATASET_PATH", str(tmp_path / "dataset"))
+    monkeypatch.setenv("PUZZLETRON_DATASET_REVISION", "fixture-revision")
+    return compile_campaign_plan(
+        experiment_config_path=RUN_PATH,
+        runner=load_runner_config(RUNNER_PATH),
+        execution=load_execution_config(EXECUTION_PATH),
+        stage_filter="full",
+    )
+
+
+def test_qwen3p5_0p8b_vlm_smoke_is_a_multimodal_overlay() -> None:
+    overlay = yaml.safe_load(RUN_PATH.read_text(encoding="utf-8"))
+
+    assert overlay["defaults"] == ["mip_smoke", "_self_"]
+    assert overlay["data"] == {
+        "modality": "multimodal",
+        "layout": "padded_varlen",
+        "max_sample_length": 512,
+        "path": "${dataset_path}",
+        "revision": "${oc.env:PUZZLETRON_DATASET_REVISION}",
+        "processor_identity": "${model_info.hf_repo}@${model_info.hf_revision}",
+        "packing": None,
+    }
+    assert overlay["tokenize_data"] == {"enabled": False, "caches": []}
+    assert overlay["sort"]["deferred_axes"] == [
+        "kv_groups",
+        "q_heads_per_group",
+        "gdn_key_groups",
+        "gdn_value_heads_per_group",
+        "gdn_key_head_dim",
+        "gdn_value_head_dim",
+    ]
+    assert overlay["sort_sanity"]["automodel"]["lm_head_backend"] == "streaming"
+    assert overlay["sort_sanity"]["max_abs_lm_loss_delta"] == 0.002
+    assert overlay["sort_sanity"]["max_abs_reverse_lm_loss_delta"] == 0.002
+    assert overlay["replacement_scoring"]["automodel"]["lm_head_backend"] == "streaming"
+
+
+def test_qwen3p5_0p8b_vlm_smoke_compiles_the_bounded_native_route(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plan = _compile_plan(monkeypatch, tmp_path)
+    config = plan.experiment_config
+    stage_ids = tuple(stage.stage_id for stage in plan.stages)
+
+    assert stage_ids == (
+        "convert",
+        "width_importance",
+        "sort",
+        "sort_sanity",
+        "width_sanity",
+        "slicing_sanity",
+        "build_library",
+        "replacement_scoring",
+        "mip",
+    )
+    assert all(stage.total_gpus == 1 for stage in plan.stages)
+    assert config["model"]["source"] == "Qwen/Qwen3.5-0.8B"
+    assert config["model"]["revision"] == "2fc06364715b967f1860aea9cf38778875588b17"
+    assert config["model"]["descriptor_override"] == "qwen3_5"
+    assert config["model"]["force_hf"] is False
+    assert config["data"]["path"] == str(tmp_path / "dataset")
+    assert config["data"]["revision"] == "fixture-revision"
+    assert config["data"]["processor_identity"] == (
+        "Qwen/Qwen3.5-0.8B@2fc06364715b967f1860aea9cf38778875588b17"
+    )
+    assert config["data"]["modality"] == "multimodal"
+    assert config["data"]["layout"] == "padded_varlen"
+    assert config["tokenize_data"]["enabled"] is False
+    assert config["tokenize_data"]["caches"] == []
+    assert config["sort"]["deferred_axes"] == [
+        "kv_groups",
+        "q_heads_per_group",
+        "gdn_key_groups",
+        "gdn_value_heads_per_group",
+        "gdn_key_head_dim",
+        "gdn_value_head_dim",
+    ]
+    assert config["sort_sanity"]["automodel"]["lm_head_backend"] == "streaming"
+    assert config["sort_sanity"]["max_abs_lm_loss_delta"] == 0.002
+    assert config["sort_sanity"]["max_abs_reverse_lm_loss_delta"] == 0.002
+    assert config["replacement_scoring"]["automodel"]["lm_head_backend"] == "streaming"
+    for section in (
+        "pruning",
+        "sort_sanity",
+        "width_sanity",
+        "depth_importance",
+        "replacement_scoring",
+    ):
+        assert config[section]["packed_token_cache_path"] is None
+
+
+def test_qwen3p5_0p8b_vlm_smoke_preserves_the_accepted_ffn_only_search(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = _compile_plan(monkeypatch, tmp_path).experiment_config
+
+    assert config["search_space"]["axes"] == {
+        "ffn_intermediate": {
+            "enabled": True,
+            "teacher_value": 3584,
+            "values": [3072, 2048],
+        }
+    }
+    assert config["width_sanity"]["axes"] == ["ffn_intermediate"]
+    assert config["mip"]["runs"]["params-90"]["search_space"] == {
+        "depth": [0],
+        "embedding": [1024],
+        "axes_default": "teacher",
+        "axes": {"ffn.intermediate_size": "all"},
+    }


### PR DESCRIPTION
### What does this PR do?

Type of change: new example

Adds a bounded, one-GPU Qwen 3.5 0.8B vision-language MIP smoke example. It preserves image and conversation inputs through native AutoModel scoring and candidate selection, proving that the vision path runs instead of exercising only the language backbone.

- Reuses the accepted Qwen 3.5 0.8B FFN-only search space and keeps unrelated attention and GDN axes fixed.
- Routes processor-produced multimodal mappings through canonical Puzzletron batches without creating text token caches.
- Makes remote-code loading an explicit opt-in shared by the model and processor.
- Uses safe serialization for resumable activation-scoring state.
- Adds a compiled-plan contract, focused batch and configuration regressions, and an opt-in real-checkpoint GPU smoke that requires vision activity for width and all 48 replacement candidates before successful MIP selection.

This example intentionally ends after MIP. Multimodal serving, distillation, and final evaluation remain separate follow-up work.

### Usage

Use `mip_vlm_smoke.yaml` with `execution.vlm_smoke.yaml` and a site-specific runner. Set `PUZZLETRON_RUN_ROOT`, `PUZZLETRON_DATASET_PATH`, and an immutable `PUZZLETRON_DATASET_REVISION`. Inspect the enabled plan with `--stage full --dry-run`, then remove only `--dry-run` to launch it.

### Testing

- The compiled VLM plan contract and secure-serialization suite passed locally.
- The one-GPU real-checkpoint smoke passed in 7 minutes 21 seconds, exercised all 48 replacement candidates, verified vision activity, and completed MIP selection.
- Ruff, formatting, syntax checks, Mypy, Bandit, license checks, and the remaining commit hooks passed.
- AutoModel config and scoring unit modules were not rerun locally because the macOS environment lacks NeMo AutoModel and has an incompatible TorchVision operator; Linux CI covers those modules.

### Before your PR is "Ready for review"

- Is this change backward compatible?: yes
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: yes
- Did you update the changelog?: N/A
- Did you get Claude approval on this PR?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a bounded, single-GPU multimodal Qwen 3.5 0.8B smoke workflow.
  - Supports native processor handling, variable-length data, streaming scoring, and FFN-focused optimization.
  - Added orchestration for conversion, analysis, validation, replacement scoring, and final processing.
  - Remote-code execution is disabled by default, with explicit opt-in support.

- **Bug Fixes**
  - Improved multimodal batch handling, metadata validation, and checkpoint resume reliability.

- **Tests**
  - Added integration and unit coverage for the complete multimodal workflow, configuration, routing, and batch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->