### PR TITLE
Add Qwen 3.5 VLM lifecycle smoke

### DIFF
--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -74,11 +74,12 @@ python examples/puzzletron/orchestrate.py \
 Review the stage list, worker paths, execution strategies, resources, and
 output directory. `--stage full` runs every stage enabled by the generated
 experiment in dependency order. Remove `--dry-run` to launch the smoke
-campaign. The checked-in
-[Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md) provides a separate
-one-GPU MIP acceptance route when you need to validate that path directly.
-For the same pinned architecture with real image-conversation inputs, use the
-[Qwen 3.5 0.8B VLM full-lifecycle smoke](docs/qwen3p5_0p8b_vlm_smoke.md).
+campaign. Two checked-in Qwen 3.5 0.8B examples exercise the complete pruning
+workflow on one GPU. Use the
+[text pruning smoke](docs/qwen3p5_0p8b_smoke.md) for text-only evaluation,
+serving measurements, distillation, and final model selection. Use the
+[vision-language pruning smoke](docs/qwen3p5_0p8b_vlm_smoke.md) for the same
+workflow with real image-conversation inputs and image-aware measurements.
 
 ### 4. Launch production
 

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -77,6 +77,8 @@ experiment in dependency order. Remove `--dry-run` to launch the smoke
 campaign. The checked-in
 [Qwen 3.5 0.8B smoke guide](docs/qwen3p5_0p8b_smoke.md) provides a separate
 one-GPU MIP acceptance route when you need to validate that path directly.
+For the same pinned architecture with real image-conversation inputs, use the
+[Qwen 3.5 0.8B VLM full-lifecycle smoke](docs/qwen3p5_0p8b_vlm_smoke.md).
 
 ### 4. Launch production
 

--- a/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_vlm_smoke.yaml
+++ b/examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_vlm_smoke.yaml
@@ -1,0 +1,115 @@
+# @package _global_
+
+defaults:
+  - mip_vlm_smoke
+  - _self_
+
+# Extend the bounded image-text MIP smoke through evaluation, physical
+# materialization, comparative multimodal serving, VLM distillation, and final
+# image-text evaluation. The inherited recipe owns the pinned public checkpoint,
+# native multimodal data contract, and FFN-only search.
+puzzle_dir: ${oc.env:PUZZLETRON_RUN_ROOT}
+data:
+  # Tested public snapshot; callers may override with another immutable SHA.
+  revision: ${oc.env:PUZZLETRON_DATASET_REVISION,51f4f4d219315c3283950994d4eb3d7fc30aa87b}
+
+# Auto-detection would select the VLM recipe from data.modality. Declare the
+# domain and trainable groups explicitly so the resolved run packet is auditable.
+global_distillation:
+  domain: vlm
+  force_hf: false
+  teacher_force_hf: false
+  student_force_hf: false
+  freeze_policy: train_all
+  validation_enabled: false
+  objective:
+    main_ce: {weight: 1.0}
+    main_kd: {weight: 1.0}
+    mtp_ce: {weight: 1.0}
+    mtp_kd: {weight: 1.0, chunk_size: 512}
+
+post_mip:
+  flows:
+    params-90:
+      source:
+        run: params-90
+        variants: all
+        objectives: all
+      nodes:
+        image_eval:
+          type: evaluation
+          config:
+            eval_samples: 2
+            block_size: 512
+        best_vlm_loss:
+          type: filter
+          input: image_eval
+          mode: top_k
+          metric: image_eval.lm_loss
+          direction: minimize
+          top_k: 2
+        materialized:
+          type: materialize
+          input: best_vlm_loss
+        vlm_serving:
+          type: aiperf
+          input: materialized
+          config:
+            endpoint_type: chat
+            input_tokens: 100
+            output_tokens: 80
+            image_batch_sizes: [1, 6, 12]
+            image_width_mean: 1280
+            image_height_mean: 720
+            concurrency: [1]
+            request_count: 1
+            extra_inputs: {min_tokens: 80}
+            use_server_token_count: true
+            benchmark_timeout: 900
+            topology:
+              tensor_parallel_size: 1
+              pipeline_parallel_size: 1
+              data_parallel_size: 1
+              prefill_context_parallel_size: 1
+              decode_context_parallel_size: 1
+              enable_expert_parallel: false
+              distributed_executor_backend: mp
+              gpu_group_size: 1
+              server_context_overhead_tokens: 16384
+              extra_vllm_args:
+                - -cc.cudagraph_mode=NONE
+                - --no-enable-flashinfer-autotune
+                - --gpu-memory-utilization
+                - "0.5"
+                - --reasoning-parser
+                - qwen3
+                - --default-chat-template-kwargs
+                - '{"enable_thinking": false}'
+        fastest_vlm:
+          type: filter
+          input: vlm_serving
+          mode: top_k
+          metric: vlm_serving.images_12.concurrency_1.image_throughput
+          direction: maximize
+          top_k: 1
+        short_vlm_kd:
+          type: global_kd
+          input: fastest_vlm
+          config:
+            max_steps: 2
+            global_batch_size: 1
+            local_batch_size: 1
+            checkpoint_every_steps: 2
+        final_image_eval:
+          type: evaluation
+          input: short_vlm_kd
+          config:
+            eval_samples: 2
+            block_size: 512
+        best:
+          type: filter
+          input: final_image_eval
+          mode: top_k
+          metric: final_image_eval.lm_loss
+          direction: minimize
+          top_k: 1

--- a/examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_vlm_smoke.yaml
+++ b/examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_vlm_smoke.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# One instance on one GPU for the bounded Qwen 3.5 VLM lifecycle. Image-backed
+# evaluation and VLM KD remain model stages; filters are controller operations.
+execution:
+  defaults:
+    failure_policy: strict
+    halt_policy: drain
+    gpus_per_node: 1
+  stages:
+    convert: {strategy: single, instances: 1}
+    width_importance: {strategy: single, instances: 1}
+    sort: {strategy: single, instances: 1}
+    sort_sanity: {strategy: single, instances: 1}
+    width_sanity: {strategy: single, instances: 1}
+    slicing_sanity: {strategy: single, instances: 1}
+    build_library: {strategy: single, instances: 1}
+    replacement_scoring: {strategy: single, instances: 1}
+    mip: {strategy: single, instances: 1}
+    post.params-90.image_eval: {strategy: sharded, instances: 1}
+    post.params-90.best_vlm_loss: {strategy: single, instances: 1}
+    post.params-90.materialized: {strategy: sharded, instances: 1}
+    post.params-90.vlm_serving: {strategy: sharded, instances: 1}
+    post.params-90.fastest_vlm: {strategy: single, instances: 1}
+    post.params-90.short_vlm_kd: {strategy: sharded, instances: 1}
+    post.params-90.final_image_eval: {strategy: sharded, instances: 1}
+    post.params-90.best: {strategy: single, instances: 1}

--- a/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_smoke.md
@@ -1,15 +1,18 @@
-# Qwen 3.5 0.8B full-lifecycle smoke
+# Qwen 3.5 0.8B text pruning smoke
 
-The checked-in Qwen 3.5 0.8B `full_smoke` recipe pins the public checkpoint revision and
-searches only the FFN intermediate sizes `[3072, 2048]`. The checked-in
-`full_smoke.yaml` experiment extends the bounded MIP smoke through evaluation,
-physical materialization, comparative AIPerf measurement, two
-global-distillation steps, final evaluation, and final selection. It keeps the
-two strongest candidates by language-model loss through materialization and
-AIPerf, then sends the candidate with higher measured output-token throughput
-to distillation.
+The checked-in `full_smoke` recipe runs a small end-to-end test of text-only
+pruning for Qwen 3.5 0.8B. It searches the FFN intermediate sizes
+`[3072, 2048]`, evaluates the candidates, saves the two strongest candidates as
+physical checkpoints, and measures their serving performance with AIPerf. It
+then distills the candidate with higher measured output-token throughput for
+two steps, evaluates it again, and selects the final checkpoint. The recipe
+pins the public checkpoint revision so repeated runs use the same starting
+model.
 
-## Run and resume the full lifecycle
+These small budgets check that the complete workflow runs and resumes
+correctly. They do not establish model quality or production throughput.
+
+## Run and resume the text workflow
 
 Use the checked-in `full_smoke.yaml` experiment and
 `execution.full_smoke.yaml` execution config as the canonical inputs. The

--- a/examples/puzzletron/docs/qwen3p5_0p8b_vlm_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_vlm_smoke.md
@@ -1,0 +1,197 @@
+# Qwen 3.5 0.8B VLM full-lifecycle smoke
+
+The checked-in `full_vlm_smoke` recipe runs a bounded image-text lifecycle for
+the public `Qwen/Qwen3.5-0.8B` checkpoint at the immutable revision declared in
+`model.yaml`. It inherits the conservative VLM MIP smoke, which searches only
+FFN intermediate sizes `[3072, 2048]`, and adds image-backed evaluation,
+physical materialization, comparative image-backed AIPerf measurement, two VLM
+distillation steps, and final image-backed evaluation. It keeps the two
+strongest candidates by image-text language-model loss through materialization
+and AIPerf, then sends the candidate with the highest measured 12-image
+throughput to distillation.
+
+These small budgets check lifecycle wiring and resumability. They do not
+establish model quality or production throughput.
+
+## Prepare the worker environment
+
+Prepare the setup and worker environments described in
+[environment setup](environment_setup.md). The worker environment must provide
+ModelOpt, NeMo AutoModel's Qwen 3.5 VLM support, the Puzzletron requirements,
+and the reviewed AIPerf/vLLM runtime selected by your runner contract.
+
+The worker-visible Hugging Face cache must contain, or be allowed to fetch,
+`Qwen/Qwen3.5-0.8B` at the pinned revision in
+`configs/families/qwen3_5/qwen3p5_0p8b/model.yaml`. If workers are offline,
+populate that cache before launch and mount it through the runner; do not
+replace the checked-in model identity with a machine-specific path.
+
+## Materialize the image-text smoke dataset
+
+Choose worker-visible dataset and output paths. The dataset revision must be an
+immutable Hugging Face commit SHA, not `main` or `latest`.
+
+```bash
+export PUZZLETRON_DATASET_PATH=/path/to/qwen3p5-vlm-smoke-data
+export PUZZLETRON_DATASET_REVISION=51f4f4d219315c3283950994d4eb3d7fc30aa87b
+export PUZZLETRON_RUN_ROOT=/path/to/qwen3p5_0p8b_full_vlm_smoke
+
+test -n "$PUZZLETRON_DATASET_PATH"
+test -n "$PUZZLETRON_DATASET_REVISION"
+test -n "$PUZZLETRON_RUN_ROOT"
+case "$PUZZLETRON_DATASET_REVISION" in
+  *[!0-9a-f]*|'')
+    echo "PUZZLETRON_DATASET_REVISION must be a lowercase commit SHA" >&2
+    exit 1
+    ;;
+esac
+test "${#PUZZLETRON_DATASET_REVISION}" -eq 40
+```
+
+Materialize eight normalized image-conversation samples. Run this networked
+preparation step once; campaign workers consume the resulting local files and
+manifest without fetching the dataset.
+
+```bash
+python examples/puzzletron/materialize_dataset.py nemotron_vlm_v2 \
+  --output "$PUZZLETRON_DATASET_PATH" \
+  --revision "$PUZZLETRON_DATASET_REVISION" \
+  --subsets sparsetables plotqa_cot wiki_en \
+  --num-samples 8 \
+  --max-shards-per-subset 1
+```
+
+Before GPU work, confirm that the immutable acquisition identity, eight
+samples, and real image inventory were published:
+
+```bash
+python - "$PUZZLETRON_DATASET_PATH" "$PUZZLETRON_DATASET_REVISION" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+expected_revision = sys.argv[2]
+manifest = json.loads((root / "manifest.json").read_text())
+acquisition = manifest["acquisition"]
+assert acquisition["revision"] == expected_revision
+assert manifest["sample_count"] == 8
+assert manifest["image_count"] >= 8
+assert len(manifest["images"]) == manifest["image_count"]
+assert all((root / item["path"]).is_file() for item in manifest["images"])
+print(json.dumps(manifest, indent=2, sort_keys=True))
+PY
+```
+
+## Materialize the site runner
+
+The experiment and execution files are canonical inputs. The checked-in Slurm
+runner is a portable placeholder: copy it into the campaign directory, fill in
+the site contract once, and reuse that same file for dry-run, launch, and
+resume.
+
+```bash
+EXPERIMENT=examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_vlm_smoke.yaml
+EXECUTION=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/execution.full_vlm_smoke.yaml
+RUNNER_TEMPLATE=examples/puzzletron/configs/orchestration/qwen3p5_0p8b/runner.slurm.yaml
+RUNNER="$PUZZLETRON_RUN_ROOT/runner.slurm.yaml"
+
+mkdir -p "$PUZZLETRON_RUN_ROOT"
+if test -e "$RUNNER"; then
+  echo "runner already exists: $RUNNER" >&2
+  exit 1
+fi
+cp "$RUNNER_TEMPLATE" "$RUNNER"
+${EDITOR:-vi} "$RUNNER"
+
+if rg -n 'REPLACE_WITH_' "$RUNNER"; then
+  echo "replace every runner placeholder before continuing" >&2
+  exit 1
+fi
+```
+
+The runner's repository, environment, container, mounts, Slurm account, and
+partition must all resolve from every worker. Include the Hugging Face model
+cache and the materialized dataset path in the worker/container mount contract.
+
+## Inspect, launch, and resume
+
+Compile and inspect the full plan without submitting work:
+
+```bash
+python examples/puzzletron/orchestrate.py \
+  --experiment "$EXPERIMENT" \
+  --runner "$RUNNER" \
+  --execution "$EXECUTION" \
+  --stage full --dry-run
+```
+
+Confirm that all enabled model stages use one GPU, image-backed stages resolve
+`data.modality=multimodal`, and no text tokenization stage is present. Confirm
+that two quality candidates reach `post.params-90.vlm_serving`, which declares
+a `chat` workload with 1, 6, and 12 1280x720 images per request rather than a
+text-only serving proxy. The `fastest_vlm` filter selects one candidate from
+the 12-image throughput metric before KD. Then launch by omitting only
+`--dry-run`:
+
+```bash
+python examples/puzzletron/orchestrate.py \
+  --experiment "$EXPERIMENT" \
+  --runner "$RUNNER" \
+  --execution "$EXECUTION" \
+  --stage full
+```
+
+After an interruption, rerun that exact launch command with the same
+environment variables and the same three input files. Puzzletron reuses
+compatible completed stages and reruns failed or incomplete stages; do not
+copy partial artifacts into a new output root.
+
+## Acceptance evidence and limits
+
+A successful command exit is necessary but not sufficient. Before treating the
+smoke as accepted, verify the cumulative report at
+`$PUZZLETRON_RUN_ROOT/artifacts/campaign_report/campaign_report.html` and its
+canonical stage summaries:
+
+- width scoring and VLM KD processed real image tensors and report a nonzero
+  vision-forward count;
+- sorting and physical slicing equivalence passed at the configured tolerance;
+- the selected checkpoint reloads after materialization and after VLM KD;
+- the two-step KD summary contains finite main CE/KD and MTP CE/KD metrics plus
+  nonzero trainable-group gradient evidence;
+- AIPerf completes every 1-, 6-, and 12-image chat workload for both retained
+  candidates without request failures, and `fastest_vlm` selects one candidate
+  using `images_12.concurrency_1.image_throughput`;
+- rerunning the launch command submits no work for completed compatible stages.
+
+Post-MIP evaluation summaries contain aggregate metrics. Verify their raw
+image-evaluation records separately:
+
+```bash
+python - "$PUZZLETRON_RUN_ROOT" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+for node in ("image_eval", "final_image_eval"):
+    records = list(
+        root.glob(
+            f"artifacts/post_mip/nodes/{node}/executions/*/raw/*/solution_0.json"
+        )
+    )
+    assert records, f"missing raw evaluation record for {node}"
+    for path in records:
+        observability = json.loads(path.read_text())["observability"]
+        assert observability["vision_forward_count"] > 0
+        assert observability["vision_output_checksums"]
+PY
+```
+
+The serving stage uses one synthetic request per candidate and workload, with
+1280x720 images in batches of 1, 6, and 12. This exercises the multimodal API,
+vision path, and comparative selection while keeping the example bounded; it
+does not isolate vision-encoder latency or establish production performance.
+Increase request count and concurrency in a separate reviewed performance run
+before making throughput claims.

