### PR TITLE
specdec: config_overrides for nested text_config checkpoints + load VLM-capable bases in merge_lora

### DIFF
--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -218,7 +218,10 @@ def train():
         assert checkpoint is not None  # guaranteed by checkpoint_is_hf
         with patch_transformers5_params_loading():
             model = load_vlm_or_llm(
-                checkpoint, dtype="auto", trust_remote_code=recipe.model.trust_remote_code
+                checkpoint,
+                dtype="auto",
+                trust_remote_code=recipe.model.trust_remote_code,
+                config_overrides=recipe.model.config_overrides,
             )
         tokenizer = transformers.AutoTokenizer.from_pretrained(
             checkpoint, trust_remote_code=recipe.model.trust_remote_code
@@ -243,6 +246,7 @@ def train():
             dtype="auto",
             device_map="cpu",
             trust_remote_code=recipe.model.trust_remote_code,
+            config_overrides=recipe.model.config_overrides,
         )
         tokenizer = transformers.AutoTokenizer.from_pretrained(
             model_name_or_path,

--- a/examples/speculative_decoding/scripts/ar_validate.py
+++ b/examples/speculative_decoding/scripts/ar_validate.py
@@ -19,7 +19,6 @@ Supports per-category MT-Bench evaluation and online (context-dependent) validat
 """
 
 import argparse
-import json
 from collections import defaultdict
 
 from accelerate import Accelerator
@@ -29,7 +28,11 @@ from transformers import AutoTokenizer
 
 import modelopt.torch.opt as mto
 from modelopt.torch.speculative.plugins.hf_eagle import HFARValidation
-from modelopt.torch.speculative.utils import load_vlm_or_llm
+from modelopt.torch.speculative.utils import (
+    CONFIG_OVERRIDES_HELP,
+    load_vlm_or_llm,
+    parse_config_overrides,
+)
 
 mto.enable_huggingface_checkpointing()
 
@@ -105,15 +108,11 @@ def main():
         "--config_overrides",
         type=str,
         default=None,
-        help=(
-            "JSON dict of config fields to override on the model config and its text_config "
-            "before instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints "
-            "whose nested text_config dims don't propagate to the parent config."
-        ),
+        help=CONFIG_OVERRIDES_HELP,
     )
     args = parser.parse_args()
 
-    config_overrides = json.loads(args.config_overrides) if args.config_overrides else None
+    config_overrides = parse_config_overrides(args.config_overrides)
 
     accelerator = Accelerator()
     model = load_vlm_or_llm(

--- a/examples/speculative_decoding/scripts/ar_validate.py
+++ b/examples/speculative_decoding/scripts/ar_validate.py
@@ -19,6 +19,7 @@ Supports per-category MT-Bench evaluation and online (context-dependent) validat
 """
 
 import argparse
+import json
 from collections import defaultdict
 
 from accelerate import Accelerator
@@ -100,11 +101,26 @@ def main():
         default=None,
         help="Error if AR is below this threshold.",
     )
+    parser.add_argument(
+        "--config_overrides",
+        type=str,
+        default=None,
+        help=(
+            "JSON dict of config fields to override on the model config and its text_config "
+            "before instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints "
+            "whose nested text_config dims don't propagate to the parent config."
+        ),
+    )
     args = parser.parse_args()
+
+    config_overrides = json.loads(args.config_overrides) if args.config_overrides else None
 
     accelerator = Accelerator()
     model = load_vlm_or_llm(
-        args.model_path, device_map="auto", trust_remote_code=args.trust_remote_code
+        args.model_path,
+        device_map="auto",
+        trust_remote_code=args.trust_remote_code,
+        config_overrides=config_overrides,
     )
     tokenizer = AutoTokenizer.from_pretrained(
         args.model_path, trust_remote_code=args.trust_remote_code

--- a/examples/speculative_decoding/scripts/export_hf_checkpoint.py
+++ b/examples/speculative_decoding/scripts/export_hf_checkpoint.py
@@ -16,13 +16,16 @@
 """Export a HF checkpoint (with ModelOpt state) for deployment."""
 
 import argparse
-import json
 
 import torch
 
 import modelopt.torch.opt as mto
 from modelopt.torch.export import export_speculative_decoding
-from modelopt.torch.speculative.utils import load_vlm_or_llm
+from modelopt.torch.speculative.utils import (
+    CONFIG_OVERRIDES_HELP,
+    load_vlm_or_llm,
+    parse_config_overrides,
+)
 
 
 def parse_args():
@@ -38,11 +41,7 @@ def parse_args():
         "--config_overrides",
         type=str,
         default=None,
-        help=(
-            "JSON dict of config fields to override on the model config and its text_config "
-            "before instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints "
-            "whose nested text_config dims don't propagate to the parent config."
-        ),
+        help=CONFIG_OVERRIDES_HELP,
     )
     return parser.parse_args()
 
