### PR TITLE
README: link Announcement Blogs and add AutoQuantize blog to Latest News

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [![license](https://img.shields.io/badge/License-Apache%202.0-blue)](./LICENSE)
 
 [Documentation](https://nvidia.github.io/Model-Optimizer) |
-[Roadmap](https://github.com/NVIDIA/Model-Optimizer/issues/1699)
+[Roadmap](https://github.com/NVIDIA/Model-Optimizer/issues/1699) |
+[Announcement Blogs](https://nvidia.github.io/Model-Optimizer/)
 
 </div>
 
@@ -26,6 +27,7 @@ Model Optimizer is also integrated with [NVIDIA Megatron-Bridge](https://github.
 
 ## Latest News
 
+- [2026/08/24] [BLOG: AutoQuantize: A Fast Automatic Mixed-Precision Assignment](https://nvidia.github.io/Model-Optimizer/announcements/autoquantize.html): How AutoQuantize scores per-layer quantization sensitivity with a fast gradient-based heuristic and solves for the lowest-scoring mixed-precision assignment under an effective-bits budget, with no per-model ablation studies required.
 - [2026/08/17] [BLOG: Developing Nemotron 3.5 Lightning NVFP4 with QAD Using NVIDIA Model Optimizer](https://developer.nvidia.com/blog/developing-nemotron-3-5-lightning-nvfp4-with-qad-using-nvidia-model-optimizer/): Learn how quantization-aware distillation recovers accuracy from aggressive NVFP4 quantization while reducing model size and increasing throughput.
 - [2026/06/26] [BLOG: Creating the NVIDIA Nemotron 3 Ultra NVFP4 Checkpoint with NVIDIA Model Optimizer](https://developer.nvidia.com/blog/creating-the-nvidia-nemotron-3-ultra-nvfp4-checkpoint-with-nvidia-model-optimizer/): How we quantized Nemotron 3 Ultra (550B) to NVFP4 with Model Optimizer — up to 5.9× higher decode-heavy inference throughput than GLM-5.1 754B FP4 while matching BF16 accuracy. [NVFP4 Checkpoint](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4) on Hugging Face.
 - [2026/05/27] [**End-to-end Optimization tutorial for Nemotron-3-Nano-30B-A3B**](./examples/megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16): Pruning + two-phase distillation + FP8 quantization achieving 2.6× vLLM throughput and 2.6× memory reduction.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [Documentation](https://nvidia.github.io/Model-Optimizer) |
 [Roadmap](https://github.com/NVIDIA/Model-Optimizer/issues/1699) |
-[Announcement Blogs](https://nvidia.github.io/Model-Optimizer/)
+[Announcement Blogs](https://nvidia.github.io/Model-Optimizer/#announcements)
 
 </div>
 


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation.

- Adds an Announcement Blogs link to the centered README header after Roadmap.
- Adds the 2026/08/24 AutoQuantize announcement at the top of Latest News.

The announcements landing page intentionally points to the documentation site root: `docs/source/index.rst` is titled "Announcements".

### Usage

N/A — documentation-only change.

### Testing

- `pre-commit run --files README.md .`
- `git diff --check`

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: N/A
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — documentation-only change.
- Did you update `CHANGELOG.rst`?: N/A — README-only documentation update.
- Did you get Claude approval on this PR?: N/A

### Additional Information

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Announcement Blogs link to the header navigation.
  * Added the August 24, 2026 AutoQuantize announcement to the Latest News section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->