--- a/examples/puzzletron/docs/qwen3p5_0p8b_vlm_smoke.md
+++ b/examples/puzzletron/docs/qwen3p5_0p8b_vlm_smoke.md
@@ -1,17 +1,17 @@
-# Qwen 3.5 0.8B VLM full-lifecycle smoke
+# Qwen 3.5 0.8B vision-language pruning smoke
 
-The checked-in `full_vlm_smoke` recipe runs a bounded image-text lifecycle for
-the public `Qwen/Qwen3.5-0.8B` checkpoint at the immutable revision declared in
-`model.yaml`. It inherits the conservative VLM MIP smoke, which searches only
-FFN intermediate sizes `[3072, 2048]`, and adds image-backed evaluation,
-physical materialization, comparative image-backed AIPerf measurement, two VLM
-distillation steps, and final image-backed evaluation. It keeps the two
-strongest candidates by image-text language-model loss through materialization
-and AIPerf, then sends the candidate with the highest measured 12-image
-throughput to distillation.
+The checked-in `full_vlm_smoke` recipe runs a small end-to-end test of
+vision-language pruning for the public `Qwen/Qwen3.5-0.8B` checkpoint. It uses
+real image-conversation examples to search the FFN intermediate sizes
+`[3072, 2048]`, evaluate the candidates, and save the two strongest candidates
+as physical checkpoints. It measures both checkpoints with 1-, 6-, and
+12-image AIPerf requests, distills the candidate with the highest measured
+12-image throughput for two steps, and runs a final image-and-text evaluation.
+The immutable revision in `model.yaml` ensures that repeated runs use the same
+starting model.
 
-These small budgets check lifecycle wiring and resumability. They do not
-establish model quality or production throughput.
+These small budgets check that the complete workflow runs and resumes
+correctly. They do not establish model quality or production throughput.
 
 ## Prepare the worker environment
 

--- a/modelopt/torch/puzzletron/anymodel/model_descriptor/base.py
+++ b/modelopt/torch/puzzletron/anymodel/model_descriptor/base.py
@@ -226,7 +226,7 @@ class ModelDescriptor(ABC):
             config,
             sorted_checkpoint_dir,
             alignment=alignment,
-            sampled_layers=sampled_layers,
+            sampled_layers=tuple(sampled_layers) if sampled_layers is not None else None,
         )
 
     @classmethod
@@ -592,6 +592,11 @@ class ModelDescriptor(ABC):
     def runtime_vllm_benchmark_args(cls, config: dict[str, Any]) -> list[str]:
         """Return extra ``vllm bench latency`` args for this descriptor."""
         return []
+
+    @classmethod
+    def runtime_vllm_multimodal_benchmark_args(cls, config: dict[str, Any]) -> list[str]:
+        """Return extra vLLM args for full-model multimodal serving."""
+        raise ValueError(f"{cls.__name__} does not declare multimodal vLLM serving support")
 
     @staticmethod
     def passthrough_weight_name_predicates() -> Dict[str, re.Pattern]:

--- a/modelopt/torch/puzzletron/anymodel/models/qwen3_5/qwen3_5_model_descriptor.py
+++ b/modelopt/torch/puzzletron/anymodel/models/qwen3_5/qwen3_5_model_descriptor.py
@@ -764,6 +764,12 @@ class Qwen3P5TextModelDescriptor(_Qwen3P5BaseModelDescriptor):
 @ModelDescriptorFactory.register_decorator("qwen3_5")
 class Qwen3P5VLModelDescriptor(_Qwen3P5BaseModelDescriptor):
     @classmethod
+    def runtime_vllm_multimodal_benchmark_args(cls, config: Any) -> list[str]:
+        return [
+            arg for arg in cls.runtime_vllm_benchmark_args(config) if arg != "--language-model-only"
+        ]
+
+    @classmethod
     def vision_module_names(cls) -> tuple[str, ...]:
         return ("model.visual",)
 
@@ -1687,6 +1693,12 @@ class Qwen3P5MoeTextModelDescriptor(_Qwen3P5MoeModelDescriptor):
 @ModelDescriptorFactory.register_decorator("qwen3_5_moe")
 class Qwen3P5MoeVLModelDescriptor(_Qwen3P5MoeModelDescriptor):
     _IS_VLM = True
+
+    @classmethod
+    def runtime_vllm_multimodal_benchmark_args(cls, config: Any) -> list[str]:
+        return [
+            arg for arg in cls.runtime_vllm_benchmark_args(config) if arg != "--language-model-only"
+        ]
 
     @classmethod
     def runtime_benchmark_export_descriptor(cls) -> Type[ModelDescriptor]:

--- a/modelopt/torch/puzzletron/benchmarks/aiperf.py
+++ b/modelopt/torch/puzzletron/benchmarks/aiperf.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 """AIPerf subprocess adapter with owned vLLM server lifecycle."""
 
 from __future__ import annotations