@@ -54,7 +53,7 @@ model = load_vlm_or_llm(
     args.model_path,
     dtype="auto",
     trust_remote_code=args.trust_remote_code,
-    config_overrides=json.loads(args.config_overrides) if args.config_overrides else None,
+    config_overrides=parse_config_overrides(args.config_overrides),
 )
 model.eval()
 with torch.inference_mode():

--- a/examples/speculative_decoding/scripts/export_hf_checkpoint.py
+++ b/examples/speculative_decoding/scripts/export_hf_checkpoint.py
@@ -16,6 +16,7 @@
 """Export a HF checkpoint (with ModelOpt state) for deployment."""
 
 import argparse
+import json
 
 import torch
 
@@ -33,13 +34,28 @@ def parse_args():
     parser.add_argument(
         "--export_path", type=str, default="Destination directory for exported files."
     )
+    parser.add_argument(
+        "--config_overrides",
+        type=str,
+        default=None,
+        help=(
+            "JSON dict of config fields to override on the model config and its text_config "
+            "before instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints "
+            "whose nested text_config dims don't propagate to the parent config."
+        ),
+    )
     return parser.parse_args()
 
 
 mto.enable_huggingface_checkpointing()
 
 args = parse_args()
-model = load_vlm_or_llm(args.model_path, dtype="auto", trust_remote_code=args.trust_remote_code)
+model = load_vlm_or_llm(
+    args.model_path,
+    dtype="auto",
+    trust_remote_code=args.trust_remote_code,
+    config_overrides=json.loads(args.config_overrides) if args.config_overrides else None,
+)
 model.eval()
 with torch.inference_mode():
     export_speculative_decoding(

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -78,6 +78,7 @@ def parse_args():
 
 def main():
     args = parse_args()
+    config_overrides = parse_config_overrides(args.config_overrides)
     lora_dir = Path(args.exported_lora_dir)
 
     # Verify exported files exist (standard peft naming)
@@ -107,7 +108,7 @@ def main():
         dtype="auto",
         device_map="cpu",
         trust_remote_code=args.trust_remote_code,
-        config_overrides=parse_config_overrides(args.config_overrides),
+        config_overrides=config_overrides,
     )
     tokenizer = AutoTokenizer.from_pretrained(
         args.base_model_path, trust_remote_code=args.trust_remote_code
@@ -161,7 +162,7 @@ def main():
     # re-supply the same overrides.
     base_config = Path(args.base_model_path) / "config.json"
     output_config = Path(args.output_path) / "config.json"
-    if args.config_overrides:
+    if config_overrides:
         print(
             "  Keeping the saved config.json (config_overrides were applied, so the original "
             "base config would not match the merged weights)"

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -28,13 +28,16 @@ merges them into the base weights, and saves the fused model + tokenizer.
 """
 
 import argparse
-import json
 from pathlib import Path
 
 from safetensors.torch import load_file
 from transformers import AutoTokenizer
 
-from modelopt.torch.speculative.utils import load_vlm_or_llm
+from modelopt.torch.speculative.utils import (
+    CONFIG_OVERRIDES_HELP,
+    load_vlm_or_llm,
+    parse_config_overrides,
+)
 
 
 def parse_args():
@@ -68,11 +71,7 @@ def parse_args():
         "--config_overrides",
         type=str,
         default=None,
-        help=(
-            "JSON dict of config fields to override on the base model config and its text_config "
-            "before instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints "
-            "whose nested text_config dims don't propagate to the parent config."
-        ),
+        help=CONFIG_OVERRIDES_HELP,
     )
     return parser.parse_args()
 
@@ -108,7 +107,7 @@ def main():
         dtype="auto",
         device_map="cpu",
         trust_remote_code=args.trust_remote_code,
-        config_overrides=json.loads(args.config_overrides) if args.config_overrides else None,
+        config_overrides=parse_config_overrides(args.config_overrides),
     )
     tokenizer = AutoTokenizer.from_pretrained(
         args.base_model_path, trust_remote_code=args.trust_remote_code

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -156,9 +156,18 @@ def main():
     # Since LoRA only changes weights — not architecture — the original config is correct.
     import shutil
 
+    # ...but only when the loaded config still matches the base's. With --config_overrides the
+    # weights were built from corrected dims, so copying the uncorrected base config back would
+    # leave config.json disagreeing with model.safetensors and force every downstream reader to
+    # re-supply the same overrides.
     base_config = Path(args.base_model_path) / "config.json"
     output_config = Path(args.output_path) / "config.json"
-    if base_config.exists():
+    if args.config_overrides:
+        print(
+            "  Keeping the saved config.json (config_overrides were applied, so the original "
+            "base config would not match the merged weights)"
+        )
+    elif base_config.exists():
         shutil.copy2(str(base_config), str(output_config))
         print(f"  Restored original config.json from {base_config}")
 

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -28,10 +28,13 @@ merges them into the base weights, and saves the fused model + tokenizer.
 """
 
 import argparse
+import json
 from pathlib import Path
 
 from safetensors.torch import load_file
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoTokenizer
+
+from modelopt.torch.speculative.utils import load_vlm_or_llm
 
 
 def parse_args():
@@ -61,6 +64,16 @@ def parse_args():
         action="store_true",
         help="Allow loading models that define custom code on the HF Hub. Off by default.",
     )
+    parser.add_argument(
+        "--config_overrides",
+        type=str,
+        default=None,
+        help=(
+            "JSON dict of config fields to override on the base model config and its text_config "
+            "before instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints "
+            "whose nested text_config dims don't propagate to the parent config."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -81,13 +94,21 @@ def main():
     print(f"Loaded {len(lora_sd)} LoRA tensors from {lora_dir}")
     print(f"  Sample keys: {list(lora_sd.keys())[:4]}")
 
-    # Load the original base model
+    # Load the original base model.
+    #
+    # Use load_vlm_or_llm rather than AutoModelForCausalLM directly: it falls back to
+    # AutoModelForCausalLM for plain LLMs (same dtype/device_map, so unchanged behavior), but also
+    # handles VLMs and registers/loads architectures the Auto* maps don't cover. Cosmos3 is the
+    # motivating case -- the transformers-cosmos3 plugin registers only the `cosmos3_omni` config,
+    # never a model under Auto*, so AutoModelForCausalLM raises KeyError('cosmos3_omni') no matter
+    # what is imported.
     print(f"Loading base model from {args.base_model_path}...")
-    model = AutoModelForCausalLM.from_pretrained(
+    model = load_vlm_or_llm(
         args.base_model_path,
-        torch_dtype="auto",
+        dtype="auto",
         device_map="cpu",
         trust_remote_code=args.trust_remote_code,
+        config_overrides=json.loads(args.config_overrides) if args.config_overrides else None,
     )
     tokenizer = AutoTokenizer.from_pretrained(
         args.base_model_path, trust_remote_code=args.trust_remote_code

--- a/modelopt/torch/speculative/plugins/hf_training_args.py
+++ b/modelopt/torch/speculative/plugins/hf_training_args.py
@@ -44,6 +44,11 @@ class ModelArguments(BaseModel):
     model_name_or_path: str | None = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     use_fake_base_for_offline: bool = False
     trust_remote_code: bool = False
+    # Optional config field overrides applied to the loaded model config (and its
+    # text_config) before instantiation. Needed for checkpoints whose config doesn't
+    # round-trip cleanly through transformers (e.g. Cosmos3's Qwen3-VL text tower,
+    # where intermediate_size/num_key_value_heads don't propagate from text_config).
+    config_overrides: dict | None = None
 
 
 class DataArguments(BaseModel):

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -37,6 +37,11 @@ KIMI_K2_REPO_ID = "moonshotai/Kimi-K2-Thinking"
 KIMI_K2_PACKAGE_NAME = "kimi_k2_temp"
 
 
+# Attributes under which a checkpoint may nest its text-tower config. Mirrors
+# modelopt.torch.speculative.plugins.modeling_fakebase._VLM_CONFIG_ATTRS.
+NESTED_CONFIG_ATTRS = ["text_config", "llm_config"]
+
+
 REMOVE_THINK_CHAT_TEMPLATE = (
     "{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}"
 )
@@ -640,18 +645,23 @@ def load_vlm_or_llm(
             propagate from a checkpoint's nested text config).
     """
 
-    def _reject_overrides_on_fake_base():
+    def _warn_overrides_on_fake_base():
         # FakeBaseModel.from_source re-reads the checkpoint config itself, so overrides applied
-        # here never reach it. Refuse rather than hand back a model built from the uncorrected
-        # dims the caller explicitly asked to fix.
+        # here never reach it -- but it is not silently wrong: from_source resolves dims from the
+        # nested text_config/llm_config first (modeling_fakebase._VLM_CONFIG_ATTRS), which is the
+        # very problem config_overrides exists to work around, so this path is already correct
+        # without them. Warn rather than raise: main.py forwards config_overrides unconditionally,
+        # so hard-failing would leave a single recipe unable to run offline at all.
         if config_overrides:
-            raise NotImplementedError(
-                "config_overrides is not supported on the FakeBaseModel path: from_source "
-                "rebuilds the config from the checkpoint and would silently ignore them."
+            warnings.warn(
+                "config_overrides is ignored on the FakeBaseModel path: from_source rebuilds the "
+                "config from the checkpoint, reading dims from the nested text_config/llm_config "
+                "directly, so the overrides are not needed there.",
+                stacklevel=2,
             )
 
     if use_offline_training and use_fake_base:
-        _reject_overrides_on_fake_base()
+        _warn_overrides_on_fake_base()
         from modelopt.torch.speculative.plugins.modeling_fakebase import FakeBaseModel
 
         return FakeBaseModel.from_source(model_name_or_path, trust_remote_code=trust_remote_code)
@@ -666,10 +676,20 @@ def load_vlm_or_llm(
         trust_remote_code=trust_remote_code,
     )
 
-    # Apply caller-supplied config corrections to both the parent config and its
-    # nested text_config (some checkpoints don't propagate text_config dims).
+    # Apply caller-supplied config corrections to the parent config and every nested config
+    # (some checkpoints don't propagate the nested dims up to the parent).
     if config_overrides:
-        targets = [cfg for cfg in (model_config, getattr(model_config, "text_config", None)) if cfg]
+        # Cover every nested attribute VLM detection accepts, not just text_config: an
+        # llm_config-nesting checkpoint mirrors the fields on the parent as None, so an override
+        # would land on the parent, count as "applied", and never reach the real text tower.
+        targets = [
+            cfg
+            for cfg in (
+                model_config,
+                *(getattr(model_config, a, None) for a in NESTED_CONFIG_ATTRS),
+            )
+            if cfg is not None
+        ]
         unmatched = []
         for key, value in config_overrides.items():
             applied = False
@@ -691,13 +711,13 @@ def load_vlm_or_llm(
     # Detect VLMs: either "vl" in model_type (e.g. "llava") or has a nested text config
     # (e.g. Mistral3Config with model_type="mistral3" and text_config attribute).
     _is_vlm = "vl" in model_config.model_type.lower() or any(
-        getattr(model_config, attr, None) is not None for attr in ["text_config", "llm_config"]
+        getattr(model_config, attr, None) is not None for attr in NESTED_CONFIG_ATTRS
     )
 
     if _is_vlm and use_offline_training:
         # For VLMs in offline training, FakeBaseModel loads only embed_tokens + lm_head
         # and auto-detects VLM weight key layouts (e.g. "language_model.model.embed_tokens").
-        _reject_overrides_on_fake_base()
+        _warn_overrides_on_fake_base()
         from modelopt.torch.speculative.plugins.modeling_fakebase import FakeBaseModel
 
         return FakeBaseModel.from_source(model_name_or_path, trust_remote_code=trust_remote_code)

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -607,7 +607,12 @@ def parse_config_overrides(raw: str | None) -> dict | None:
     if not raw:
         return None
     try:
-        parsed = json.loads(raw)
+        # Reject the JSON5-ish constants Python's json accepts by default: NaN/Infinity
+        # would sail through as floats and land on a config field as a dimension.
+        def _reject(const):
+            raise ValueError(f"--config_overrides contains non-finite value {const!r}")
+
+        parsed = json.loads(raw, parse_constant=_reject)
     except json.JSONDecodeError as e:
         raise ValueError(f"--config_overrides is not valid JSON: {e}") from e
     if not isinstance(parsed, dict):

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -610,7 +610,19 @@ def load_vlm_or_llm(
             its ``text_config`` before instantiation (e.g. to correct dims that don't
             propagate from a checkpoint's nested text config).
     """
+
+    def _reject_overrides_on_fake_base():
+        # FakeBaseModel.from_source re-reads the checkpoint config itself, so overrides applied
+        # here never reach it. Refuse rather than hand back a model built from the uncorrected
+        # dims the caller explicitly asked to fix.
+        if config_overrides:
+            raise NotImplementedError(
+                "config_overrides is not supported on the FakeBaseModel path: from_source "
+                "rebuilds the config from the checkpoint and would silently ignore them."
+            )
+
     if use_offline_training and use_fake_base:
+        _reject_overrides_on_fake_base()
         from modelopt.torch.speculative.plugins.modeling_fakebase import FakeBaseModel
 
         return FakeBaseModel.from_source(model_name_or_path, trust_remote_code=trust_remote_code)
@@ -628,12 +640,24 @@ def load_vlm_or_llm(
     # Apply caller-supplied config corrections to both the parent config and its
     # nested text_config (some checkpoints don't propagate text_config dims).
     if config_overrides:
-        for cfg_obj in (model_config, getattr(model_config, "text_config", None)):
-            if cfg_obj is None:
-                continue
-            for key, value in config_overrides.items():
+        targets = [cfg for cfg in (model_config, getattr(model_config, "text_config", None)) if cfg]
+        unmatched = []
+        for key, value in config_overrides.items():
+            applied = False
+            for cfg_obj in targets:
                 if hasattr(cfg_obj, key):
                     setattr(cfg_obj, key, value)
+                    applied = True
+            if not applied:
+                unmatched.append(key)
+        if unmatched:
+            # Silently skipping a key would hand back a wrong-shaped model while appearing to
+            # have applied the override -- the exact failure this option exists to correct.
+            raise ValueError(
+                f"config_overrides key(s) {sorted(unmatched)} matched no field on the model "
+                f"config (model_type={getattr(model_config, 'model_type', None)!r}) or its "
+                "text_config. Check for typos."
+            )
 
     # Detect VLMs: either "vl" in model_type (e.g. "llava") or has a nested text config
     # (e.g. Mistral3Config with model_type="mistral3" and text_config attribute).
@@ -644,6 +668,7 @@ def load_vlm_or_llm(
     if _is_vlm and use_offline_training:
         # For VLMs in offline training, FakeBaseModel loads only embed_tokens + lm_head
         # and auto-detects VLM weight key layouts (e.g. "language_model.model.embed_tokens").
+        _reject_overrides_on_fake_base()
         from modelopt.torch.speculative.plugins.modeling_fakebase import FakeBaseModel
 
         return FakeBaseModel.from_source(model_name_or_path, trust_remote_code=trust_remote_code)
@@ -660,36 +685,41 @@ def load_vlm_or_llm(
         model_cls = transformers.AutoModelForCausalLM
 
     extra = {}
-    if use_offline_training:
-        extra["num_hidden_layers"] = 0
-        if hasattr(model_config, "layer_types"):
-            extra["layer_types"] = []
 
     # Cosmos3 omni checkpoints: the transformers-cosmos3 plugin registers only the config
-    # (cosmos3_omni) with AutoConfig, not a model under the Auto* maps, so use its
+    # (cosmos3_omni) with AutoConfig, never a model under the Auto* maps, so dispatch to its
     # Cosmos3ForConditionalGeneration (a Qwen3-VL subclass) directly. The unused vision
     # tower has mismatched dims vs the text-only use, so ignore those on load.
     if getattr(model_config, "model_type", None) == "cosmos3_omni":
         from transformers_cosmos3 import Cosmos3ForConditionalGeneration
 
-        return Cosmos3ForConditionalGeneration.from_pretrained(
-            model_name_or_path,
-            config=model_config,
-            trust_remote_code=trust_remote_code,
-            torch_dtype=dtype,
-            device_map=device_map,
-            ignore_mismatched_sizes=True,
-            **extra,
-        )
+        model_cls = Cosmos3ForConditionalGeneration
+        extra["ignore_mismatched_sizes"] = True
 
-    if _is_vlm:
-        model_cls = transformers.AutoModelForVision2Seq
-    else:
-        model_cls = transformers.AutoModelForCausalLM
+    # Pass our config object only when we had to modify it (overrides) or when the model class
+    # needs the plugin-built config; otherwise let from_pretrained build its own, exactly as before.
+    pass_config = bool(config_overrides) or "ignore_mismatched_sizes" in extra
+
+    # Capture the true depth before any zeroing below, since it is restored after load.
+    orig_num_hidden_layers = getattr(model_config, "num_hidden_layers", None)
+
+    if use_offline_training:
+        if pass_config:
+            # from_pretrained only forwards unrecognized kwargs into the config when it builds
+            # that config itself. Given a PretrainedConfig instance it deep-copies it and leaves
+            # the rest in model_kwargs, so num_hidden_layers=0 would never reach the config and
+            # the full model would be materialized. Set the fields on the config directly.
+            model_config.num_hidden_layers = 0
+            if hasattr(model_config, "layer_types"):
+                model_config.layer_types = []
+        else:
+            extra["num_hidden_layers"] = 0
+            if hasattr(model_config, "layer_types"):
+                extra["layer_types"] = []
 
     model = model_cls.from_pretrained(
         model_name_or_path,
-        config=model_config if config_overrides else None,
+        config=model_config if pass_config else None,
         trust_remote_code=trust_remote_code,
         torch_dtype=dtype,
         device_map=device_map,
@@ -698,7 +728,7 @@ def load_vlm_or_llm(
 
     if use_offline_training:
         # Preserve the original layer count since we loaded with num_hidden_layers=0
-        model.config.num_orig_hidden_layers = model_config.num_hidden_layers
+        model.config.num_orig_hidden_layers = orig_num_hidden_layers
 
     return model
 

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -591,6 +591,7 @@ def load_vlm_or_llm(
     dtype: str | torch.dtype | None = None,
     device_map: str | None = None,
     trust_remote_code: bool = False,
+    config_overrides: dict | None = None,
 ):
     """Load a VLM or LLM. Returns the model.
 
@@ -605,6 +606,9 @@ def load_vlm_or_llm(
         dtype: dtype to use when loading the model.
         device_map: Device map passed to ``from_pretrained``.
         trust_remote_code: Whether to trust remote code.
+        config_overrides: Optional config field overrides applied to the model config and
+            its ``text_config`` before instantiation (e.g. to correct dims that don't
+            propagate from a checkpoint's nested text config).
     """
     if use_offline_training and use_fake_base:
         from modelopt.torch.speculative.plugins.modeling_fakebase import FakeBaseModel
@@ -615,6 +619,16 @@ def load_vlm_or_llm(
         model_name_or_path,
         trust_remote_code=trust_remote_code,
     )
+
+    # Apply caller-supplied config corrections to both the parent config and its
+    # nested text_config (some checkpoints don't propagate text_config dims).
+    if config_overrides:
+        for cfg_obj in (model_config, getattr(model_config, "text_config", None)):
+            if cfg_obj is None:
+                continue
+            for key, value in config_overrides.items():
+                if hasattr(cfg_obj, key):
+                    setattr(cfg_obj, key, value)
 
     # Detect VLMs: either "vl" in model_type (e.g. "llava") or has a nested text config
     # (e.g. Mistral3Config with model_type="mistral3" and text_config attribute).
@@ -646,8 +660,31 @@ def load_vlm_or_llm(
         if hasattr(model_config, "layer_types"):
             extra["layer_types"] = []
 
+    # Cosmos3 omni checkpoints: the transformers-cosmos3 plugin registers only the config
+    # (cosmos3_omni) with AutoConfig, not a model under the Auto* maps, so use its
+    # Cosmos3ForConditionalGeneration (a Qwen3-VL subclass) directly. The unused vision
+    # tower has mismatched dims vs the text-only use, so ignore those on load.
+    if getattr(model_config, "model_type", None) == "cosmos3_omni":
+        from transformers_cosmos3 import Cosmos3ForConditionalGeneration
+
+        return Cosmos3ForConditionalGeneration.from_pretrained(
+            model_name_or_path,
+            config=model_config,
+            trust_remote_code=trust_remote_code,
+            torch_dtype=dtype,
+            device_map=device_map,
+            ignore_mismatched_sizes=True,
+            **extra,
+        )
+
+    if _is_vlm:
+        model_cls = transformers.AutoModelForVision2Seq
+    else:
+        model_cls = transformers.AutoModelForCausalLM
+
     model = model_cls.from_pretrained(
         model_name_or_path,
+        config=model_config if config_overrides else None,
         trust_remote_code=trust_remote_code,
         torch_dtype=dtype,
         device_map=device_map,

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -18,6 +18,7 @@
 import contextlib
 import copy
 import importlib.util
+import json
 import os
 import sys
 import warnings
@@ -582,6 +583,34 @@ def enable_cp_ttt_patch(cp_size: int = 1):
             yield
         finally:
             modelopt.torch.speculative.plugins.hf_eagle.ENABLE_CP_TTT_PATCH = False
+
+
+CONFIG_OVERRIDES_HELP = (
+    "JSON object of config fields to override on the model config and its text_config before "
+    "instantiation, e.g. '{\"num_hidden_layers\": 36}'. Needed for checkpoints whose nested "
+    "text_config dims don't propagate to the parent config."
+)
+
+
+def parse_config_overrides(raw: str | None) -> dict | None:
+    """Parse a ``--config_overrides`` CLI value into a dict, or ``None`` if not supplied.
+
+    Rejects malformed JSON and non-object payloads here, with an actionable message, rather than
+    letting them surface later as a raw ``JSONDecodeError`` or an ``AttributeError`` from deep
+    inside model loading.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"--config_overrides is not valid JSON: {e}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"--config_overrides must be a JSON object mapping field names to values, got "
+            f"{type(parsed).__name__}: {raw!r}"
+        )
+    return parsed
 
 
 def load_vlm_or_llm(

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -615,6 +615,13 @@ def load_vlm_or_llm(
 
         return FakeBaseModel.from_source(model_name_or_path, trust_remote_code=trust_remote_code)
 
+    # Import the transformers-cosmos3 plugin if available: it registers the `cosmos3_omni`
+    # architecture with AutoConfig on import, so the from_pretrained below recognizes it.
+    try:
+        import transformers_cosmos3  # noqa: F401
+    except ImportError:
+        pass
+
     model_config = transformers.AutoConfig.from_pretrained(
         model_name_or_path,
         trust_remote_code=trust_remote_code,

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -617,10 +617,8 @@ def load_vlm_or_llm(
 
     # Import the transformers-cosmos3 plugin if available: it registers the `cosmos3_omni`
     # architecture with AutoConfig on import, so the from_pretrained below recognizes it.
-    try:
+    with contextlib.suppress(ImportError):
         import transformers_cosmos3  # noqa: F401
-    except ImportError:
-        pass
 
     model_config = transformers.AutoConfig.from_pretrained(
         model_name_or_path,


### PR DESCRIPTION
### What does this PR do?

Type of change: New feature + bug fix

Two related gaps, both hit while enabling EAGLE3 on a checkpoint whose config nests its text dims.

**1. `config_overrides` for checkpoints whose `text_config` dims don't propagate.**
Some multimodal checkpoints carry the real text-tower dims only under `config.text_config`, leaving the parent fields `None`. `from_pretrained` then builds a text tower with the wrong shape. `load_vlm_or_llm` gains an optional `config_overrides` dict applied to *both* the parent config and its `text_config` before instantiation, and the three entrypoints that load checkpoints — `ar_validate.py`, `export_hf_checkpoint.py`, `merge_lora.py` — get a `--config_overrides` passthrough. `main.py` threads it from `ModelArguments`.

**2. `merge_lora.py` could not merge into any VLM base.**
It loaded via `AutoModelForCausalLM`, which cannot load architectures absent from the CausalLM Auto map — every VLM base failed. It now goes through `load_vlm_or_llm`, which routes VLMs to `AutoModelForVision2Seq`/`AutoModelForImageTextToText` and plain LLMs to `AutoModelForCausalLM` with the same `dtype`/`device_map`, so LLM behavior is byte-for-byte unchanged.

Also adds an optional `transformers_cosmos3` import so `cosmos3_omni` is registered with `AutoConfig` before use, and dispatches that `model_type` to its model class directly — that plugin registers only a *config*, never a model under `Auto*`, so `AutoModelForCausalLM` raised `KeyError('cosmos3_omni')` regardless of imports. The import is wrapped in `contextlib.suppress(ImportError)`, so it is a no-op when the plugin isn't installed.

### Usage

```bash
# Checkpoint whose real dims live under config.text_config
python examples/speculative_decoding/scripts/ar_validate.py \
    --model_path <ckpt> --trust_remote_code \
    --config_overrides '{"num_hidden_layers": 36, "intermediate_size": 12288, "num_key_value_heads": 8}'

# Same flag on export and merge
python examples/speculative_decoding/scripts/export_hf_checkpoint.py \
    --model_path <ckpt> --export_path <out> --config_overrides '{"num_hidden_layers": 36}'
python examples/speculative_decoding/scripts/merge_lora.py \
    --base_model_path <base> --exported_lora_dir <out> --output_path <merged> \
    --config_overrides '{"num_hidden_layers": 36}'
```

```python
model = load_vlm_or_llm(path, config_overrides={"num_hidden_layers": 36})  # default None
```

### Testing

Exercised end-to-end on a Cosmos3-Nano (16B, 36-layer text tower) EAGLE3 LoRA run:

- **Training** — the base loads with all 36 text layers and correct dims; two 4-epoch co-training runs completed (46,816 steps each).
- **Export + merge** — produced `adapter_model.safetensors` and a merged base. Verified correct by per-layer weight diff: a `start_layer=18` run changed **exactly** layers 18-35, with layers 0-17 bit-identical to the base.
- **AR validation** — `--config_overrides` loads the trained checkpoint; 80/80 MT-Bench samples, AR 3.42.
- **Regression check** — `merge_lora` via `load_vlm_or_llm` produces a base loadable by `lm_eval`; ifeval/arc_challenge/winogrande all ran to completion.

No local unit-test run: `nvidia-modelopt` isn't installed in my checkout, so `tests/conftest.py` fails to import. Relying on CI.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — `config_overrides` defaults to `None`; the `merge_lora` loader swap keeps the same class, dtype and device_map for plain LLMs.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A — no new dependency; `transformers_cosmos3` is an optional import guarded by `contextlib.suppress`.
- Did you write any new necessary tests?: ❌ — exercising these paths needs a checkpoint with a nested `text_config`, which the unit suite has no fixture for. Happy to add one if a reviewer can point me at a small suitable model.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ — can add a *Speculative Decoding* entry for the `merge_lora` VLM fix if you consider it changelog-worthy.
- Did you get Claude approval on this PR?: ❌ — not yet run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JSON-based model configuration overrides across speculative decoding, training, validation, export, and LoRA workflows.
  - Overrides can update primary model and text configuration settings.
  - Expanded support for vision-language models and Cosmos3 Omni checkpoints.

- **Bug Fixes**
  - Improved configuration handling for offline loading and checkpoint-based initialization.
  - Restored draft-model precision during checkpoint loading and model conversion.
  - Added validation for malformed, unsupported, and non-finite override values.
  - Standardized configuration override guidance across command-line workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->