@@ -426,6 +423,7 @@ def _vllm_server_command(
         processor_assets = ("preprocessor_config.json", "video_preprocessor_config.json")
         if not any((checkpoint_dir / name).is_file() for name in processor_assets):
             raise ValueError("multimodal AIPerf requires local processor assets")
+        max_pixels = max(1, image_width_mean * image_height_mean)
         command.extend(
             (
                 "--limit-mm-per-prompt",
@@ -433,8 +431,8 @@ def _vllm_server_command(
                 "--mm-processor-kwargs",
                 json.dumps(
                     {
-                        "max_pixels": max(1, image_width_mean * image_height_mean),
-                        "min_pixels": 262144,
+                        "max_pixels": max_pixels,
+                        "min_pixels": min(262144, max_pixels),
                         "max_num_frames": 1,
                     },
                     sort_keys=True,
@@ -559,11 +557,6 @@ def run_aiperf_sweep(
 
     checkpoint_dir = Path(checkpoint_dir).resolve()
     artifact_dir = Path(artifact_dir).resolve()
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    _prepare_vllm_checkpoint(
-        checkpoint_dir,
-        trust_remote_code=trust_remote_code,
-    )
     concurrency_values = tuple(int(value) for value in concurrencies)
     if not concurrency_values or len(set(concurrency_values)) != len(concurrency_values):
         raise ValueError("AIPerf concurrencies must be non-empty and unique")
@@ -581,6 +574,11 @@ def run_aiperf_sweep(
         raise ValueError("AIPerf image_batch_sizes cannot mix text-only and multimodal workloads")
     if multimodal and (image_width_mean <= 0 or image_height_mean <= 0):
         raise ValueError("multimodal AIPerf requires positive image dimensions")
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _prepare_vllm_checkpoint(
+        checkpoint_dir,
+        trust_remote_code=trust_remote_code,
+    )
     request_counts = {
         value: int((request_counts or {}).get(value, max(32, 4 * value)))
         for value in concurrency_values

--- a/modelopt/torch/puzzletron/benchmarks/aiperf.py
+++ b/modelopt/torch/puzzletron/benchmarks/aiperf.py
@@ -71,14 +71,22 @@ def _prepare_vllm_checkpoint(
         return True
 
 
-def _descriptor_vllm_args(checkpoint_dir: Path) -> list[str]:
+def _descriptor_vllm_args(checkpoint_dir: Path, *, multimodal: bool = False) -> list[str]:
     """Resolve the same model-specific vLLM contract used by runtime stats."""
     from ..anymodel.registry import resolve_descriptor
 
     config = json.loads((checkpoint_dir / "config.json").read_text())
     resolution = resolve_descriptor(config)
     descriptor = cast("type[ModelDescriptor]", resolution.descriptor)
-    return [str(arg) for arg in descriptor.runtime_vllm_benchmark_args(config)]
+    method = (
+        descriptor.runtime_vllm_multimodal_benchmark_args
+        if multimodal
+        else descriptor.runtime_vllm_benchmark_args
+    )
+    args = [str(arg) for arg in method(config)]
+    if multimodal and "--language-model-only" in args:
+        raise ValueError("multimodal vLLM serving cannot use --language-model-only")
+    return args
 
 
 def _free_port() -> int:
@@ -110,8 +118,19 @@ def _short_tokenizer_alias(checkpoint_dir: Path, artifact_dir: Path) -> Path:
     return alias
 
 
-def _server_max_model_len(input_tokens: int, output_tokens: int, topology: dict[str, Any]) -> int:
+def _server_max_model_len(
+    input_tokens: int,
+    output_tokens: int,
+    topology: dict[str, Any],
+    *,
+    image_batch_size: int = 0,
+) -> int:
     """Reserve capacity for endpoint-specific chat/control tokens."""
+    if image_batch_size > 0 and "server_context_overhead_tokens" not in topology:
+        raise ValueError(
+            "multimodal AIPerf workloads require an explicit "
+            "server_context_overhead_tokens visual-token budget"
+        )
     overhead = int(topology.get("server_context_overhead_tokens", 64))
     if overhead < 0:
         raise ValueError("server_context_overhead_tokens must be nonnegative")
@@ -229,6 +248,11 @@ def _parse_export(path: Path) -> tuple[dict[str, float], int]:
         "total_gpu_energy_j": ("total_gpu_energy", "avg"),
         "output_tokens_per_joule": ("output_tokens_per_joule", "avg"),
         "energy_per_user_j": ("energy_per_user", "avg"),
+        "num_images": ("num_images", "avg"),
+        "image_throughput": ("image_throughput", "avg"),
+        "image_latency_mean_ms": ("image_latency", "avg"),
+        "image_latency_p95_ms": ("image_latency", "p95"),
+        "image_latency_p99_ms": ("image_latency", "p99"),
     }
     metrics = {}
     for output_name, (raw_name, stat) in mapping.items():
@@ -278,7 +302,23 @@ def _profile_command(
     extra_inputs: dict[str, Any] | None,
     use_server_token_count: bool,
     gpu_telemetry: str | None,
+    image_batch_size: int,
+    image_width_mean: int,
+    image_height_mean: int,
 ) -> list[str]:
+    if image_batch_size < 0:
+        raise ValueError("image_batch_size must be nonnegative")
+    if image_batch_size > 0:
+        if endpoint_type != "chat":
+            raise ValueError("multimodal AIPerf workloads require endpoint_type='chat'")
+        if image_width_mean <= 0 or image_height_mean <= 0:
+            raise ValueError(
+                "multimodal AIPerf workloads require positive image_width_mean "
+                "and image_height_mean"
+            )
+    elif image_width_mean != 0 or image_height_mean != 0:
+        raise ValueError("image dimensions require image_batch_size > 0")
+
     command = [
         str(executable),
         "profile",
@@ -307,9 +347,24 @@ def _profile_command(
         str(artifact_dir),
         "--random-seed",
         str(seed),
-        "--ui",
+        "--image-batch-size",
+        str(image_batch_size),
+        "--ui-type",
         "none",
     ]
+    if image_batch_size > 0:
+        command.extend(
+            (
+                "--image-width-mean",
+                str(image_width_mean),
+                "--image-width-stddev",
+                "0",
+                "--image-height-mean",
+                str(image_height_mean),
+                "--image-height-stddev",
+                "0",
+            )
+        )
     if gpu_telemetry:
         command.extend(("--gpu-telemetry", str(gpu_telemetry)))
     resolved_extra_inputs = _exact_length_extra_inputs(extra_inputs, output_tokens)
@@ -329,6 +384,9 @@ def _vllm_server_command(
     output_tokens: int,
     topology: dict[str, Any],
     trust_remote_code: bool,
+    image_batch_size: int = 0,
+    image_width_mean: int = 0,
+    image_height_mean: int = 0,
 ) -> list[str]:
     """Build the vLLM command under the caller's explicit code-trust policy."""
 
@@ -343,14 +401,53 @@ def _vllm_server_command(
         "--served-model-name",
         model_name,
         "--max-model-len",
-        str(_server_max_model_len(input_tokens, output_tokens, topology)),
+        str(
+            _server_max_model_len(
+                input_tokens,
+                output_tokens,
+                topology,
+                image_batch_size=image_batch_size,
+            )
+        ),
     ]
     if trust_remote_code:
         command.append("--trust-remote-code")
     command.extend(_topology_vllm_args(topology))
-    command.extend(_descriptor_vllm_args(checkpoint_dir))
+    command.extend(_descriptor_vllm_args(checkpoint_dir, multimodal=image_batch_size > 0))
+    if image_batch_size > 0:
+        config = json.loads((checkpoint_dir / "config.json").read_text())
+        architectures = tuple(config.get("architectures") or ()) + (
+            str(config.get("base_architecture") or ""),
+        )
+        if "vision_config" not in config or not any(
+            "ConditionalGeneration" in str(value) for value in architectures
+        ):
+            raise ValueError("multimodal AIPerf requires a full VLM checkpoint")
+        processor_assets = ("preprocessor_config.json", "video_preprocessor_config.json")
+        if not any((checkpoint_dir / name).is_file() for name in processor_assets):
+            raise ValueError("multimodal AIPerf requires local processor assets")
+        command.extend(
+            (
+                "--limit-mm-per-prompt",
+                json.dumps({"image": image_batch_size, "video": 0}, sort_keys=True),
+                "--mm-processor-kwargs",
+                json.dumps(
+                    {
+                        "max_pixels": max(1, image_width_mean * image_height_mean),
+                        "min_pixels": 262144,
+                        "max_num_frames": 1,
+                    },
+                    sort_keys=True,
+                ),
+            )
+        )
     extra_vllm_args = tuple(str(arg) for arg in topology.get("extra_vllm_args", ()))
-    reserved_options = {"--config", "--trust-remote-code"}
+    reserved_options = {
+        "--config",
+        "--trust-remote-code",
+        "--limit-mm-per-prompt",
+        "--mm-processor-kwargs",
+    }
     normalized_options = {arg.partition("=")[0].replace("_", "-") for arg in extra_vllm_args}
     overridden_options = {
         reserved
@@ -452,6 +549,9 @@ def run_aiperf_sweep(
     readiness_timeout: float = 1200,
     benchmark_timeout: float = 600,
     gpu_telemetry: str | None = "pynvml",
+    image_batch_sizes: Iterable[int] | None = None,
+    image_width_mean: int = 0,
+    image_height_mean: int = 0,
     trust_remote_code: bool = False,
     allow_aiperf_v011_online_tokenizer_resolution: bool = False,
 ) -> list[BenchmarkResult]:
@@ -469,6 +569,18 @@ def run_aiperf_sweep(
         raise ValueError("AIPerf concurrencies must be non-empty and unique")
     if any(value < 1 for value in concurrency_values):
         raise ValueError(f"AIPerf concurrencies must be positive: {concurrency_values}")
+    image_batch_values = (
+        (0,) if image_batch_sizes is None else tuple(int(value) for value in image_batch_sizes)
+    )
+    if not image_batch_values or len(set(image_batch_values)) != len(image_batch_values):
+        raise ValueError("AIPerf image_batch_sizes must be non-empty and unique")
+    if any(value < 0 for value in image_batch_values):
+        raise ValueError(f"AIPerf image_batch_sizes must be nonnegative: {image_batch_values}")
+    multimodal = any(value > 0 for value in image_batch_values)
+    if multimodal and any(value == 0 for value in image_batch_values):
+        raise ValueError("AIPerf image_batch_sizes cannot mix text-only and multimodal workloads")
+    if multimodal and (image_width_mean <= 0 or image_height_mean <= 0):
+        raise ValueError("multimodal AIPerf requires positive image dimensions")
     request_counts = {
         value: int((request_counts or {}).get(value, max(32, 4 * value)))
         for value in concurrency_values
@@ -478,9 +590,17 @@ def run_aiperf_sweep(
         prefix="aiperf_architecture",
     )
     canonical_topology = _canonical_topology(topology)
-    topology_id = topology_id or stable_hash(canonical_topology, prefix="aiperf_topology")
-    workload = {"input_tokens": input_tokens, "output_tokens": output_tokens}
-    workload_id = stable_hash(workload, prefix="aiperf_workload")
+    descriptor_args = _descriptor_vllm_args(checkpoint_dir, multimodal=multimodal)
+    server_contract = {
+        "topology": canonical_topology,
+        "server_context_overhead_tokens": topology.get("server_context_overhead_tokens"),
+        "descriptor_args": descriptor_args,
+        "extra_vllm_args": tuple(str(arg) for arg in topology.get("extra_vllm_args", ())),
+        "max_image_batch_size": max(image_batch_values),
+        "image_width_mean": image_width_mean,
+        "image_height_mean": image_height_mean,
+    }
+    topology_id = topology_id or stable_hash(server_contract, prefix="aiperf_topology")
     revisions = {"aiperf": _package_version("aiperf"), "vllm": _package_version("vllm")}
     port = _free_port()
     model_name = f"puzzletron-{architecture_id[:16]}"
@@ -494,6 +614,9 @@ def run_aiperf_sweep(
         output_tokens=output_tokens,
         topology=topology,
         trust_remote_code=trust_remote_code,
+        image_batch_size=max(image_batch_values),
+        image_width_mean=image_width_mean,
+        image_height_mean=image_height_mean,
     )
     executable = _resolve_executable(executable)
     env = _clean_subprocess_environment(
@@ -509,58 +632,86 @@ def run_aiperf_sweep(
             allow_aiperf_v011_online_tokenizer_resolution
         ),
     )
-    cached: dict[int, BenchmarkResult] = {}
-    missing: list[tuple[int, Path, list[str], str]] = []
-    for concurrency in concurrency_values:
-        run_dir = artifact_dir / f"concurrency_{concurrency}"
-        run_dir.mkdir(parents=True, exist_ok=True)
-        command = _profile_command(
-            executable=executable,
-            model_name=model_name,
-            port=port,
-            endpoint_type=endpoint_type,
-            concurrency=concurrency,
-            request_count=request_counts[concurrency],
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            tokenizer_dir=tokenizer_dir,
-            artifact_dir=run_dir,
-            seed=seed,
-            extra_inputs=extra_inputs,
-            use_server_token_count=use_server_token_count,
-            gpu_telemetry=gpu_telemetry,
-        )
-        cache_identity = stable_hash(
-            {
-                "architecture_id": architecture_id,
-                "solution_id": solution_id,
-                "profile_id": profile_id,
-                "topology": canonical_topology,
-                "workload": workload,
-                "concurrency": concurrency,
-                "request_count": request_counts[concurrency],
-                "endpoint_type": endpoint_type,
-                "extra_inputs": _exact_length_extra_inputs(extra_inputs, output_tokens),
-                "use_server_token_count": use_server_token_count,
-                "trust_remote_code": trust_remote_code,
-                "allow_aiperf_v011_online_tokenizer_resolution": (
-                    allow_aiperf_v011_online_tokenizer_resolution
-                ),
-                "revisions": revisions,
-            },
-            prefix="aiperf_result",
-        )
-        metadata_path = run_dir / "puzzletron_aiperf_result.json"
-        export = run_dir / "profile_export_aiperf.json"
-        if metadata_path.is_file() and export.is_file():
-            result = BenchmarkResult(**json.loads(metadata_path.read_text()))
-            if result.cache_identity == cache_identity:
-                cached[concurrency] = result
-                continue
-        missing.append((concurrency, run_dir, command, cache_identity))
+    cached: dict[tuple[int, int], BenchmarkResult] = {}
+    missing: list[tuple[int, int, dict[str, int], str, Path, list[str], str]] = []
+    for image_batch_size in image_batch_values:
+        for concurrency in concurrency_values:
+            workload = {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "image_batch_size": image_batch_size,
+                "image_width_mean": image_width_mean if image_batch_size else 0,
+                "image_height_mean": image_height_mean if image_batch_size else 0,
+            }
+            workload_id = stable_hash(workload, prefix="aiperf_workload")
+            run_dir = artifact_dir / f"concurrency_{concurrency}"
+            if image_batch_size > 0:
+                run_dir = artifact_dir / f"images_{image_batch_size}" / f"concurrency_{concurrency}"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            command = _profile_command(
+                executable=executable,
+                model_name=model_name,
+                port=port,
+                endpoint_type=endpoint_type,
+                concurrency=concurrency,
+                request_count=request_counts[concurrency],
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                tokenizer_dir=tokenizer_dir,
+                artifact_dir=run_dir,
+                seed=seed,
+                extra_inputs=extra_inputs,
+                use_server_token_count=use_server_token_count,
+                gpu_telemetry=gpu_telemetry,
+                image_batch_size=image_batch_size,
+                image_width_mean=image_width_mean if image_batch_size else 0,
+                image_height_mean=image_height_mean if image_batch_size else 0,
+            )
+            cache_identity = stable_hash(
+                {
+                    "architecture_id": architecture_id,
+                    "solution_id": solution_id,
+                    "profile_id": profile_id,
+                    "server_contract": server_contract,
+                    "workload": workload,
+                    "concurrency": concurrency,
+                    "request_count": request_counts[concurrency],
+                    "endpoint_type": endpoint_type,
+                    "extra_inputs": _exact_length_extra_inputs(extra_inputs, output_tokens),
+                    "use_server_token_count": use_server_token_count,
+                    "trust_remote_code": trust_remote_code,
+                    "allow_aiperf_v011_online_tokenizer_resolution": (
+                        allow_aiperf_v011_online_tokenizer_resolution
+                    ),
+                    "revisions": revisions,
+                },
+                prefix="aiperf_result",
+            )
+            metadata_path = run_dir / "puzzletron_aiperf_result.json"
+            export = run_dir / "profile_export_aiperf.json"
+            if metadata_path.is_file() and export.is_file():
+                result = BenchmarkResult(**json.loads(metadata_path.read_text()))
+                if result.cache_identity == cache_identity:
+                    cached[(image_batch_size, concurrency)] = result
+                    continue
+            missing.append(
+                (
+                    image_batch_size,
+                    concurrency,
+                    workload,
+                    workload_id,
+                    run_dir,
+                    command,
+                    cache_identity,
+                )
+            )
 
     if not missing:
-        return [cached[value] for value in concurrency_values]
+        return [
+            cached[(image_batch_size, concurrency)]
+            for image_batch_size in image_batch_values
+            for concurrency in concurrency_values
+        ]
 
     with server_log.open("a", encoding="utf-8") as log:
         server = subprocess.Popen(  # nosec B603
@@ -573,7 +724,15 @@ def run_aiperf_sweep(
         )
         try:
             _wait_for_health(f"http://127.0.0.1:{port}/health", server, readiness_timeout)
-            for concurrency, run_dir, command, cache_identity in missing:
+            for (
+                image_batch_size,
+                concurrency,
+                workload,
+                workload_id,
+                run_dir,
+                command,
+                cache_identity,
+            ) in missing:
                 started_at = datetime.now(timezone.utc)
                 subprocess.run(  # nosec B603
                     command,
@@ -633,10 +792,14 @@ def run_aiperf_sweep(
                 (run_dir / "puzzletron_aiperf_result.json").write_text(
                     json.dumps(result_payload, indent=2, sort_keys=True) + "\n"
                 )
-                cached[concurrency] = result
+                cached[(image_batch_size, concurrency)] = result
         finally:
             _stop_process_group(server)
-    return [cached[value] for value in concurrency_values]
+    return [
+        cached[(image_batch_size, concurrency)]
+        for image_batch_size in image_batch_values
+        for concurrency in concurrency_values
+    ]
 
 
 def run_aiperf_benchmark(

--- a/modelopt/torch/puzzletron/diagnostics/campaign_progress_report.py
+++ b/modelopt/torch/puzzletron/diagnostics/campaign_progress_report.py
@@ -4650,7 +4650,21 @@ pre{{max-height:480px;overflow:auto;background:#07101b;border:1px solid #1d2a3d;
     const observations=payload.observations||[];
     const throughput=document.getElementById(`${{section}}-throughput`);
     if(throughput){{
-      const points=observations.filter(row=>row.status==='success'&&finite((row.metrics||{{}}).output_token_throughput)&&finite((row.metrics||{{}}).request_throughput));
+      const points=observations.flatMap(row=>{{
+        if(row.status!=='success')return [];
+        const metrics=row.metrics||{{}};
+        const namespaces=[...new Set(Object.keys(metrics).map(name=>name.match(/^((?:images_[1-9][0-9]*\\.)?concurrency_[1-9][0-9]*)\\./)?.[1]).filter(Boolean))];
+        if(!namespaces.length&&finite(metrics.output_token_throughput)&&finite(metrics.request_throughput))return [{{...row,metrics,workload:''}}];
+        return namespaces.map(namespace=>{{
+          const prefix=`${{namespace}}.`;
+          return {{...row,metrics:{{
+            output_token_throughput:metrics[`${{prefix}}output_token_throughput`],
+            request_throughput:metrics[`${{prefix}}request_throughput`],
+            ttft_mean_ms:metrics[`${{prefix}}ttft_mean_ms`],
+            tpot_mean_ms:metrics[`${{prefix}}tpot_mean_ms`]
+          }},workload:namespace.replaceAll('_',' ')}};
+        }}).filter(point=>finite(point.metrics.output_token_throughput)&&finite(point.metrics.request_throughput));
+      }});
       const groups=[
         ['Candidates',points.filter(row=>!selected(row))],
         ['Selected by downstream filter',points.filter(selected)],
@@ -4658,10 +4672,10 @@ pre{{max-height:480px;overflow:auto;background:#07101b;border:1px solid #1d2a3d;
       const traces=groups.filter(([,rows])=>rows.length).map(([name,rows],index)=>({{
         x:rows.map(row=>Number(row.metrics.output_token_throughput)),
         y:rows.map(row=>Number(row.metrics.request_throughput)),
-        text:rows.map(label),customdata:rows.map(row=>[row.metrics.ttft_mean_ms,row.metrics.tpot_mean_ms]),
+        text:rows.map(label),customdata:rows.map(row=>[row.metrics.ttft_mean_ms,row.metrics.tpot_mean_ms,row.workload]),
         mode:'markers',type:'scatter',name,
         marker:{{size:index?15:9,color:rows.map(row=>row.color||'#4f8cff'),symbol:index?'diamond-open':'circle',line:{{color:index?'#ffffff':'rgba(0,0,0,0)',width:index?2:0}}}},
-        hovertemplate:'%{{text}}<br>output=%{{x:.6g}} tokens/s<br>requests=%{{y:.6g}}/s<br>TTFT=%{{customdata[0]:.6g}} ms<br>TPOT=%{{customdata[1]:.6g}} ms<extra></extra>'
+        hovertemplate:'%{{text}}<br>%{{customdata[2]}}<br>output=%{{x:.6g}} tokens/s<br>requests=%{{y:.6g}}/s<br>TTFT=%{{customdata[0]:.6g}} ms<br>TPOT=%{{customdata[1]:.6g}} ms<extra></extra>'
       }}));
       Plotly.react(throughput,traces,{{...charts.theme,title:charts.chartTitle('Output throughput vs request throughput',16),xaxis:{{...charts.theme.xaxis,title:'Output token throughput (tokens/s)'}},yaxis:{{...charts.theme.yaxis,title:'Request throughput (requests/s)'}},hovermode:'closest'}},charts.config);
     }}

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -32,7 +32,7 @@ import json
 import os
 import types
 from collections import deque
-from contextlib import ExitStack, nullcontext
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Callable
 
@@ -75,8 +75,6 @@ from nemo_automodel.recipes.vlm.kd import _validate_cp_pre_embed_teacher_compati
 from nemo_automodel.recipes.vlm.kd import _verify_tokenizer_compatibility as _verify_vlm_tokenizers
 from torch.distributed.tensor import DTensor, Replicate
 from torch.utils.checkpoint import checkpoint
-
-from modelopt.torch.opt.dynamic import DynamicModule
 
 from ..plugins.automodel.batch_adapter import VisionForwardMonitor
 from ..plugins.automodel.local_kd_recipe import _copy_hf_auxiliary_assets
@@ -230,13 +228,6 @@ def install_unsharded_checkpoint_state_dict_support() -> None:
             error
         )
 
-    def dynamic_attributes_reset(model):
-        stack = ExitStack()
-        for module in model.modules():
-            if isinstance(module, DynamicModule):
-                stack.enter_context(module.reset_dynamic_attributes())
-        return stack
-
     original_get = stateful_wrappers.get_model_state_dict
     if not getattr(original_get, "_puzzletron_unsharded_fallback", False):
 
@@ -246,16 +237,15 @@ def install_unsharded_checkpoint_state_dict_support() -> None:
             except RuntimeError as error:
                 if not is_empty_dcp_state(error):
                     raise
-                with dynamic_attributes_reset(model):
-                    state_dict = {
-                        name: parameter.detach()
-                        for name, parameter in model.named_parameters(remove_duplicate=False)
-                    }
-                    for name, buffer in model.named_buffers(remove_duplicate=False):
-                        module_name, _, buffer_name = name.rpartition(".")
-                        owner = model.get_submodule(module_name)
-                        if buffer_name not in owner._non_persistent_buffers_set:
-                            state_dict[name] = buffer.detach()
+                state_dict = {
+                    name: parameter.detach()
+                    for name, parameter in model.named_parameters(remove_duplicate=False)
+                }
+                for name, buffer in model.named_buffers(remove_duplicate=False):
+                    module_name, _, buffer_name = name.rpartition(".")
+                    owner = model.get_submodule(module_name)
+                    if buffer_name not in owner._non_persistent_buffers_set:
+                        state_dict[name] = buffer.detach()
                 if not state_dict:
                     raise
                 return state_dict
@@ -272,11 +262,10 @@ def install_unsharded_checkpoint_state_dict_support() -> None:
             except RuntimeError as error:
                 if not is_empty_dcp_state(error):
                     raise
-                with dynamic_attributes_reset(model):
-                    return model.load_state_dict(
-                        state_dict,
-                        strict=True if options is None else bool(options.strict),
-                    )
+                return model.load_state_dict(
+                    state_dict,
+                    strict=True if options is None else bool(options.strict),
+                )
 
         setattr(set_model_state_dict, "_puzzletron_unsharded_fallback", True)
         stateful_wrappers.set_model_state_dict = set_model_state_dict

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -232,23 +232,26 @@ def install_unsharded_checkpoint_state_dict_support() -> None:
     if not getattr(original_get, "_puzzletron_unsharded_fallback", False):
 
         def get_model_state_dict(model, *args, **kwargs):
+            # Snapshot references before DCP enters ModelOpt's dynamic-attribute
+            # reset contexts. Some nested dynamic VLMs expose no registered
+            # tensors after that failed traversal has unwound.
+            fallback_state_dict = {
+                name: parameter.detach()
+                for name, parameter in model.named_parameters(remove_duplicate=False)
+            }
+            for name, buffer in model.named_buffers(remove_duplicate=False):
+                module_name, _, buffer_name = name.rpartition(".")
+                owner = model.get_submodule(module_name)
+                if buffer_name not in owner._non_persistent_buffers_set:
+                    fallback_state_dict[name] = buffer.detach()
             try:
                 return original_get(model, *args, **kwargs)
             except RuntimeError as error:
                 if not is_empty_dcp_state(error):
                     raise
-                state_dict = {
-                    name: parameter.detach()
-                    for name, parameter in model.named_parameters(remove_duplicate=False)
-                }
-                for name, buffer in model.named_buffers(remove_duplicate=False):
-                    module_name, _, buffer_name = name.rpartition(".")
-                    owner = model.get_submodule(module_name)
-                    if buffer_name not in owner._non_persistent_buffers_set:
-                        state_dict[name] = buffer.detach()
-                if not state_dict:
+                if not fallback_state_dict:
                     raise
-                return state_dict
+                return fallback_state_dict
 
         setattr(get_model_state_dict, "_puzzletron_unsharded_fallback", True)
         stateful_wrappers.get_model_state_dict = get_model_state_dict

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -212,6 +212,38 @@ def install_pp_checkpoint_state_dict_support() -> None:
         setattr(stateful_wrappers, name, non_strict)
 
 
+def install_unsharded_checkpoint_state_dict_support() -> None:
+    """Fall back to the ordinary state dict for a one-rank dynamic model.
+
+    PyTorch DCP can reject an otherwise valid unsharded DynamicModule after its
+    model-state verification removes every entry.  A one-rank checkpoint needs
+    no distributed state-dict transformation, so use the module's regular
+    state dict for this specific failure while preserving every other error.
+    """
+    from nemo_automodel.components.checkpoint import stateful_wrappers
+
+    original = stateful_wrappers.get_model_state_dict
+    if getattr(original, "_puzzletron_unsharded_fallback", False):
+        return
+
+    def get_model_state_dict(model, *args, **kwargs):
+        try:
+            return original(model, *args, **kwargs)
+        except RuntimeError as error:
+            if (
+                "model state_dict is required to save or load, but model state_dict is empty"
+                not in str(error)
+            ):
+                raise
+            state_dict = model.state_dict()
+            if not state_dict:
+                raise
+            return state_dict
+
+    setattr(get_model_state_dict, "_puzzletron_unsharded_fallback", True)
+    stateful_wrappers.get_model_state_dict = get_model_state_dict
+
+
 def _trace_global_kd_phase(phase: str) -> None:
     if os.environ.get("PUZZLETRON_TRACE_GLOBAL_KD") != "1":
         return
@@ -654,6 +686,8 @@ class _WeightedObjectiveMixin:
     ):
         """Publish a completion marker only after model and optimizer DCP succeed."""
 
+        if not torch.distributed.is_initialized() or torch.distributed.get_world_size() == 1:
+            install_unsharded_checkpoint_state_dict_support()
         result = None
         publication_error: Exception | None = None
         publication_error_text: str | None = None

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -215,39 +215,71 @@ def install_pp_checkpoint_state_dict_support() -> None:
 
 
 def install_unsharded_checkpoint_state_dict_support() -> None:
-    """Fall back to the ordinary state dict for a one-rank dynamic model.
+    """Fall back to named tensors for a one-rank dynamic model checkpoint.
 
     PyTorch DCP can reject an otherwise valid unsharded DynamicModule after its
-    model-state verification removes every entry.  A one-rank checkpoint needs
-    no distributed state-dict transformation, so use the module's regular
-    state dict for this specific failure while preserving every other error.
+    model-state verification removes every entry. The module's regular state
+    dict is empty for the same reason, so collect registered parameters and
+    persistent buffers directly. A one-rank checkpoint needs no distributed
+    state-dict transformation.
     """
     from nemo_automodel.components.checkpoint import stateful_wrappers
 
-    original = stateful_wrappers.get_model_state_dict
-    if getattr(original, "_puzzletron_unsharded_fallback", False):
-        return
+    def is_empty_dcp_state(error: RuntimeError) -> bool:
+        return "model state_dict is required to save or load, but model state_dict is empty" in str(
+            error
+        )
 
-    def get_model_state_dict(model, *args, **kwargs):
-        try:
-            return original(model, *args, **kwargs)
-        except RuntimeError as error:
-            if (
-                "model state_dict is required to save or load, but model state_dict is empty"
-                not in str(error)
-            ):
-                raise
-            with ExitStack() as stack:
-                for module in model.modules():
-                    if isinstance(module, DynamicModule):
-                        stack.enter_context(module.reset_dynamic_attributes())
-                state_dict = model.state_dict()
-            if not state_dict:
-                raise
-            return state_dict
+    def dynamic_attributes_reset(model):
+        stack = ExitStack()
+        for module in model.modules():
+            if isinstance(module, DynamicModule):
+                stack.enter_context(module.reset_dynamic_attributes())
+        return stack
 
-    setattr(get_model_state_dict, "_puzzletron_unsharded_fallback", True)
-    stateful_wrappers.get_model_state_dict = get_model_state_dict
+    original_get = stateful_wrappers.get_model_state_dict
+    if not getattr(original_get, "_puzzletron_unsharded_fallback", False):
+
+        def get_model_state_dict(model, *args, **kwargs):
+            try:
+                return original_get(model, *args, **kwargs)
+            except RuntimeError as error:
+                if not is_empty_dcp_state(error):
+                    raise
+                with dynamic_attributes_reset(model):
+                    state_dict = {
+                        name: parameter.detach()
+                        for name, parameter in model.named_parameters(remove_duplicate=False)
+                    }
+                    for name, buffer in model.named_buffers(remove_duplicate=False):
+                        module_name, _, buffer_name = name.rpartition(".")
+                        owner = model.get_submodule(module_name)
+                        if buffer_name not in owner._non_persistent_buffers_set:
+                            state_dict[name] = buffer.detach()
+                if not state_dict:
+                    raise
+                return state_dict
+
+        setattr(get_model_state_dict, "_puzzletron_unsharded_fallback", True)
+        stateful_wrappers.get_model_state_dict = get_model_state_dict
+
+    original_set = stateful_wrappers.set_model_state_dict
+    if not getattr(original_set, "_puzzletron_unsharded_fallback", False):
+
+        def set_model_state_dict(model, state_dict, *args, options=None, **kwargs):
+            try:
+                return original_set(model, state_dict, *args, options=options, **kwargs)
+            except RuntimeError as error:
+                if not is_empty_dcp_state(error):
+                    raise
+                with dynamic_attributes_reset(model):
+                    return model.load_state_dict(
+                        state_dict,
+                        strict=True if options is None else bool(options.strict),
+                    )
+
+        setattr(set_model_state_dict, "_puzzletron_unsharded_fallback", True)
+        stateful_wrappers.set_model_state_dict = set_model_state_dict
 
 
 def _trace_global_kd_phase(phase: str) -> None:

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -212,68 +212,6 @@ def install_pp_checkpoint_state_dict_support() -> None:
         setattr(stateful_wrappers, name, non_strict)
 
 
-def install_unsharded_checkpoint_state_dict_support() -> None:
-    """Fall back to named tensors for a one-rank dynamic model checkpoint.
-
-    PyTorch DCP can reject an otherwise valid unsharded DynamicModule after its
-    model-state verification removes every entry. The module's regular state
-    dict is empty for the same reason, so collect registered parameters and
-    persistent buffers directly. A one-rank checkpoint needs no distributed
-    state-dict transformation.
-    """
-    from nemo_automodel.components.checkpoint import stateful_wrappers
-
-    def is_empty_dcp_state(error: RuntimeError) -> bool:
-        return "model state_dict is required to save or load, but model state_dict is empty" in str(
-            error
-        )
-
-    original_get = stateful_wrappers.get_model_state_dict
-    if not getattr(original_get, "_puzzletron_unsharded_fallback", False):
-
-        def get_model_state_dict(model, *args, **kwargs):
-            # Snapshot references before DCP enters ModelOpt's dynamic-attribute
-            # reset contexts. Some nested dynamic VLMs expose no registered
-            # tensors after that failed traversal has unwound.
-            fallback_state_dict = {
-                name: parameter.detach()
-                for name, parameter in model.named_parameters(remove_duplicate=False)
-            }
-            for name, buffer in model.named_buffers(remove_duplicate=False):
-                module_name, _, buffer_name = name.rpartition(".")
-                owner = model.get_submodule(module_name)
-                if buffer_name not in owner._non_persistent_buffers_set:
-                    fallback_state_dict[name] = buffer.detach()
-            try:
-                return original_get(model, *args, **kwargs)
-            except RuntimeError as error:
-                if not is_empty_dcp_state(error):
-                    raise
-                if not fallback_state_dict:
-                    raise
-                return fallback_state_dict
-
-        setattr(get_model_state_dict, "_puzzletron_unsharded_fallback", True)
-        stateful_wrappers.get_model_state_dict = get_model_state_dict
-
-    original_set = stateful_wrappers.set_model_state_dict
-    if not getattr(original_set, "_puzzletron_unsharded_fallback", False):
-
-        def set_model_state_dict(model, state_dict, *args, options=None, **kwargs):
-            try:
-                return original_set(model, state_dict, *args, options=options, **kwargs)
-            except RuntimeError as error:
-                if not is_empty_dcp_state(error):
-                    raise
-                return model.load_state_dict(
-                    state_dict,
-                    strict=True if options is None else bool(options.strict),
-                )
-
-        setattr(set_model_state_dict, "_puzzletron_unsharded_fallback", True)
-        stateful_wrappers.set_model_state_dict = set_model_state_dict
-
-
 def _trace_global_kd_phase(phase: str) -> None:
     if os.environ.get("PUZZLETRON_TRACE_GLOBAL_KD") != "1":
         return
@@ -716,8 +654,6 @@ class _WeightedObjectiveMixin:
     ):
         """Publish a completion marker only after model and optimizer DCP succeed."""
 
-        if not torch.distributed.is_initialized() or torch.distributed.get_world_size() == 1:
-            install_unsharded_checkpoint_state_dict_support()
         result = None
         publication_error: Exception | None = None
         publication_error_text: str | None = None
@@ -1200,6 +1136,7 @@ class _WeightedObjectiveMixin:
             checkpoint_chunks=True,
         )
         setattr(self, attribute, engine)
+        self.untrack_state(attribute)  # type: ignore[attr-defined]
         return engine
 
     def _hidden_objective_losses(

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -32,7 +32,7 @@ import json
 import os
 import types
 from collections import deque
-from contextlib import nullcontext
+from contextlib import ExitStack, nullcontext
 from pathlib import Path
 from typing import Any, Callable
 
@@ -75,6 +75,8 @@ from nemo_automodel.recipes.vlm.kd import _validate_cp_pre_embed_teacher_compati
 from nemo_automodel.recipes.vlm.kd import _verify_tokenizer_compatibility as _verify_vlm_tokenizers
 from torch.distributed.tensor import DTensor, Replicate
 from torch.utils.checkpoint import checkpoint
+
+from modelopt.torch.opt.dynamic import DynamicModule
 
 from ..plugins.automodel.batch_adapter import VisionForwardMonitor
 from ..plugins.automodel.local_kd_recipe import _copy_hf_auxiliary_assets
@@ -235,7 +237,11 @@ def install_unsharded_checkpoint_state_dict_support() -> None:
                 not in str(error)
             ):
                 raise
-            state_dict = model.state_dict()
+            with ExitStack() as stack:
+                for module in model.modules():
+                    if isinstance(module, DynamicModule):
+                        stack.enter_context(module.reset_dynamic_attributes())
+                state_dict = model.state_dict()
             if not state_dict:
                 raise
             return state_dict

--- a/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
+++ b/modelopt/torch/puzzletron/distillation/global_kd_recipe.py
@@ -77,6 +77,7 @@ from torch.distributed.tensor import DTensor, Replicate
 from torch.utils.checkpoint import checkpoint
 
 from ..plugins.automodel.batch_adapter import VisionForwardMonitor
+from ..plugins.automodel.local_kd_recipe import _copy_hf_auxiliary_assets
 from ..plugins.automodel.pp_utils import set_pp_vlm_chunk_specs
 from ..security_policy import require_boolean_policy
 from .flash_kld import TrainingFlashKLD
@@ -707,6 +708,10 @@ class _WeightedObjectiveMixin:
                             default=False,
                         ),
                     )
+                model_config = _config_value(getattr(self, "cfg", None), "model")
+                source_dir = _config_value(model_config, "pretrained_model_name_or_path")
+                if source_dir:
+                    _copy_hf_auxiliary_assets(Path(source_dir), consolidated)
                 Path(checkpoint_path, "saving_completed").touch()
             except Exception as error:  # noqa: BLE001 - all ranks must reach the collective
                 publication_error = error

--- a/modelopt/torch/puzzletron/plugins/automodel/local_kd_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/local_kd_recipe.py
@@ -443,10 +443,10 @@ def _copy_hf_auxiliary_assets(source_dir: Path, consolidated_dir: Path) -> None:
     retaining bounded tokenizer and image/video processor assets needed by
     ``AutoProcessor.from_pretrained``.
     """
-    if not source_dir.is_dir() or not consolidated_dir.is_dir():
-        return
     if source_dir.is_symlink() or consolidated_dir.is_symlink():
         raise ValueError("checkpoint asset directories must not be symbolic links")
+    if not source_dir.is_dir() or not consolidated_dir.is_dir():
+        return
 
     candidates = [source_dir / name for name in sorted(_HF_AUXILIARY_FILENAMES)]
     chat_templates = source_dir / "chat_templates"

--- a/modelopt/torch/puzzletron/plugins/automodel/local_kd_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/local_kd_recipe.py
@@ -466,6 +466,10 @@ def _copy_hf_auxiliary_assets(source_dir: Path, consolidated_dir: Path) -> None:
         destination = consolidated_dir / relative
         if destination.is_symlink():
             raise ValueError(f"checkpoint destination must not be a symbolic link: {relative}")
+        if destination.parent.is_symlink():
+            raise ValueError(
+                f"checkpoint destination directory must not be a symbolic link: {destination.parent.name}"
+            )
         if destination.exists():
             continue
         size = source.stat().st_size
@@ -477,10 +481,6 @@ def _copy_hf_auxiliary_assets(source_dir: Path, consolidated_dir: Path) -> None:
         validated.append((source, destination))
 
     for source, destination in validated:
-        if destination.parent.is_symlink():
-            raise ValueError(
-                f"checkpoint destination directory must not be a symbolic link: {destination.parent.name}"
-            )
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, destination)
 

--- a/modelopt/torch/puzzletron/plugins/automodel/local_kd_recipe.py
+++ b/modelopt/torch/puzzletron/plugins/automodel/local_kd_recipe.py
@@ -90,6 +90,8 @@ def _consolidated_export_enabled(value) -> bool:
     from nemo_automodel.components.checkpoint.config import SaveConsolidatedMode
 
     return value != SaveConsolidatedMode.FALSE
+
+
 from .solution_recipe import ReplaceBlockScoringRecipe
 
 logger = logging.getLogger(__name__)
@@ -97,13 +99,26 @@ logger = logging.getLogger(__name__)
 __all__ = ["AutoModelLocalDistillationRecipe"]
 
 
-_HF_WEIGHT_FILENAMES = {
-    "model.safetensors",
-    "model.safetensors.index.json",
-    "pytorch_model.bin",
-    "pytorch_model.bin.index.json",
-    "config.json",
+_HF_AUXILIARY_FILENAMES = {
+    "added_tokens.json",
+    "chat_template.json",
+    "chat_template.jinja",
+    "generation_config.json",
+    "merges.txt",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "sentencepiece.bpe.model",
+    "special_tokens_map.json",
+    "spiece.model",
+    "tokenizer.json",
+    "tokenizer.model",
+    "tokenizer_config.json",
+    "video_preprocessor_config.json",
+    "vocab.json",
+    "vocab.txt",
 }
+_HF_AUXILIARY_FILE_SIZE_LIMIT = 64 * 1024 * 1024
+_HF_AUXILIARY_TOTAL_SIZE_LIMIT = 256 * 1024 * 1024
 
 
 def _mask_local_kd_tensors(
@@ -120,9 +135,7 @@ def _mask_local_kd_tensors(
         return student, teacher
     mask = hidden_mask.bool()
     if student.ndim < 2:
-        raise RuntimeError(
-            "padded/packed local KD requires replay tensors with token dimensions"
-        )
+        raise RuntimeError("padded/packed local KD requires replay tensors with token dimensions")
     if tuple(student.shape[:2]) == tuple(mask.shape):
         return student[mask], teacher[mask]
     if tuple(student.shape[:2]) == tuple(reversed(mask.shape)):
@@ -386,8 +399,7 @@ def _loss_trend_summary(
         if summary:
             per_hidden_width[str(width)] = summary
     relative_decrease = (
-        (aggregate["first_median"] - aggregate["last_median"])
-        / abs(aggregate["first_median"])
+        (aggregate["first_median"] - aggregate["last_median"]) / abs(aggregate["first_median"])
         if aggregate["first_median"] != 0
         else None
     )
@@ -428,22 +440,49 @@ def _copy_hf_auxiliary_assets(source_dir: Path, consolidated_dir: Path) -> None:
     NeMo AutoModel's consolidated saver persists the tokenizer but does not
     currently preserve every multimodal processor file.  Copying only absent,
     non-weight files keeps the consolidated model/config authoritative while
-    retaining image/video processors and custom-code assets needed by
+    retaining bounded tokenizer and image/video processor assets needed by
     ``AutoProcessor.from_pretrained``.
     """
     if not source_dir.is_dir() or not consolidated_dir.is_dir():
         return
-    for source in source_dir.rglob("*"):
-        if not source.is_file():
+    if source_dir.is_symlink() or consolidated_dir.is_symlink():
+        raise ValueError("checkpoint asset directories must not be symbolic links")
+
+    candidates = [source_dir / name for name in sorted(_HF_AUXILIARY_FILENAMES)]
+    chat_templates = source_dir / "chat_templates"
+    if chat_templates.is_symlink():
+        raise ValueError("checkpoint chat_templates directory must not be a symbolic link")
+    if chat_templates.is_dir():
+        candidates.extend(sorted(chat_templates.glob("*.jinja")))
+
+    validated = []
+    total_size = 0
+    for source in candidates:
+        if not source.exists() and not source.is_symlink():
             continue
+        if source.is_symlink() or not source.is_file():
+            raise ValueError(f"checkpoint asset must be a regular file: {source.name}")
         relative = source.relative_to(source_dir)
-        if source.name in _HF_WEIGHT_FILENAMES or source.suffix in {".safetensors", ".bin"}:
-            continue
         destination = consolidated_dir / relative
+        if destination.is_symlink():
+            raise ValueError(f"checkpoint destination must not be a symbolic link: {relative}")
         if destination.exists():
             continue
+        size = source.stat().st_size
+        if size > _HF_AUXILIARY_FILE_SIZE_LIMIT:
+            raise ValueError(f"checkpoint asset exceeds the per-file size limit: {relative}")
+        total_size += size
+        if total_size > _HF_AUXILIARY_TOTAL_SIZE_LIMIT:
+            raise ValueError("checkpoint assets exceed the aggregate size limit")
+        validated.append((source, destination))
+
+    for source, destination in validated:
+        if destination.parent.is_symlink():
+            raise ValueError(
+                f"checkpoint destination directory must not be a symbolic link: {destination.parent.name}"
+            )
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, destination)
+        shutil.copyfile(source, destination)
 
 
 def _detach_tree(value):
@@ -708,10 +747,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             native_dataloader
             if (
                 self._use_vlm_recipe
-                or (
-                    self._data_spec is not None
-                    and self._data_spec.layout is not DataLayout.FIXED
-                )
+                or (self._data_spec is not None and self._data_spec.layout is not DataLayout.FIXED)
             )
             else self._build_puzzletron_train_dataloader()
         )
@@ -760,9 +796,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
                 if axis not in mesh.mesh_dim_names or mesh[axis].size() <= 1:
                     continue
                 group = mesh[axis].get_group()
-                local_peer_sets.append(
-                    tuple(torch.distributed.get_process_group_ranks(group))
-                )
+                local_peer_sets.append(tuple(torch.distributed.get_process_group_ranks(group)))
         gathered = [None] * torch.distributed.get_world_size()
         torch.distributed.all_gather_object(gathered, tuple(local_peer_sets))
         lane, lane_count = logical_data_lane_from_peer_sets(
@@ -779,9 +813,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
     def _architecture_sample_index(self, step: int, micro_step: int = 0) -> int:
         hydra_cfg = getattr(self, "_hydra_cfg", None)
         grad_accum = (
-            int(hydra_cfg.bypass.training.grad_accumulation_steps)
-            if hydra_cfg is not None
-            else 1
+            int(hydra_cfg.bypass.training.grad_accumulation_steps) if hydra_cfg is not None else 1
         )
         iteration = (int(step) - 1) * grad_accum + int(micro_step)
         return iteration * self._logical_dp_size + self._logical_dp_lane
@@ -829,10 +861,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             trust_remote_code=bool(self.cfg.model.get("trust_remote_code", True)),
             token=True,
         )
-        if (
-            self._data_spec is not None
-            and self._data_spec.layout is not DataLayout.FIXED
-        ):
+        if self._data_spec is not None and self._data_spec.layout is not DataLayout.FIXED:
             from ...utils.data.dataloaders import prepare_validation_dataloader
 
             validation_args = OmegaConf.to_container(data_cfg, resolve=True)
@@ -1078,8 +1107,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
                     for subblock in elastic.parent_block_config.subblock_configs
                 }
                 teacher_counts = {
-                    key: subblock_cost(subblock)
-                    for key, subblock in teacher_subblocks.items()
+                    key: subblock_cost(subblock) for key, subblock in teacher_subblocks.items()
                 }
                 for candidate in elastic.sampler.sizes:
                     candidate_id = str(candidate.identity.value)
@@ -1153,9 +1181,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             return self._teacher_hidden_width
         sample_index = self._architecture_sample_index(step, micro_step)
         generator = torch.Generator().manual_seed(
-            int(self._hydra_cfg.bypass.get("elastic_seed", 42))
-            + 7_919
-            + 104_729 * sample_index
+            int(self._hydra_cfg.bypass.get("elastic_seed", 42)) + 7_919 + 104_729 * sample_index
         )
         width = _select_hidden_width(
             self._hidden_widths,
@@ -1175,11 +1201,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
         # cycle so the combined global axes cover their Cartesian product.
         hidden_period = max(1, len(self._hidden_widths))
         sample_index = self._architecture_sample_index(step, micro_step)
-        width = int(
-            self._ple_widths[
-                (sample_index // hidden_period) % len(self._ple_widths)
-            ]
-        )
+        width = int(self._ple_widths[(sample_index // hidden_period) % len(self._ple_widths)])
         self._ple_width_counts[width] += 1
         return width
 
@@ -1561,17 +1583,13 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
         validation_result: list[dict[str, object] | None] = [None]
         if self.dist_env.is_main:
             try:
-                if require_completed and not (
-                    checkpoint_path / "saving_completed"
-                ).is_file():
+                if require_completed and not (checkpoint_path / "saving_completed").is_file():
                     raise RuntimeError(
                         f"checkpoint has no saving_completed marker: {checkpoint_path}"
                     )
                 validation_result[0] = validate_automodel_bypass_checkpoint(
                     checkpoint_path,
-                    expected_rng_ranks=range(
-                        self._get_dp_group_size(include_cp=True)
-                    ),
+                    expected_rng_ranks=range(self._get_dp_group_size(include_cp=True)),
                 )
             except BaseException as error:
                 validation_result[0] = {
@@ -1608,8 +1626,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
         torch.distributed.broadcast_object_list(quarantine_error, src=0)
         if quarantine_error[0] is not None:
             raise RuntimeError(
-                f"cannot prepare checkpoint transaction {checkpoint_path}: "
-                f"{quarantine_error[0]}"
+                f"cannot prepare checkpoint transaction {checkpoint_path}: {quarantine_error[0]}"
             )
         torch.distributed.barrier()
 
@@ -1798,9 +1815,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
                     hidden_width=hidden_width,
                     ple_width=ple_width,
                     targets=(
-                        self._last_elastic_targets
-                        if self._elastic_masker is not None
-                        else {}
+                        self._last_elastic_targets if self._elastic_masker is not None else {}
                     ),
                     parameter_counts=self._elastic_parameter_counts_by_width.get(
                         int(hidden_width), {}
@@ -1880,9 +1895,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
                                 "dp_lane": self._logical_dp_lane,
                                 "selection": selection_record,
                                 "per_layer_loss": dict(layer_metrics),
-                                "per_subblock_loss": dict(
-                                    self._current_subblock_metrics
-                                ),
+                                "per_subblock_loss": dict(self._current_subblock_metrics),
                             }
                         )
                 self._teacher_records.clear()
@@ -2067,16 +2080,13 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             save_at_steps = {
                 int(value)
                 for value in (
-                    self._hydra_cfg.bypass.model.model_overrides.get("save_at_steps", [])
-                    or []
+                    self._hydra_cfg.bypass.model.model_overrides.get("save_at_steps", []) or []
                 )
             }
             save_interval_seconds = float(
                 self._hydra_cfg.bypass.model.model_overrides.get("save_interval_seconds", 0) or 0
             )
-            step_due = step in save_at_steps or (
-                save_interval > 0 and step % save_interval == 0
-            )
+            step_due = step in save_at_steps or (save_interval > 0 and step % save_interval == 0)
             time_due = (
                 save_interval_seconds > 0
                 and time.monotonic() - last_checkpoint_time >= save_interval_seconds
@@ -2135,9 +2145,8 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
         global_hidden_width_counts = dict(self._hidden_width_counts)
         global_ple_width_counts = dict(self._ple_width_counts)
         if (
-            (self._embedding_spec is not None or self._ple_spec is not None)
-            and not single_batch_overfit
-        ):
+            self._embedding_spec is not None or self._ple_spec is not None
+        ) and not single_batch_overfit:
             payload = {
                 "dp_lane": self._logical_dp_lane,
                 "hidden_width_counts": dict(self._hidden_width_counts),
@@ -2158,9 +2167,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             )
 
         if self._embedding_spec is not None and not single_batch_overfit:
-            missing_widths = sorted(
-                set(self._hidden_widths) - set(global_hidden_width_counts)
-            )
+            missing_widths = sorted(set(self._hidden_widths) - set(global_hidden_width_counts))
             if missing_widths:
                 raise RuntimeError(
                     "nested bypass did not sample every configured hidden width: "
@@ -2185,9 +2192,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             }
 
         if self._ple_spec is not None and not single_batch_overfit:
-            missing_ple_widths = sorted(
-                set(self._ple_widths) - set(global_ple_width_counts)
-            )
+            missing_ple_widths = sorted(set(self._ple_widths) - set(global_ple_width_counts))
             if missing_ple_widths:
                 raise RuntimeError(
                     "nested bypass did not sample every configured PLE width: "
@@ -2227,9 +2232,7 @@ class AutoModelLocalDistillationRecipe(ReplaceBlockScoringRecipe):
             fixed_targets = overfit_structure[3] if overfit_structure is not None else {}
             structure_identities = set()
             for record in loss_history:
-                selections = record.get("elastic_selections") or (
-                    record.get("elastic_selection"),
-                )
+                selections = record.get("elastic_selections") or (record.get("elastic_selection"),)
                 for raw_selection in selections:
                     selection = dict(raw_selection or {})
                     selection.pop("step", None)

--- a/modelopt/torch/puzzletron/post_mip/records.py
+++ b/modelopt/torch/puzzletron/post_mip/records.py
@@ -266,7 +266,12 @@ class CandidateLedger:
         observation = self._observation_for_revision(owner, revision_id)
         if observation is None:
             return {}
-        pattern = re.compile(rf"^concurrency_([1-9][0-9]*)\.{re.escape(metric)}$")
+        image_namespace = ""
+        image_match = re.fullmatch(r"(images_[1-9][0-9]*)\.(.+)", metric)
+        if image_match is not None:
+            image_namespace = re.escape(image_match.group(1)) + r"\."
+            metric = image_match.group(2)
+        pattern = re.compile(rf"^{image_namespace}concurrency_([1-9][0-9]*)\.{re.escape(metric)}$")
         values = {}
         for name, value in observation.metrics.items():
             match = pattern.fullmatch(name)

--- a/modelopt/torch/puzzletron/post_mip/reporting.py
+++ b/modelopt/torch/puzzletron/post_mip/reporting.py
@@ -21,6 +21,7 @@ import hashlib
 import html
 import json
 import math
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -326,22 +327,41 @@ def render_aiperf_report(section_id: str, payload: Mapping[str, Any]) -> str:
         metrics = dict(row.get("metrics") or {})
         selected = bool(row.get("selected_by"))
         selection = "Selected by Fastest" if selected else ""
-        rows.append(
-            f"<tr class='{'selected-candidate' if selected else ''}'>"
-            f"<td>{_text(row.get('label') or row.get('architecture_id') or 'unknown')}</td>"
-            f"<td>{_text(row.get('status') or 'pending')}</td>"
-            f"<td>{_text(selection)}</td>"
-            f"<td>{_number(metrics.get('request_throughput'))}</td>"
-            f"<td>{_number(metrics.get('output_token_throughput'))}</td>"
-            f"<td>{_number(metrics.get('ttft_mean_ms'))}</td>"
-            f"<td>{_number(metrics.get('tpot_mean_ms'))}</td>"
-            f"<td>{_text(row.get('error') or '')}</td>"
-            "</tr>"
+        namespaces = sorted(
+            {
+                match.group(1)
+                for name in metrics
+                if (
+                    match := re.fullmatch(
+                        r"((?:images_[1-9][0-9]*\.)?concurrency_[1-9][0-9]*)\..+",
+                        name,
+                    )
+                )
+            }
         )
+        if not namespaces:
+            namespaces = [""]
+        for namespace in namespaces:
+            prefix = f"{namespace}." if namespace else ""
+            workload = namespace.replace(".", " / ").replace("_", " ") or "single run"
+            rows.append(
+                f"<tr class='{'selected-candidate' if selected else ''}'>"
+                f"<td>{_text(row.get('label') or row.get('architecture_id') or 'unknown')}</td>"
+                f"<td>{_text(workload)}</td>"
+                f"<td>{_text(row.get('status') or 'pending')}</td>"
+                f"<td>{_text(selection)}</td>"
+                f"<td>{_number(metrics.get(prefix + 'request_throughput'))}</td>"
+                f"<td>{_number(metrics.get(prefix + 'image_throughput'))}</td>"
+                f"<td>{_number(metrics.get(prefix + 'output_token_throughput'))}</td>"
+                f"<td>{_number(metrics.get(prefix + 'ttft_mean_ms'))}</td>"
+                f"<td>{_number(metrics.get(prefix + 'tpot_mean_ms'))}</td>"
+                f"<td>{_text(row.get('error') or '')}</td>"
+                "</tr>"
+            )
     table = (
         "<div class='table-wrap'><table><thead><tr>"
-        "<th>Candidate</th><th>Status</th><th>Selection</th>"
-        "<th>Requests/s</th><th>Output tokens/s</th><th>TTFT mean (ms)</th>"
+        "<th>Candidate</th><th>Workload</th><th>Status</th><th>Selection</th>"
+        "<th>Requests/s</th><th>Images/s</th><th>Output tokens/s</th><th>TTFT mean (ms)</th>"
         "<th>TPOT mean (ms)</th><th>Error</th>"
         f"</tr></thead><tbody>{''.join(rows)}</tbody></table></div>"
         if rows

--- a/modelopt/torch/puzzletron/post_mip/runner.py
+++ b/modelopt/torch/puzzletron/post_mip/runner.py
@@ -483,12 +483,11 @@ def _aiperf(
     for result in results:
         if len(results) == 1:
             metrics.update(result.metrics)
-        metrics.update(
-            {
-                f"concurrency_{result.concurrency}.{key}": value
-                for key, value in result.metrics.items()
-            }
-        )
+        image_batch_size = int(result.workload.get("image_batch_size", 0))
+        namespace = f"concurrency_{result.concurrency}"
+        if image_batch_size > 0:
+            namespace = f"images_{image_batch_size}.{namespace}"
+        metrics.update({f"{namespace}.{key}": value for key, value in result.metrics.items()})
     return {
         "metrics": metrics,
         "result_paths": [result.raw_artifacts for result in results],

--- a/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
+++ b/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
@@ -292,23 +292,18 @@ def test_vllm_server_command_loads_full_multimodal_model(monkeypatch, tmp_path):
     (tmp_path / "config.json").write_text(
         json.dumps(
             {
+                "model_type": "qwen3_5",
                 "architectures": ["AnyModel"],
                 "base_architecture": "Qwen3_5ForConditionalGeneration",
                 "vision_config": {"model_type": "qwen3_5_vision"},
+                "text_config": {
+                    "model_type": "qwen3_5_text",
+                    "layer_types": ["linear_attention"],
+                },
             }
         )
     )
     (tmp_path / "preprocessor_config.json").write_text("{}")
-    monkeypatch.setattr(
-        "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
-        lambda _checkpoint, **_kwargs: [
-            "--model-loader-extra-config",
-            '{"enable_weights_track": false}',
-            "--mamba-cache-mode",
-            "align",
-            "--enable-prefix-caching",
-        ],
-    )
 
     command = _vllm_server_command(
         checkpoint_dir=tmp_path,
@@ -357,6 +352,38 @@ def test_vllm_server_command_requires_visual_context_budget(monkeypatch, tmp_pat
             image_width_mean=1280,
             image_height_mean=720,
         )
+
+
+def test_vllm_server_command_bounds_processor_pixels_for_small_images(monkeypatch, tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "vision_config": {},
+            }
+        )
+    )
+    (tmp_path / "preprocessor_config.json").write_text("{}")
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
+        lambda _checkpoint, **_kwargs: [],
+    )
+
+    command = _vllm_server_command(
+        checkpoint_dir=tmp_path,
+        port=8000,
+        model_name="served-model",
+        input_tokens=100,
+        output_tokens=80,
+        topology={"gpu_group_size": 1, "server_context_overhead_tokens": 256},
+        trust_remote_code=False,
+        image_batch_size=1,
+        image_width_mean=128,
+        image_height_mean=128,
+    )
+
+    processor = json.loads(command[command.index("--mm-processor-kwargs") + 1])
+    assert processor["min_pixels"] == processor["max_pixels"] == 128 * 128
 
 
 @pytest.mark.parametrize(
@@ -546,6 +573,10 @@ def test_multimodal_sweep_keeps_image_workloads_and_cache_paths_distinct(monkeyp
         lambda _checkpoint, **_kwargs: [],
     )
     monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._free_port",
+        lambda: 8000,
+    )
+    monkeypatch.setattr(
         "modelopt.torch.puzzletron.benchmarks.aiperf._wait_for_health",
         lambda *_args, **_kwargs: None,
     )
@@ -607,17 +638,18 @@ def test_multimodal_sweep_keeps_image_workloads_and_cache_paths_distinct(monkeyp
 
 def test_multimodal_sweep_rejects_an_empty_image_workload_axis(monkeypatch, tmp_path):
     checkpoint = tmp_path / "checkpoint"
+    artifact_dir = tmp_path / "artifacts"
     checkpoint.mkdir()
     (checkpoint / "config.json").write_text("{}")
     monkeypatch.setattr(
         "modelopt.torch.puzzletron.benchmarks.aiperf._prepare_vllm_checkpoint",
-        lambda *_args, **_kwargs: None,
+        lambda *_args, **_kwargs: pytest.fail("checkpoint preparation must follow validation"),
     )
 
     with pytest.raises(ValueError, match="must be non-empty"):
         run_aiperf_sweep(
             checkpoint,
-            artifact_dir=tmp_path / "artifacts",
+            artifact_dir=artifact_dir,
             concurrencies=(1,),
             input_tokens=100,
             output_tokens=80,
@@ -625,6 +657,7 @@ def test_multimodal_sweep_rejects_an_empty_image_workload_axis(monkeypatch, tmp_
             topology={"gpu_group_size": 1},
             image_batch_sizes=(),
         )
+    assert not artifact_dir.exists()
 
 
 def _offline_environment() -> dict[str, str]:

--- a/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
+++ b/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
@@ -35,6 +35,7 @@ from modelopt.torch.puzzletron.benchmarks.aiperf import (
     _server_max_model_len,
     _topology_vllm_args,
     _vllm_server_command,
+    run_aiperf_sweep,
 )
 
 # Subprocess environment and request sizing
@@ -261,7 +262,7 @@ def test_vllm_topology_args_enable_dp_and_expert_parallel_only_when_requested():
 def test_vllm_server_command_applies_explicit_remote_code_policy(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
-        lambda _checkpoint: [],
+        lambda _checkpoint, **_kwargs: [],
     )
 
     default_command = _vllm_server_command(
@@ -287,6 +288,77 @@ def test_vllm_server_command_applies_explicit_remote_code_policy(monkeypatch, tm
     assert "--trust-remote-code" in trusted_command
 
 
+def test_vllm_server_command_loads_full_multimodal_model(monkeypatch, tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["AnyModel"],
+                "base_architecture": "Qwen3_5ForConditionalGeneration",
+                "vision_config": {"model_type": "qwen3_5_vision"},
+            }
+        )
+    )
+    (tmp_path / "preprocessor_config.json").write_text("{}")
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
+        lambda _checkpoint, **_kwargs: [
+            "--model-loader-extra-config",
+            '{"enable_weights_track": false}',
+            "--mamba-cache-mode",
+            "align",
+            "--enable-prefix-caching",
+        ],
+    )
+
+    command = _vllm_server_command(
+        checkpoint_dir=tmp_path,
+        port=8000,
+        model_name="served-model",
+        input_tokens=100,
+        output_tokens=80,
+        topology={"gpu_group_size": 1, "server_context_overhead_tokens": 12288},
+        trust_remote_code=False,
+        image_batch_size=12,
+        image_width_mean=1280,
+        image_height_mean=720,
+    )
+
+    assert "--language-model-only" not in command
+    assert command[command.index("--max-model-len") + 1] == "12468"
+    assert json.loads(command[command.index("--limit-mm-per-prompt") + 1]) == {
+        "image": 12,
+        "video": 0,
+    }
+    assert json.loads(command[command.index("--mm-processor-kwargs") + 1]) == {
+        "max_num_frames": 1,
+        "max_pixels": 1280 * 720,
+        "min_pixels": 262144,
+    }
+    assert "--mamba-cache-mode" in command
+    assert "--enable-prefix-caching" in command
+
+
+def test_vllm_server_command_requires_visual_context_budget(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
+        lambda _checkpoint, **_kwargs: [],
+    )
+
+    with pytest.raises(ValueError, match="visual-token budget"):
+        _vllm_server_command(
+            checkpoint_dir=tmp_path,
+            port=8000,
+            model_name="served-model",
+            input_tokens=100,
+            output_tokens=80,
+            topology={"gpu_group_size": 1},
+            trust_remote_code=False,
+            image_batch_size=1,
+            image_width_mean=1280,
+            image_height_mean=720,
+        )
+
+
 @pytest.mark.parametrize(
     "extra_arg",
     [
@@ -304,7 +376,7 @@ def test_vllm_server_command_applies_explicit_remote_code_policy(monkeypatch, tm
 def test_vllm_server_command_rejects_remote_code_policy_override(monkeypatch, tmp_path, extra_arg):
     monkeypatch.setattr(
         "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
-        lambda _checkpoint: [],
+        lambda _checkpoint, **_kwargs: [],
     )
 
     with pytest.raises(ValueError, match="cannot set policy-owned vLLM options"):
@@ -338,6 +410,9 @@ def test_profile_command_maps_each_workload_answer_to_aiperf_cli(tmp_path):
         extra_inputs=None,
         use_server_token_count=True,
         gpu_telemetry=None,
+        image_batch_size=0,
+        image_width_mean=0,
+        image_height_mean=0,
     )
 
     assert command[command.index("--concurrency") + 1] == "8"
@@ -347,7 +422,72 @@ def test_profile_command_maps_each_workload_answer_to_aiperf_cli(tmp_path):
     assert command[command.index("--output-tokens-mean") + 1] == "128"
     assert command[command.index("--output-tokens-stddev") + 1] == "0"
     assert command[command.index("--tokenizer") + 1] == str(tmp_path / "tokenizer")
+    assert command[command.index("--image-batch-size") + 1] == "0"
+    assert "--image-width-mean" not in command
+    assert "--image-height-mean" not in command
     assert "--use-server-token-count" in command
+
+
+def test_profile_command_maps_multimodal_workload_to_aiperf_cli(tmp_path):
+    command = _profile_command(
+        executable=Path("/opt/aiperf/bin/aiperf"),
+        model_name="served-model",
+        port=8000,
+        endpoint_type="chat",
+        concurrency=1,
+        request_count=4,
+        input_tokens=100,
+        output_tokens=80,
+        tokenizer_dir=tmp_path / "tokenizer",
+        artifact_dir=tmp_path / "artifacts",
+        seed=7,
+        extra_inputs={"min_tokens": 80},
+        use_server_token_count=True,
+        gpu_telemetry=None,
+        image_batch_size=12,
+        image_width_mean=1280,
+        image_height_mean=720,
+    )
+
+    assert command[command.index("--image-batch-size") + 1] == "12"
+    assert command[command.index("--image-width-mean") + 1] == "1280"
+    assert command[command.index("--image-width-stddev") + 1] == "0"
+    assert command[command.index("--image-height-mean") + 1] == "720"
+    assert command[command.index("--image-height-stddev") + 1] == "0"
+
+
+@pytest.mark.parametrize(
+    ("endpoint_type", "image_batch_size", "image_width_mean", "image_height_mean", "match"),
+    [
+        ("completions", 1, 1280, 720, "require endpoint_type='chat'"),
+        ("chat", -1, 0, 0, "must be nonnegative"),
+        ("chat", 1, 0, 720, "require positive"),
+        ("chat", 0, 1280, 720, "require image_batch_size > 0"),
+    ],
+)
+def test_profile_command_rejects_invalid_multimodal_workloads(
+    tmp_path, endpoint_type, image_batch_size, image_width_mean, image_height_mean, match
+):
+    with pytest.raises(ValueError, match=match):
+        _profile_command(
+            executable=Path("/opt/aiperf/bin/aiperf"),
+            model_name="served-model",
+            port=8000,
+            endpoint_type=endpoint_type,
+            concurrency=1,
+            request_count=1,
+            input_tokens=100,
+            output_tokens=80,
+            tokenizer_dir=tmp_path / "tokenizer",
+            artifact_dir=tmp_path / "artifacts",
+            seed=7,
+            extra_inputs=None,
+            use_server_token_count=True,
+            gpu_telemetry=None,
+            image_batch_size=image_batch_size,
+            image_width_mean=image_width_mean,
+            image_height_mean=image_height_mean,
+        )
 
 
 def test_parse_export_preserves_interactivity_and_energy_metrics(tmp_path):
@@ -367,6 +507,9 @@ def test_parse_export_preserves_interactivity_and_energy_metrics(tmp_path):
                 "total_gpu_energy": {"avg": 4500.0},
                 "output_tokens_per_joule": {"avg": 64.0},
                 "energy_per_user": {"avg": 70.0},
+                "num_images": {"avg": 12.0},
+                "image_throughput": {"avg": 24.0},
+                "image_latency": {"avg": 40.0, "p95": 50.0, "p99": 60.0},
                 "error_request_count": {"avg": 0.0},
             }
         )
@@ -380,6 +523,108 @@ def test_parse_export_preserves_interactivity_and_energy_metrics(tmp_path):
     assert metrics["total_gpu_power_w"] == 900.0
     assert metrics["total_gpu_energy_j"] == 4500.0
     assert metrics["output_tokens_per_joule"] == 64.0
+    assert metrics["num_images"] == 12.0
+    assert metrics["image_throughput"] == 24.0
+    assert metrics["image_latency_p95_ms"] == 50.0
+
+
+def test_multimodal_sweep_keeps_image_workloads_and_cache_paths_distinct(monkeypatch, tmp_path):
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["AnyModel"],
+                "base_architecture": "Qwen3_5ForConditionalGeneration",
+                "vision_config": {"model_type": "qwen3_5_vision"},
+            }
+        )
+    )
+    (checkpoint / "preprocessor_config.json").write_text("{}")
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._descriptor_vllm_args",
+        lambda _checkpoint, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._wait_for_health",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._stop_process_group",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf.subprocess.Popen",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+
+    def fake_run(command, **_kwargs):
+        artifact_dir = Path(command[command.index("--artifact-dir") + 1])
+        image_batch_size = int(command[command.index("--image-batch-size") + 1])
+        (artifact_dir / "profile_export_aiperf.json").write_text(
+            json.dumps(
+                {
+                    "input_sequence_length": {"avg": 100.0},
+                    "output_sequence_length": {"avg": 80.0},
+                    "num_images": {"avg": float(image_batch_size)},
+                    "image_throughput": {"avg": float(image_batch_size)},
+                    "error_request_count": {"avg": 0.0},
+                }
+            )
+        )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf.subprocess.run",
+        fake_run,
+    )
+
+    results = run_aiperf_sweep(
+        checkpoint,
+        artifact_dir=tmp_path / "artifacts",
+        concurrencies=(1,),
+        input_tokens=100,
+        output_tokens=80,
+        gpu_ids="0",
+        topology={"gpu_group_size": 1, "server_context_overhead_tokens": 16384},
+        request_counts={1: 1},
+        executable=Path("/opt/aiperf/bin/aiperf"),
+        endpoint_type="chat",
+        image_batch_sizes=(1, 6, 12),
+        image_width_mean=1280,
+        image_height_mean=720,
+        gpu_telemetry=None,
+    )
+
+    assert [result.workload["image_batch_size"] for result in results] == [1, 6, 12]
+    assert len({result.workload_id for result in results}) == 3
+    assert len({result.cache_identity for result in results}) == 3
+    assert all(
+        f"images_{result.workload['image_batch_size']}" in result.raw_artifacts["profile"]
+        for result in results
+    )
+
+
+def test_multimodal_sweep_rejects_an_empty_image_workload_axis(monkeypatch, tmp_path):
+    checkpoint = tmp_path / "checkpoint"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text("{}")
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.benchmarks.aiperf._prepare_vllm_checkpoint",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ValueError, match="must be non-empty"):
+        run_aiperf_sweep(
+            checkpoint,
+            artifact_dir=tmp_path / "artifacts",
+            concurrencies=(1,),
+            input_tokens=100,
+            output_tokens=80,
+            gpu_ids="0",
+            topology={"gpu_group_size": 1},
+            image_batch_sizes=(),
+        )
 
 
 def _offline_environment() -> dict[str, str]:

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -462,19 +462,28 @@ def test_global_kd_checkpoint_copies_vlm_assets_before_completion(tmp_path, monk
     assert (checkpoint / "saving_completed").is_file()
 
 
-def test_hf_auxiliary_assets_reject_symlinks_before_copying(tmp_path):
+@pytest.mark.parametrize("symlink_location", ["source", "destination"])
+def test_hf_auxiliary_assets_reject_symlinks_before_copying(tmp_path, symlink_location):
     source = tmp_path / "source"
     consolidated = tmp_path / "consolidated"
     source.mkdir()
     consolidated.mkdir()
     (source / "preprocessor_config.json").write_text("{}")
-    (source / "target.json").write_text("{}")
-    (source / "tokenizer_config.json").symlink_to(source / "target.json")
+    if symlink_location == "source":
+        (source / "target.json").write_text("{}")
+        (source / "tokenizer_config.json").symlink_to(source / "target.json")
+    else:
+        templates = source / "chat_templates"
+        templates.mkdir()
+        (templates / "vision.jinja").write_text("template")
+        destination = tmp_path / "destination"
+        destination.mkdir()
+        (consolidated / "chat_templates").symlink_to(destination)
 
-    with pytest.raises(ValueError, match="regular file"):
+    with pytest.raises(ValueError, match="symbolic link|regular file"):
         local_kd_recipe._copy_hf_auxiliary_assets(source, consolidated)
 
-    assert list(consolidated.iterdir()) == []
+    assert not (consolidated / "preprocessor_config.json").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -85,6 +85,31 @@ def test_global_kd_checkpoint_context_uses_active_anymodel_block_configs(
     assert observed[0][0].to_dict() == {"subblock_configs": []}
 
 
+def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
+    from nemo_automodel.components.checkpoint import stateful_wrappers
+
+    from modelopt.torch.puzzletron.distillation import global_kd_recipe
+
+    failure = [
+        "The option indicates that model state_dict is required to save or load, "
+        "but model state_dict is empty.rank = dist.get_rank()=0."
+    ]
+
+    def failed_dcp_state(*args, **kwargs):
+        raise RuntimeError(failure[0])
+
+    monkeypatch.setattr(stateful_wrappers, "get_model_state_dict", failed_dcp_state)
+    global_kd_recipe.install_unsharded_checkpoint_state_dict_support()
+
+    model = torch.nn.Linear(2, 3)
+    state_dict = stateful_wrappers.get_model_state_dict(model)
+
+    assert set(state_dict) == {"bias", "weight"}
+    failure[0] = "unrelated checkpoint failure"
+    with pytest.raises(RuntimeError, match="unrelated checkpoint failure"):
+        stateful_wrappers.get_model_state_dict(model)
+
+
 def test_distillation_overfit_stage_disables_mtp_objectives_by_default(monkeypatch, tmp_path):
     """Nano-like checkpoints without MTP must not enable MTP loss implicitly."""
     from modelopt.torch.puzzletron.manifest import StageManifest

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -100,20 +100,9 @@ def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
     global_kd_recipe.install_unsharded_checkpoint_state_dict_support()
 
     class DynamicModel(torch.nn.Linear):
-        reset = False
-
-        @contextmanager
-        def reset_dynamic_attributes(self):
-            self.reset = True
-            try:
-                yield
-            finally:
-                self.reset = False
-
         def state_dict(self):
             return {}
 
-    monkeypatch.setattr(global_kd_recipe, "DynamicModule", DynamicModel)
     model = DynamicModel(2, 3)
     state_dict = stateful_wrappers.get_model_state_dict(model)
 

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -362,6 +362,73 @@ def test_global_kd_preserves_physical_dp_mesh_when_ep_overlays_shards(tmp_path, 
     assert recipe["distributed"]["dp_size"] == 4
 
 
+@pytest.mark.parametrize(
+    "checkpoint_config",
+    [
+        {"block_configs": [{"subblock_configs": []}]},
+        {"text_config": {"block_configs": [{"subblock_configs": []}]}},
+    ],
+)
+def test_global_kd_checkpoint_copies_vlm_assets_before_completion(
+    tmp_path, monkeypatch, checkpoint_config
+):
+    from modelopt.torch.puzzletron.distillation.global_kd_recipe import _WeightedObjectiveMixin
+
+    source = tmp_path / "student"
+    source.mkdir()
+    (source / "preprocessor_config.json").write_text('{"source": true}')
+    (source / "processor_config.json").write_text('{"processor": true}')
+    (source / "model.safetensors").write_bytes(b"source weights")
+
+    class BaseRecipe:
+        def save_checkpoint(
+            self,
+            epoch,
+            step,
+            train_loss,
+            val_loss,
+            best_metric_key="default",
+        ):
+            del train_loss, val_loss, best_metric_key
+            checkpoint = tmp_path / f"epoch_{epoch}_step_{step}"
+            consolidated = checkpoint / "model/consolidated"
+            consolidated.mkdir(parents=True)
+            (consolidated / "config.json").write_text(json.dumps(checkpoint_config))
+            (consolidated / "model.safetensors").write_bytes(b"consolidated weights")
+            return "saved"
+
+    class Recipe(_WeightedObjectiveMixin, BaseRecipe):
+        pass
+
+    recipe = Recipe()
+    recipe.checkpointer = type(
+        "Checkpointer",
+        (),
+        {"config": type("Config", (), {"checkpoint_dir": tmp_path})()},
+    )()
+    recipe.dist_env = type("DistEnv", (), {"is_main": True})()
+    recipe.cfg = {
+        "model": {
+            "pretrained_model_name_or_path": str(source),
+            "trust_remote_code": True,
+        }
+    }
+    monkeypatch.setattr(
+        "modelopt.torch.puzzletron.utils.vllm_adapter.refresh_realized_checkpoint_config",
+        lambda *args, **kwargs: None,
+    )
+
+    assert recipe.save_checkpoint(2, 17, 0.5, {"lm_loss": 0.25}) == "saved"
+
+    checkpoint = tmp_path / "epoch_2_step_17"
+    consolidated = checkpoint / "model/consolidated"
+    assert json.loads((consolidated / "preprocessor_config.json").read_text()) == {"source": True}
+    assert json.loads((consolidated / "processor_config.json").read_text()) == {"processor": True}
+    assert json.loads((consolidated / "config.json").read_text()) == checkpoint_config
+    assert (consolidated / "model.safetensors").read_bytes() == b"consolidated weights"
+    assert (checkpoint / "saving_completed").is_file()
+
+
 def test_global_kd_checkpoint_publication_failure_reaches_all_ranks(tmp_path, monkeypatch):
     """Preserve the failing rank's exception while every rank completes collectives."""
 

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -96,13 +96,11 @@ def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
         raise RuntimeError(failure[0])
 
     monkeypatch.setattr(stateful_wrappers, "get_model_state_dict", failed_dcp_state)
+    monkeypatch.setattr(stateful_wrappers, "set_model_state_dict", failed_dcp_state)
     global_kd_recipe.install_unsharded_checkpoint_state_dict_support()
 
-    class DynamicModel:
+    class DynamicModel(torch.nn.Linear):
         reset = False
-
-        def modules(self):
-            return [self]
 
         @contextmanager
         def reset_dynamic_attributes(self):
@@ -113,13 +111,16 @@ def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
                 self.reset = False
 
         def state_dict(self):
-            return {"weight": torch.ones(1)} if self.reset else {}
+            return {}
 
     monkeypatch.setattr(global_kd_recipe, "DynamicModule", DynamicModel)
-    model = DynamicModel()
+    model = DynamicModel(2, 3)
     state_dict = stateful_wrappers.get_model_state_dict(model)
 
-    assert set(state_dict) == {"weight"}
+    assert set(state_dict) == {"bias", "weight"}
+    replacement = {name: torch.ones_like(value) for name, value in state_dict.items()}
+    stateful_wrappers.set_model_state_dict(model, replacement)
+    assert all(torch.equal(value, replacement[name]) for name, value in model.named_parameters())
     failure[0] = "unrelated checkpoint failure"
     with pytest.raises(RuntimeError, match="unrelated checkpoint failure"):
         stateful_wrappers.get_model_state_dict(model)

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -22,18 +22,20 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from nemo_automodel.components.checkpoint import stateful_wrappers
 
+from modelopt.torch.puzzletron.distillation import global_kd_recipe
 from modelopt.torch.puzzletron.distillation.global_automodel import (
     GlobalKDConfig,
     GlobalKDResult,
     build_automodel_global_kd_recipe,
     build_global_kd_config,
 )
+from modelopt.torch.puzzletron.distillation.global_kd_recipe import _WeightedObjectiveMixin
+from modelopt.torch.puzzletron.plugins.automodel import local_kd_recipe
 
 
 def test_global_kd_pp_shape_reset_uses_pipeline_activation_dtype(monkeypatch):
-    from modelopt.torch.puzzletron.distillation import global_kd_recipe
-
     calls = []
     monkeypatch.setattr(
         global_kd_recipe,
@@ -59,7 +61,6 @@ def test_global_kd_checkpoint_context_uses_active_anymodel_block_configs(
 ):
     """Checkpoint conversion keeps the student’s per-layer MoE geometry."""
     from modelopt.torch.puzzletron.anymodel.automodel import AutoModelDescriptorFactory
-    from modelopt.torch.puzzletron.distillation import global_kd_recipe
 
     observed = []
 
@@ -86,10 +87,6 @@ def test_global_kd_checkpoint_context_uses_active_anymodel_block_configs(
 
 
 def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
-    from nemo_automodel.components.checkpoint import stateful_wrappers
-
-    from modelopt.torch.puzzletron.distillation import global_kd_recipe
-
     failure = [
         "The option indicates that model state_dict is required to save or load, "
         "but model state_dict is empty.rank = dist.get_rank()=0."
@@ -101,10 +98,28 @@ def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
     monkeypatch.setattr(stateful_wrappers, "get_model_state_dict", failed_dcp_state)
     global_kd_recipe.install_unsharded_checkpoint_state_dict_support()
 
-    model = torch.nn.Linear(2, 3)
+    class DynamicModel:
+        reset = False
+
+        def modules(self):
+            return [self]
+
+        @contextmanager
+        def reset_dynamic_attributes(self):
+            self.reset = True
+            try:
+                yield
+            finally:
+                self.reset = False
+
+        def state_dict(self):
+            return {"weight": torch.ones(1)} if self.reset else {}
+
+    monkeypatch.setattr(global_kd_recipe, "DynamicModule", DynamicModel)
+    model = DynamicModel()
     state_dict = stateful_wrappers.get_model_state_dict(model)
 
-    assert set(state_dict) == {"bias", "weight"}
+    assert set(state_dict) == {"weight"}
     failure[0] = "unrelated checkpoint failure"
     with pytest.raises(RuntimeError, match="unrelated checkpoint failure"):
         stateful_wrappers.get_model_state_dict(model)
@@ -388,14 +403,13 @@ def test_global_kd_preserves_physical_dp_mesh_when_ep_overlays_shards(tmp_path, 
 
 
 def test_global_kd_checkpoint_copies_vlm_assets_before_completion(tmp_path, monkeypatch):
-    from modelopt.torch.puzzletron.distillation.global_kd_recipe import _WeightedObjectiveMixin
-
     checkpoint_config = {"text_config": {"block_configs": [{"subblock_configs": []}]}}
     source = tmp_path / "student"
     source.mkdir()
     (source / "preprocessor_config.json").write_text('{"source": true}')
     (source / "processor_config.json").write_text('{"processor": true}')
     (source / "model.safetensors").write_bytes(b"source weights")
+    (source / "modeling_untrusted.py").write_text("raise RuntimeError\n")
 
     class BaseRecipe:
         def save_checkpoint(
@@ -443,14 +457,49 @@ def test_global_kd_checkpoint_copies_vlm_assets_before_completion(tmp_path, monk
     assert json.loads((consolidated / "processor_config.json").read_text()) == {"processor": True}
     assert json.loads((consolidated / "config.json").read_text()) == checkpoint_config
     assert (consolidated / "model.safetensors").read_bytes() == b"consolidated weights"
+    assert not (consolidated / "modeling_untrusted.py").exists()
     assert (checkpoint / "saving_completed").is_file()
+
+
+def test_hf_auxiliary_assets_reject_symlinks_before_copying(tmp_path):
+    source = tmp_path / "source"
+    consolidated = tmp_path / "consolidated"
+    source.mkdir()
+    consolidated.mkdir()
+    (source / "preprocessor_config.json").write_text("{}")
+    (source / "target.json").write_text("{}")
+    (source / "tokenizer_config.json").symlink_to(source / "target.json")
+
+    with pytest.raises(ValueError, match="regular file"):
+        local_kd_recipe._copy_hf_auxiliary_assets(source, consolidated)
+
+    assert list(consolidated.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("file_limit", "total_limit", "expected"),
+    [(1, 10, "per-file"), (10, 3, "aggregate")],
+)
+def test_hf_auxiliary_assets_enforce_size_limits_before_copying(
+    tmp_path, monkeypatch, file_limit, total_limit, expected
+):
+    source = tmp_path / "source"
+    consolidated = tmp_path / "consolidated"
+    source.mkdir()
+    consolidated.mkdir()
+    (source / "preprocessor_config.json").write_bytes(b"{}")
+    (source / "processor_config.json").write_bytes(b"{}")
+    monkeypatch.setattr(local_kd_recipe, "_HF_AUXILIARY_FILE_SIZE_LIMIT", file_limit)
+    monkeypatch.setattr(local_kd_recipe, "_HF_AUXILIARY_TOTAL_SIZE_LIMIT", total_limit)
+
+    with pytest.raises(ValueError, match=expected):
+        local_kd_recipe._copy_hf_auxiliary_assets(source, consolidated)
+
+    assert list(consolidated.iterdir()) == []
 
 
 def test_global_kd_checkpoint_publication_failure_reaches_all_ranks(tmp_path, monkeypatch):
     """Preserve the failing rank's exception while every rank completes collectives."""
-
-    # Import the dynamic mixin at test runtime to preserve lightweight module collection.
-    from modelopt.torch.puzzletron.distillation.global_kd_recipe import _WeightedObjectiveMixin
 
     publication = {"error": None, "broadcasts": 0}
     parent_save_errors = [None, None]
@@ -568,10 +617,6 @@ def test_global_kd_checkpoint_publication_failure_reaches_all_ranks(tmp_path, mo
 
 
 def test_global_kd_text_optimizer_excludes_inactive_modality_branches():
-    import torch
-
-    from modelopt.torch.puzzletron.distillation.global_kd_recipe import _WeightedObjectiveMixin
-
     class ToyModel(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from nemo_automodel.components.checkpoint import stateful_wrappers
+from nemo_automodel.recipes.base_recipe import BaseRecipe as AutoModelBaseRecipe
 
 from modelopt.torch.puzzletron.distillation import global_kd_recipe
 from modelopt.torch.puzzletron.distillation.global_automodel import (
@@ -84,41 +84,6 @@ def test_global_kd_checkpoint_context_uses_active_anymodel_block_configs(
 
     assert len(observed) == 1
     assert observed[0][0].to_dict() == {"subblock_configs": []}
-
-
-def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
-    failure = [
-        "The option indicates that model state_dict is required to save or load, "
-        "but model state_dict is empty.rank = dist.get_rank()=0."
-    ]
-
-    original_parameters = []
-
-    def failed_dcp_state(model, *args, **kwargs):
-        if not original_parameters:
-            original_parameters.extend(model._parameters.values())
-            model._parameters.clear()
-        raise RuntimeError(failure[0])
-
-    monkeypatch.setattr(stateful_wrappers, "get_model_state_dict", failed_dcp_state)
-    monkeypatch.setattr(stateful_wrappers, "set_model_state_dict", failed_dcp_state)
-    global_kd_recipe.install_unsharded_checkpoint_state_dict_support()
-
-    class DynamicModel(torch.nn.Linear):
-        def state_dict(self):
-            return {}
-
-    model = DynamicModel(2, 3)
-    state_dict = stateful_wrappers.get_model_state_dict(model)
-
-    assert set(state_dict) == {"bias", "weight"}
-    model._parameters.update(zip(("weight", "bias"), original_parameters))
-    replacement = {name: torch.ones_like(value) for name, value in state_dict.items()}
-    stateful_wrappers.set_model_state_dict(model, replacement)
-    assert all(torch.equal(value, replacement[name]) for name, value in model.named_parameters())
-    failure[0] = "unrelated checkpoint failure"
-    with pytest.raises(RuntimeError, match="unrelated checkpoint failure"):
-        stateful_wrappers.get_model_state_dict(model)
 
 
 def test_distillation_overfit_stage_disables_mtp_objectives_by_default(monkeypatch, tmp_path):
@@ -644,6 +609,21 @@ def test_global_kd_text_optimizer_excludes_inactive_modality_branches():
     assert all(id(parameter) not in optimized for parameter in model.mm_projector.parameters())
     assert all(id(parameter) in optimized for parameter in model.language.parameters())
     assert all(id(parameter) in optimized for parameter in model.mtp.parameters())
+
+
+def test_global_kd_does_not_checkpoint_flash_kld_helper_as_model():
+    class Recipe(_WeightedObjectiveMixin, AutoModelBaseRecipe):
+        def __init__(self):
+            self.model_parts = [torch.nn.Linear(2, 2)]
+            self.loss_fn = SimpleNamespace(chunk_size=512)
+            self.main_kd_loss_fn = SimpleNamespace(chunk_size=0, temperature=2.0)
+            self.mtp_kd_loss_fn = SimpleNamespace(chunk_size=0, temperature=2.0)
+
+    recipe = Recipe()
+    engine = recipe._flash_kld_engine("mtp")
+
+    assert recipe._flash_kld_engine("mtp") is engine
+    assert recipe.__dict__["__state_tracked"] == {"model_parts"}
 
 
 def test_global_kd_quarantines_unmarked_checkpoint_even_with_dcp_metadata(tmp_path):

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -422,17 +422,26 @@ def test_global_kd_checkpoint_copies_vlm_assets_before_completion(tmp_path, monk
     assert (checkpoint / "saving_completed").is_file()
 
 
-@pytest.mark.parametrize("symlink_location", ["source", "destination"])
+@pytest.mark.parametrize(
+    "symlink_location",
+    ["source_directory", "source_asset", "destination_directory", "destination_asset_directory"],
+)
 def test_hf_auxiliary_assets_reject_symlinks_before_copying(tmp_path, symlink_location):
     source = tmp_path / "source"
     consolidated = tmp_path / "consolidated"
-    source.mkdir()
-    consolidated.mkdir()
-    (source / "preprocessor_config.json").write_text("{}")
-    if symlink_location == "source":
+    if symlink_location == "source_directory":
+        source.symlink_to(tmp_path / "missing-source", target_is_directory=True)
+    else:
+        source.mkdir()
+        (source / "preprocessor_config.json").write_text("{}")
+    if symlink_location == "destination_directory":
+        consolidated.symlink_to(tmp_path / "missing-destination", target_is_directory=True)
+    else:
+        consolidated.mkdir()
+    if symlink_location == "source_asset":
         (source / "target.json").write_text("{}")
         (source / "tokenizer_config.json").symlink_to(source / "target.json")
-    else:
+    elif symlink_location == "destination_asset_directory":
         templates = source / "chat_templates"
         templates.mkdir()
         (templates / "vision.jinja").write_text("template")

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -92,7 +92,12 @@ def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
         "but model state_dict is empty.rank = dist.get_rank()=0."
     ]
 
-    def failed_dcp_state(*args, **kwargs):
+    original_parameters = []
+
+    def failed_dcp_state(model, *args, **kwargs):
+        if not original_parameters:
+            original_parameters.extend(model._parameters.values())
+            model._parameters.clear()
         raise RuntimeError(failure[0])
 
     monkeypatch.setattr(stateful_wrappers, "get_model_state_dict", failed_dcp_state)
@@ -107,6 +112,7 @@ def test_unsharded_checkpoint_falls_back_only_for_empty_dcp_state(monkeypatch):
     state_dict = stateful_wrappers.get_model_state_dict(model)
 
     assert set(state_dict) == {"bias", "weight"}
+    model._parameters.update(zip(("weight", "bias"), original_parameters))
     replacement = {name: torch.ones_like(value) for name, value in state_dict.items()}
     stateful_wrappers.set_model_state_dict(model, replacement)
     assert all(torch.equal(value, replacement[name]) for name, value in model.named_parameters())

--- a/tests/unit/torch/puzzletron/test_global_kd_canonical.py
+++ b/tests/unit/torch/puzzletron/test_global_kd_canonical.py
@@ -362,18 +362,10 @@ def test_global_kd_preserves_physical_dp_mesh_when_ep_overlays_shards(tmp_path, 
     assert recipe["distributed"]["dp_size"] == 4
 
 
-@pytest.mark.parametrize(
-    "checkpoint_config",
-    [
-        {"block_configs": [{"subblock_configs": []}]},
-        {"text_config": {"block_configs": [{"subblock_configs": []}]}},
-    ],
-)
-def test_global_kd_checkpoint_copies_vlm_assets_before_completion(
-    tmp_path, monkeypatch, checkpoint_config
-):
+def test_global_kd_checkpoint_copies_vlm_assets_before_completion(tmp_path, monkeypatch):
     from modelopt.torch.puzzletron.distillation.global_kd_recipe import _WeightedObjectiveMixin
 
+    checkpoint_config = {"text_config": {"block_configs": [{"subblock_configs": []}]}}
     source = tmp_path / "student"
     source.mkdir()
     (source / "preprocessor_config.json").write_text('{"source": true}')

--- a/tests/unit/torch/puzzletron/test_post_mip_filters.py
+++ b/tests/unit/torch/puzzletron/test_post_mip_filters.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import math
 
@@ -13,6 +25,7 @@ from modelopt.torch.puzzletron.post_mip.records import (
     CandidateRevision,
     NodeObservation,
 )
+from modelopt.torch.puzzletron.post_mip.reporting import render_aiperf_report
 
 
 def _ledger(tmp_path, metrics_by_revision):
@@ -46,6 +59,13 @@ def _sweep(*values):
     }
 
 
+def _vlm_sweep(*values):
+    return {
+        f"images_12.concurrency_{concurrency}.image_throughput": value
+        for concurrency, value in values
+    }
+
+
 def test_individual_best_ranks_each_model_by_its_best_concurrency(tmp_path):
     ledger = _ledger(
         tmp_path,
@@ -75,6 +95,60 @@ def test_individual_best_ranks_each_model_by_its_best_concurrency(tmp_path):
         "revision-b": 30.0,
         "revision-c": 15.0,
     }
+
+
+def test_multimodal_sweep_selection_resolves_one_image_workload(tmp_path):
+    ledger = _ledger(
+        tmp_path,
+        {
+            "revision-a": _vlm_sweep((1, 20.0), (2, 25.0)),
+            "revision-b": _vlm_sweep((1, 30.0), (2, 15.0)),
+        },
+    )
+
+    selected, excluded, scores = apply_filter(
+        ledger,
+        ("revision-a", "revision-b"),
+        {
+            "mode": "top_k",
+            "metric": "serving.images_12.image_throughput",
+            "direction": "maximize",
+            "top_k": 1,
+            "best_selection_mode": "individual_best",
+        },
+    )
+
+    assert selected == ("revision-b",)
+    assert excluded == {"revision-a": "outside top_k"}
+    assert scores == {"revision-a": 25.0, "revision-b": 30.0}
+
+
+def test_aiperf_report_renders_multimodal_namespaced_metrics():
+    html = render_aiperf_report(
+        "vlm-serving",
+        {
+            "status": "completed",
+            "observations": [
+                {
+                    "label": "candidate-a",
+                    "status": "success",
+                    "selected_by": ["fastest_vlm"],
+                    "metrics": {
+                        "images_12.concurrency_1.request_throughput": 2.0,
+                        "images_12.concurrency_1.image_throughput": 24.0,
+                        "images_12.concurrency_1.output_token_throughput": 128.0,
+                        "images_12.concurrency_1.ttft_mean_ms": 10.0,
+                        "images_12.concurrency_1.tpot_mean_ms": 3.0,
+                    },
+                }
+            ],
+        },
+    )
+
+    assert "images 12 / concurrency 1" in html
+    assert "<td>24</td>" in html
+    assert "<td>128</td>" in html
+    assert "Selected by Fastest" in html
 
 
 def test_best_per_concurrency_unions_top_k_from_each_point(tmp_path):

--- a/tests/unit/torch/puzzletron/test_post_mip_runner.py
+++ b/tests/unit/torch/puzzletron/test_post_mip_runner.py
@@ -197,7 +197,14 @@ def test_aiperf_consumes_request_count_without_forwarding_setup_only_keys(
     def fake_run_aiperf_sweep(checkpoint, **settings):
         captured["checkpoint"] = checkpoint
         captured.update(settings)
-        return [SimpleNamespace(concurrency=8, metrics={}, raw_artifacts={})]
+        return [
+            SimpleNamespace(
+                concurrency=8,
+                workload={"image_batch_size": 12},
+                metrics={},
+                raw_artifacts={},
+            )
+        ]
 
     monkeypatch.setattr(
         "modelopt.torch.puzzletron.benchmarks.run_aiperf_sweep",
@@ -217,6 +224,9 @@ def test_aiperf_consumes_request_count_without_forwarding_setup_only_keys(
                 "allow_aiperf_v011_online_tokenizer_resolution": True,
                 "input_tokens": 1024,
                 "output_tokens": 128,
+                "image_batch_sizes": [1, 6, 12],
+                "image_width_mean": 1280,
+                "image_height_mean": 720,
                 "topology": {"gpu_group_size": 1},
             }
         },
@@ -238,6 +248,9 @@ def test_aiperf_consumes_request_count_without_forwarding_setup_only_keys(
     assert captured["request_counts"] == {8: 23}
     assert captured["trust_remote_code"] is True
     assert captured["allow_aiperf_v011_online_tokenizer_resolution"] is True
+    assert captured["image_batch_sizes"] == [1, 6, 12]
+    assert captured["image_width_mean"] == 1280
+    assert captured["image_height_mean"] == 720
     assert "request_count" not in captured
     assert "minimum_request_count" not in captured
     assert "requests_per_concurrency" not in captured

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_vlm_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_vlm_smoke_plan.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU plan contracts for the complete Qwen 3.5 0.8B VLM smoke."""
+
+from itertools import pairwise
+from pathlib import Path
+
+import yaml
+
+from puzzletron_orchestrator.compiler import (
+    compile_campaign_plan,
+    load_execution_config,
+    load_runner_config,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+RUN_PATH = (
+    REPOSITORY_ROOT
+    / "examples/puzzletron/configs/families/qwen3_5/qwen3p5_0p8b/runs/full_vlm_smoke.yaml"
+)
+ORCHESTRATION_ROOT = REPOSITORY_ROOT / "examples/puzzletron/configs/orchestration/qwen3p5_0p8b"
+RUNNER_PATH = ORCHESTRATION_ROOT / "runner.slurm.yaml"
+EXECUTION_PATH = ORCHESTRATION_ROOT / "execution.full_vlm_smoke.yaml"
+
+
+def _compile_plan(monkeypatch, tmp_path: Path, *, dataset_revision="fixture-revision"):
+    monkeypatch.setenv("PUZZLETRON_RUN_ROOT", str(tmp_path / "results"))
+    monkeypatch.setenv("PUZZLETRON_DATASET_PATH", str(tmp_path / "dataset"))
+    if dataset_revision is None:
+        monkeypatch.delenv("PUZZLETRON_DATASET_REVISION", raising=False)
+    else:
+        monkeypatch.setenv("PUZZLETRON_DATASET_REVISION", dataset_revision)
+    return compile_campaign_plan(
+        experiment_config_path=RUN_PATH,
+        runner=load_runner_config(RUNNER_PATH),
+        execution=load_execution_config(EXECUTION_PATH),
+        stage_filter="full",
+    )
+
+
+def test_qwen3p5_0p8b_full_vlm_smoke_inherits_the_vlm_mip_route(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    run_config = yaml.safe_load(RUN_PATH.read_text())
+    config = _compile_plan(monkeypatch, tmp_path).experiment_config
+
+    assert run_config["defaults"] == ["mip_vlm_smoke", "_self_"]
+    assert config["model"]["revision"] == "2fc06364715b967f1860aea9cf38778875588b17"
+    assert config["data"]["modality"] == "multimodal"
+    assert config["data"]["layout"] == "padded_varlen"
+    assert config["data"]["revision"] == "fixture-revision"
+    assert config["tokenize_data"] == {
+        "enabled": False,
+        "workers": 16,
+        "tokenize_batch_size": 64,
+        "content_field": "messages",
+        "caches": [],
+    }
+    assert config["mip"]["runs"]["params-90"]["search_space"] == {
+        "depth": [0],
+        "embedding": [1024],
+        "axes_default": "teacher",
+        "axes": {"ffn.intermediate_size": "all"},
+    }
+    assert config["sort"]["deferred_axes"] == [
+        "kv_groups",
+        "q_heads_per_group",
+        "gdn_key_groups",
+        "gdn_value_heads_per_group",
+        "gdn_key_head_dim",
+        "gdn_value_head_dim",
+    ]
+
+
+def test_qwen3p5_0p8b_full_vlm_smoke_defaults_to_the_tested_dataset_snapshot(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = _compile_plan(monkeypatch, tmp_path, dataset_revision=None).experiment_config
+
+    assert config["data"]["revision"] == "51f4f4d219315c3283950994d4eb3d7fc30aa87b"
+
+
+def test_qwen3p5_0p8b_full_vlm_smoke_compiles_the_one_gpu_lifecycle(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plan = _compile_plan(monkeypatch, tmp_path)
+    stage_ids = tuple(stage.stage_id for stage in plan.stages)
+    post_stage_ids = tuple(stage_id for stage_id in stage_ids if stage_id.startswith("post."))
+
+    assert "tokenize_data" not in stage_ids
+    assert post_stage_ids == (
+        "post.params-90.image_eval",
+        "post.params-90.best_vlm_loss",
+        "post.params-90.materialized",
+        "post.params-90.vlm_serving",
+        "post.params-90.fastest_vlm",
+        "post.params-90.short_vlm_kd",
+        "post.params-90.final_image_eval",
+        "post.params-90.best",
+    )
+    post_nodes = tuple(stage for stage in plan.stages if stage.stage_id.startswith("post."))
+    assert post_nodes[0].parents == ("mip",)
+    for parent, node in pairwise(post_nodes):
+        assert node.parents == (parent.stage_id,)
+    assert stage_ids[-1] == "post.params-90.best"
+    assert all(stage.total_gpus == 1 for stage in plan.stages)
+
+
+def test_qwen3p5_0p8b_full_vlm_smoke_bounds_work_and_declares_vlm_kd(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config = _compile_plan(monkeypatch, tmp_path).experiment_config
+    nodes = config["post_mip"]["flows"]["params-90"]["nodes"]
+
+    assert nodes["image_eval"]["config"] == {"eval_samples": 2, "block_size": 512}
+    assert config["mip"]["runs"]["params-90"]["solver"]["num_solutions"] == 1
+    assert config["mip"]["runs"]["params-90"]["homogeneous"]["keep"] == 5
+    assert nodes["best_vlm_loss"]["top_k"] == 2
+    assert nodes["vlm_serving"]["input"] == "materialized"
+    assert nodes["fastest_vlm"] == {
+        "type": "filter",
+        "input": "vlm_serving",
+        "mode": "top_k",
+        "metric": "vlm_serving.images_12.concurrency_1.image_throughput",
+        "direction": "maximize",
+        "top_k": 1,
+    }
+    assert nodes["short_vlm_kd"]["input"] == "fastest_vlm"
+    assert nodes["short_vlm_kd"]["config"] == {
+        "max_steps": 2,
+        "global_batch_size": 1,
+        "local_batch_size": 1,
+        "checkpoint_every_steps": 2,
+    }
+    assert nodes["final_image_eval"]["config"] == {
+        "eval_samples": 2,
+        "block_size": 512,
+    }
+    assert nodes["best"]["top_k"] == 1
+    assert nodes["vlm_serving"]["config"]["endpoint_type"] == "chat"
+    assert nodes["vlm_serving"]["config"]["image_batch_sizes"] == [1, 6, 12]
+    assert nodes["vlm_serving"]["config"]["image_width_mean"] == 1280
+    assert nodes["vlm_serving"]["config"]["image_height_mean"] == 720
+    assert nodes["vlm_serving"]["config"]["concurrency"] == [1]
+    assert nodes["vlm_serving"]["config"]["request_count"] == 1
+    assert nodes["vlm_serving"]["config"]["topology"]["server_context_overhead_tokens"] == 16384
+    assert config["global_distillation"]["domain"] == "vlm"
+    assert config["global_distillation"]["freeze_policy"] == "train_all"

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_vlm_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_vlm_smoke_plan.py
@@ -51,47 +51,14 @@ def _compile_plan(monkeypatch, tmp_path: Path, *, dataset_revision="fixture-revi
     )
 
 
-def test_qwen3p5_0p8b_full_vlm_smoke_inherits_the_vlm_mip_route(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    run_config = yaml.safe_load(RUN_PATH.read_text())
-    config = _compile_plan(monkeypatch, tmp_path).experiment_config
-
-    assert run_config["defaults"] == ["mip_vlm_smoke", "_self_"]
-    assert config["model"]["revision"] == "2fc06364715b967f1860aea9cf38778875588b17"
-    assert config["data"]["modality"] == "multimodal"
-    assert config["data"]["layout"] == "padded_varlen"
-    assert config["data"]["revision"] == "fixture-revision"
-    assert config["tokenize_data"] == {
-        "enabled": False,
-        "workers": 16,
-        "tokenize_batch_size": 64,
-        "content_field": "messages",
-        "caches": [],
-    }
-    assert config["mip"]["runs"]["params-90"]["search_space"] == {
-        "depth": [0],
-        "embedding": [1024],
-        "axes_default": "teacher",
-        "axes": {"ffn.intermediate_size": "all"},
-    }
-    assert config["sort"]["deferred_axes"] == [
-        "kv_groups",
-        "q_heads_per_group",
-        "gdn_key_groups",
-        "gdn_value_heads_per_group",
-        "gdn_key_head_dim",
-        "gdn_value_head_dim",
-    ]
-
-
 def test_qwen3p5_0p8b_full_vlm_smoke_defaults_to_the_tested_dataset_snapshot(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
+    run_config = yaml.safe_load(RUN_PATH.read_text())
     config = _compile_plan(monkeypatch, tmp_path, dataset_revision=None).experiment_config
 
+    assert run_config["defaults"] == ["mip_vlm_smoke", "_self_"]
     assert config["data"]["revision"] == "51f4f4d219315c3283950994d4eb3d7fc30aa87b"
 
 


### PR DESCRIPTION
### What does this PR do?

Type of change: new example

Adds a bounded end-to-end pruning smoke for the public Qwen 3.5 0.8B vision-language checkpoint. It uses real image conversations throughout candidate evaluation and distillation, then verifies that the selected physical checkpoint can be served and evaluated again.

- Evaluates and materializes the strongest pruning candidates, measures them with 1-, 6-, and 12-image chat requests, and selects one using measured 12-image throughput.
- Runs a short vision-language distillation step and a final image-and-text evaluation.
- Preserves processor assets in distilled checkpoints and handles one-GPU checkpoint publication without weakening distributed checkpoint behavior.
- Validates image workload limits before creating artifacts, keeps multimodal caches distinct, and leaves existing text-only behavior unchanged.
- Explains that this small smoke checks workflow integration and resume behavior, not production quality or throughput.

### Usage

Follow `examples/puzzletron/docs/qwen3p5_0p8b_vlm_smoke.md` to prepare the pinned dataset, inspect the dry-run plan, launch the smoke, resume it, and verify the resulting evidence.

### Testing

Focused CPU tests cover descriptor routing, multimodal command validation, cache and artifact separation, post-MIP metrics, distillation checkpoint assets, one-GPU checkpoint fallback, plan topology, and inherited smoke behavior. Repository formatting, type, YAML, Markdown, security, license, and lint hooks pass.

A real-checkpoint acceptance rerun is in progress. The previous run completed pruning, materialization, all configured multimodal serving workloads, and both distillation optimizer steps, but failed while publishing the first distillation checkpoint. Checkpoint publication, final evaluation and reporting, and no-op resume remain to be verified by the current run.

### Before your PR is "Ready for review"

- Is this change backward compatible?: yes
- If you copied code from any other sources or added a new PIP dependency, did you follow the contributor guidance?: N/A
- Did you write any new necessary tests?: yes
- Did you update the changelog?: N/A
- Did you get Claude approval on this PR?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end single-GPU multimodal pruning workflow for Qwen 3.5 0.8B.
  - Added image-aware serving benchmarks, evaluation, throughput selection, and distillation.
  - Added support for image workload parameters, metrics, processor settings, and multimodal limits.
  - Improved checkpoint publishing with validated vision-language processor assets.
  - Enhanced performance reports with workload labels and image-throughput metrics.

- **Documentation**
  - Added comprehensive multimodal smoke-test guidance.
  - Clarified separate text-only and vision-language workflows, including setup, launch, validation, and resume steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->