### PR TITLE
Speed up megatron_bridge example tests by ~6x on a single GPU

### DIFF
--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -155,7 +155,8 @@ jobs:
     with:
       docker_image: "nvcr.io/nvidia/nemo:26.08"
       example: megatron_bridge
-      timeout_minutes: 75
+      # PR runs single-GPU (~11 min); the nightly runs every test multi-GPU (~58 min).
+      timeout_minutes: ${{ startsWith(github.ref, 'refs/heads/pull-request/') && 30 || 75 }}
       pip_install_extras: "[hf,puzzletron,dev-test]"
       runner: ${{ startsWith(github.ref, 'refs/heads/pull-request/') && 'linux-amd64-gpu-rtxpro6000-latest-1' || 'linux-amd64-gpu-rtxpro6000-latest-2' }}
       allow_failure: ${{ contains(format(',{0},', vars.ALLOW_FAILURE_EXAMPLE_TESTS), ',megatron_bridge,') }}

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -38,71 +38,58 @@ import os
 import signal
 import sys
 import tempfile
-import threading
 from pathlib import Path
 from unittest.mock import patch
 
 import torch
-from _test_utils.examples.run_command import _ORPHAN_PIPE_TIMEOUT_S, MODELOPT_ROOT
+from _test_utils.examples.run_command import MODELOPT_ROOT
 from _test_utils.torch.distributed.utils import get_free_port
 
 import modelopt.torch.utils.distributed as dist
 
 # torchrun's PContext installs handlers for these and never restores them.
-_TAIL_INTERVAL_S = 0.2  # how often the tailer echoes new output
-
 _LAUNCHER_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT)
 
 
 @contextlib.contextmanager
 def _capture_output():
-    """Capture everything a step emits, as one ordered stream, while still streaming it live.
+    """Capture everything a step emits, in the order it happened.
 
     Three sources have to end up in the same place: ``print`` from the script, records from loggers
     Megatron-Bridge uses for lines tests assert on, and fd-level writes from ``torchrun`` workers
     and C extensions. Under pytest's fd capture ``sys.stdout``/``sys.stderr`` are objects over
     pytest's own temp file rather than fds 1/2, so both a redirect and an fd swap are needed.
 
-    A tailer thread echoes the buffer as it fills, so a job-level timeout -- which SIGKILLs the
-    runner without running any ``finally`` -- still leaves the log in the CI output. Writing to a
-    pipe instead would stream more directly, but its backpressure cost the 1-GPU suite 3m43 -> 9m06.
+    Buffered, not streamed: the caller prints the result, which pytest shows for a failing test.
+    Echoing it live would not reach the CI log anyway -- without ``-s``, fd 1 is already pytest's
+    own capture file. Piping it to stream for real cost the 1-GPU suite 3m43 -> 9m06 in
+    backpressure, so surviving a job-level SIGKILL would need a file outside the process.
     """
     holder = [""]
     with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as tmp:
-        live = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # the fd we do not touch
-        done = threading.Event()
-        sent = [0]
-
-        def _tail():
-            """Echo new bytes as they land, so a SIGKILLed job still has the log."""
-            while True:
-                data = os.pread(tmp.fileno(), 1 << 20, sent[0])  # pread: leaves the write offset
-                if data:
-                    sent[0] += len(data)
-                    live.write(data.decode("utf-8", errors="replace"))
-                elif done.is_set():
-                    return
-                else:
-                    done.wait(_TAIL_INTERVAL_S)
-
-        sys.stdout.flush()
-        sys.stderr.flush()
-        saved_out, saved_err = os.dup(1), os.dup(2)
-        os.dup2(tmp.fileno(), 1)
-        os.dup2(tmp.fileno(), 2)
-        sink = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # now the temp file
-        handler = logging.StreamHandler(sink)
+        handler = logging.StreamHandler()  # bound to the swapped fd 2 below
         handler.setFormatter(logging.Formatter("%(message)s"))
         root = logging.getLogger()
-        others = [lg for lg in root.manager.loggerDict.values() if isinstance(lg, logging.Logger)]
+        with logging._lock:  # any getLogger() from a background thread mutates loggerDict
+            others = [
+                lg for lg in root.manager.loggerDict.values() if isinstance(lg, logging.Logger)
+            ]
         # Lower levels only for loggers that own their output: a propagating logger still needs its
         # own level lowered, or it drops the record before root sees it.
         levels = {lg: lg.level for lg in [root, *others] if lg.handlers or not lg.propagate}
         # Attach the handler only where the record cannot reach root, or it is written twice.
         handled = [root, *(lg for lg in others if not lg.propagate)]
-        tailer = threading.Thread(target=_tail, daemon=True)
-        tailer.start()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        saved_out, saved_err = os.dup(1), os.dup(2)
+        sink = None
         try:
+            # Inside the try: a raise between here and the restore would otherwise leave fds 1/2
+            # pointing at a temp file the ``with`` then closes, silencing the rest of the session.
+            os.dup2(tmp.fileno(), 1)
+            os.dup2(tmp.fileno(), 2)
+            sink = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")
+            handler.setStream(sink)
             for lg in levels:
                 if lg.level > logging.INFO:
                     lg.setLevel(logging.INFO)
@@ -115,16 +102,14 @@ def _capture_output():
                 lg.removeHandler(handler)
             for lg, level in levels.items():
                 lg.setLevel(level)
-            sink.close()
+            if sink is not None:
+                sink.close()
             sys.stdout.flush()
             sys.stderr.flush()
             os.dup2(saved_out, 1)
             os.dup2(saved_err, 2)
             os.close(saved_out)
             os.close(saved_err)
-            done.set()
-            tailer.join(_ORPHAN_PIPE_TIMEOUT_S)  # bounded, like the subprocess reader
-            live.close()
             tmp.seek(0)
             holder[0] = tmp.read()
 
@@ -142,7 +127,8 @@ def _preserved_signal_handlers():
         yield
     finally:
         for sig, handler in saved.items():
-            signal.signal(sig, handler)
+            if handler is not None:  # installed from C; not restorable via signal.signal()
+                signal.signal(sig, handler)
 
 
 def reset_megatron_global_state() -> None:
@@ -259,6 +245,7 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
         raise
     finally:
         os.chdir(cwd)
+        print(native[0])  # keep the step's output in the test log
 
 
 def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
@@ -296,6 +283,7 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
         raise
     finally:
         os.chdir(cwd)
+        print(cap[0])  # keep the step's output in the test log
 
 
 def run_example_step(cmd_parts: list[str], example_path: str) -> str:

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -37,6 +37,7 @@ import logging
 import os
 import signal
 import sys
+import tempfile
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -48,6 +49,8 @@ from _test_utils.torch.distributed.utils import get_free_port
 import modelopt.torch.utils.distributed as dist
 
 # torchrun's PContext installs handlers for these and never restores them.
+_TAIL_INTERVAL_S = 0.2  # how often the tailer echoes new output
+
 _LAUNCHER_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT)
 
 
@@ -60,62 +63,86 @@ def _capture_output():
     and C extensions. Under pytest's fd capture ``sys.stdout``/``sys.stderr`` are objects over
     pytest's own temp file rather than fds 1/2, so both a redirect and an fd swap are needed.
 
-    Tee rather than buffer: a job-level timeout SIGKILLs the runner without running any ``finally``,
-    and that is exactly when the log is wanted.
+    A tailer thread echoes the buffer as it fills, so a job-level timeout -- which SIGKILLs the
+    runner without running any ``finally`` -- still leaves the log in the CI output. Writing to a
+    pipe instead would stream more directly, but its backpressure cost the 1-GPU suite 3m43 -> 9m06.
     """
     holder = [""]
-    chunks: list[str] = []
-    read_fd, write_fd = os.pipe()
-    live = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # the fd we do not touch
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as tmp:
+        live = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # the fd we do not touch
+        done = threading.Event()
+        sent = [0]
 
-    def _drain():
-        with os.fdopen(read_fd, "r", errors="replace") as pipe:
-            for line in pipe:
-                live.write(line)
-                chunks.append(line)
+        def _tail():
+            """Echo new bytes as they land, so a SIGKILLed job still has the log."""
+            while True:
+                data = os.pread(tmp.fileno(), 1 << 20, sent[0])  # pread: leaves the write offset
+                if data:
+                    sent[0] += len(data)
+                    live.write(data.decode("utf-8", errors="replace"))
+                elif done.is_set():
+                    return
+                else:
+                    done.wait(_TAIL_INTERVAL_S)
 
-    reader = threading.Thread(target=_drain, daemon=True)
-    reader.start()
-    sys.stdout.flush()
-    sys.stderr.flush()
-    saved_out, saved_err = os.dup(1), os.dup(2)
-    os.dup2(write_fd, 1)
-    os.dup2(write_fd, 2)
-    sink = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # now the pipe
-    handler = logging.StreamHandler(sink)
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    root = logging.getLogger()
-    others = [lg for lg in root.manager.loggerDict.values() if isinstance(lg, logging.Logger)]
-    # Lower levels only for loggers that own their output; doing it for every logger switches on
-    # torch dynamo/inductor INFO and floods the pipe, which cost the 1-GPU suite 3m43 -> 9m01.
-    # A propagating logger still needs its own level lowered, or it drops the record before root.
-    levels = {lg: lg.level for lg in [root, *others] if lg.handlers or not lg.propagate}
-    # Attach the handler only where the record cannot reach root, or it is written twice.
-    handled = [root, *(lg for lg in others if not lg.propagate)]
-    try:
-        for lg in levels:
-            if lg.level > logging.INFO:
-                lg.setLevel(logging.INFO)
-        for lg in handled:
-            lg.addHandler(handler)
-        with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
-            yield holder
-    finally:
-        for lg in handled:
-            lg.removeHandler(handler)
-        for lg, level in levels.items():
-            lg.setLevel(level)
-        sink.close()
         sys.stdout.flush()
         sys.stderr.flush()
-        os.dup2(saved_out, 1)
-        os.dup2(saved_err, 2)
-        os.close(saved_out)
-        os.close(saved_err)
-        os.close(write_fd)  # EOF for the reader
-        reader.join(_ORPHAN_PIPE_TIMEOUT_S)  # bounded: an orphan may still hold the pipe
-        live.close()
-        holder[0] = "".join(chunks)
+        saved_out, saved_err = os.dup(1), os.dup(2)
+        os.dup2(tmp.fileno(), 1)
+        os.dup2(tmp.fileno(), 2)
+        sink = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # now the temp file
+        handler = logging.StreamHandler(sink)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        root = logging.getLogger()
+        others = [lg for lg in root.manager.loggerDict.values() if isinstance(lg, logging.Logger)]
+        # Lower levels only for loggers that own their output: a propagating logger still needs its
+        # own level lowered, or it drops the record before root sees it.
+        levels = {lg: lg.level for lg in [root, *others] if lg.handlers or not lg.propagate}
+        # Attach the handler only where the record cannot reach root, or it is written twice.
+        handled = [root, *(lg for lg in others if not lg.propagate)]
+        tailer = threading.Thread(target=_tail, daemon=True)
+        tailer.start()
+        try:
+            for lg in levels:
+                if lg.level > logging.INFO:
+                    lg.setLevel(logging.INFO)
+            for lg in handled:
+                lg.addHandler(handler)
+            with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+                yield holder
+        finally:
+            for lg in handled:
+                lg.removeHandler(handler)
+            for lg, level in levels.items():
+                lg.setLevel(level)
+            sink.close()
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os.dup2(saved_out, 1)
+            os.dup2(saved_err, 2)
+            os.close(saved_out)
+            os.close(saved_err)
+            done.set()
+            tailer.join(_ORPHAN_PIPE_TIMEOUT_S)  # bounded, like the subprocess reader
+            live.close()
+            tmp.seek(0)
+            holder[0] = tmp.read()
+
+
+@contextlib.contextmanager
+def _preserved_signal_handlers():
+    """Put back handlers a step installs; with a subprocess launcher, process exit did this.
+
+    Both paths need it: ``PContext.start()`` installs its own, and a Megatron training loop run
+    in-process is if anything likelier to (graceful exit, checkpoint-on-signal). Losing them breaks
+    pytest's Ctrl-C and CI cancellation for the rest of the session.
+    """
+    saved = {s: signal.getsignal(s) for s in _LAUNCHER_SIGNALS}
+    try:
+        yield
+    finally:
+        for sig, handler in saved.items():
+            signal.signal(sig, handler)
 
 
 def reset_megatron_global_state() -> None:
@@ -179,10 +206,15 @@ def _require_drivable(script: str, example_path: str) -> None:
 
 def requested_world_size(cmd_parts: list[str]) -> int | None:
     """World size a ``torchrun`` command asks for, or ``None`` if it is not a plain integer."""
-    for part in cmd_parts:
-        if str(part).startswith("--nproc_per_node="):
-            value = str(part).split("=", 1)[1]
-            return int(value) if value.isdigit() else None  # "gpu"/"auto": keep torchrun
+    parts = [str(p) for p in cmd_parts]
+    for i, part in enumerate(parts):
+        if part.startswith("--nproc_per_node="):
+            value = part.split("=", 1)[1]
+        elif part == "--nproc_per_node" and i + 1 < len(parts):
+            value = parts[i + 1]  # torchrun accepts the space-separated form too
+        else:
+            continue
+        return int(value) if value.isdigit() else None  # "gpu"/"auto"
     return None
 
 
@@ -195,9 +227,10 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
     os.environ["WORLD_SIZE"] = "1"
     os.environ["LOCAL_RANK"] = "0"
     if not dist.is_initialized():
-        os.environ.setdefault("MASTER_PORT", str(get_free_port()))
-        dist.setup()
-        torch.cuda.set_device(dist.local_rank())
+        # Not setdefault: another suite may have left a stale MASTER_PORT in the environment, and
+        # binding an occupied port blocks in rendezvous until timeout instead of failing fast.
+        os.environ["MASTER_PORT"] = str(get_free_port())
+        dist.setup()  # also sets the CUDA device
 
     script = next(p for p in cmd_parts if str(p).endswith(".py"))
     argv = [str(p) for p in cmd_parts[cmd_parts.index(script) :]]
@@ -208,10 +241,13 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
     try:
         module = _load_example_module(str(script), example_path)
         reset_megatron_global_state()  # a previous step left its own parallel state behind
-        with patch.object(sys, "argv", argv):
-            args = module.get_args()
         try:
-            with _capture_output() as native:
+            with _preserved_signal_handlers(), _capture_output() as native:
+                # Inside the guard: argparse calls parser.error() -> SystemExit on a flag that has
+                # drifted from the example's parser, which is the failure this suite most wants to
+                # report clearly rather than raise bare out of the runner.
+                with patch.object(sys, "argv", argv):
+                    args = module.get_args()
                 module.main(args)
         except SystemExit as e:
             if e.code not in (0, None):
@@ -242,15 +278,15 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
         # The rendezvous store now lives in a long-lived process, so do not rely on torchrun's
         # fixed default port being free by the time the next step starts.
         argv.insert(1, f"--master_port={get_free_port()}")
-    # PContext.start() installs its own handlers for these and never puts them back; with a
-    # subprocess launcher the process exit did that for us. Losing them would break pytest's
-    # Ctrl-C and CI cancellation handling for the rest of the session.
-    saved_handlers = {s: signal.getsignal(s) for s in _LAUNCHER_SIGNALS}
     cwd = os.getcwd()
     os.chdir(example_dir)
     cap = [""]
     try:
-        with _capture_output() as cap, patch.object(sys, "argv", argv):
+        with (
+            _preserved_signal_handlers(),
+            _capture_output() as cap,
+            patch.object(sys, "argv", argv),
+        ):
             torchrun_main()
         return cap[0]
     except BaseException as e:
@@ -259,8 +295,6 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
         e.captured_output = cap[0]
         raise
     finally:
-        for sig, handler in saved_handlers.items():
-            signal.signal(sig, handler)
         os.chdir(cwd)
 
 

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -255,8 +255,6 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
 
 def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
     """Run an example step without shelling out. ``None`` falls back to a subprocess."""
-    if os.environ.get("MODELOPT_NO_INPROCESS_EXAMPLES"):
-        return None
     script = next((str(p) for p in cmd_parts if str(p).endswith(".py")), None)
     if script is None:
         return None

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -21,7 +21,8 @@ commands drive ``torchrun`` itself in-process, which only saves the launcher's o
 pytest process cannot be more than one rank -- but keeps torchrun's fresh worker processes.
 
 The script's own ``get_args()`` still runs, so CLI flags and recipe strings stay covered. Not
-covered: the ``torchrun`` invocation and the ``__main__`` block (``dist.setup()``/``dist.abort()``).
+covered: the ``torchrun`` invocation and the ``__main__`` block (``dist.setup()``, ``dist.abort()``
+and ``dist.cleanup()``).
 
 Megatron and torch.distributed.run are imported lazily on purpose: this module is imported at
 collection time, and importing ``megatron.bridge`` initialises CUDA in the pytest process, which
@@ -52,14 +53,16 @@ _LAUNCHER_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUI
 
 
 @contextlib.contextmanager
-def _capture_output():
+def _capture_output(buf):
     """Capture what a step writes in this process, including lines from logging handlers.
 
     ``redirect_stdout`` alone misses them: Megatron-Bridge logs some lines that tests assert on
     through a logger rather than ``print``. stderr is redirected too, so the captured string
-    matches the subprocess path, which combines both streams.
+    matches the subprocess path, which combines both streams. Pair with :func:`_capture_output_fd`
+    for output written straight to fd 1/2, which rebinding ``sys.stdout`` cannot see.
+
+    The caller owns ``buf`` so that its content is still readable if this manager raises on entry.
     """
-    buf = io.StringIO()
     handler = logging.StreamHandler(buf)
     handler.setFormatter(logging.Formatter("%(message)s"))
     targets = [logging.getLogger()]
@@ -69,14 +72,14 @@ def _capture_output():
         if isinstance(lg, logging.Logger) and (lg.handlers or not lg.propagate)
     ]
     levels = {}
-    for lg in targets:
-        lg.addHandler(handler)
-        levels[lg] = lg.level
-        if lg.level > logging.INFO:
-            lg.setLevel(logging.INFO)
     try:
+        for lg in targets:
+            lg.addHandler(handler)
+            levels[lg] = lg.level
+            if lg.level > logging.INFO:
+                lg.setLevel(logging.INFO)
         with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-            yield buf
+            yield
     finally:
         for lg, level in levels.items():
             lg.removeHandler(handler)
@@ -196,24 +199,27 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
     example_dir = str(MODELOPT_ROOT / "examples" / example_path)
     cwd = os.getcwd()
     os.chdir(example_dir)  # match the subprocess path, which runs with the example dir as cwd
-    output = ""
+    buf, native = io.StringIO(), [""]  # bound up front: readable even if a capture fails to start
     try:
         module = _load_example_module(str(script), example_path)
         reset_megatron_global_state()  # a previous step left its own parallel state behind
         with patch.object(sys, "argv", argv):
             args = module.get_args()
         try:
-            with _capture_output() as buf:
+            with _capture_output_fd() as native, _capture_output(buf):
                 module.main(args)
         except SystemExit as e:
             if e.code not in (0, None):
                 raise RuntimeError(f"{script} exited with code {e.code}") from e
-        finally:
-            output = buf.getvalue()
-        return output
+        return buf.getvalue() + native[0]
+    except BaseException as e:
+        # The caller matches transient-HuggingFace markers on this; str(e) alone would not show
+        # a 503 raised deep inside the script.
+        e.captured_output = buf.getvalue() + native[0]
+        raise
     finally:
         os.chdir(cwd)
-        print(output)  # keep the script's output in the test log
+        print(buf.getvalue() + native[0])  # keep the script's output in the test log
 
 
 def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
@@ -244,6 +250,11 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
         with _capture_output_fd() as cap, patch.object(sys, "argv", argv):
             torchrun_main()
         return cap[0]
+    except BaseException as e:
+        # ChildFailedError only carries the worker's traceback when the entrypoint is decorated
+        # with @record, which the examples are not -- so the captured output is all the caller has.
+        e.captured_output = cap[0]
+        raise
     finally:
         for sig, handler in saved_handlers.items():
             signal.signal(sig, handler)

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -33,17 +33,16 @@ import contextlib
 import gc
 import importlib
 import importlib.util
-import io
 import logging
 import os
 import signal
 import sys
-import tempfile
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
 import torch
-from _test_utils.examples.run_command import MODELOPT_ROOT
+from _test_utils.examples.run_command import _ORPHAN_PIPE_TIMEOUT_S, MODELOPT_ROOT
 from _test_utils.torch.distributed.utils import get_free_port
 
 import modelopt.torch.utils.distributed as dist
@@ -53,64 +52,70 @@ _LAUNCHER_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUI
 
 
 @contextlib.contextmanager
-def _capture_output(buf):
-    """Capture what a step writes in this process, including lines from logging handlers.
+def _capture_output():
+    """Capture everything a step emits, as one ordered stream, while still streaming it live.
 
-    ``redirect_stdout`` alone misses them: Megatron-Bridge logs some lines that tests assert on
-    through a logger rather than ``print``. stderr is redirected too, so the captured string
-    matches the subprocess path, which combines both streams. Pair with :func:`_capture_output_fd`
-    for output written straight to fd 1/2, which rebinding ``sys.stdout`` cannot see.
+    Three sources have to end up in the same place: ``print`` from the script, records from loggers
+    Megatron-Bridge uses for lines tests assert on, and fd-level writes from ``torchrun`` workers
+    and C extensions. Under pytest's fd capture ``sys.stdout``/``sys.stderr`` are objects over
+    pytest's own temp file rather than fds 1/2, so both a redirect and an fd swap are needed.
 
-    The caller owns ``buf`` so that its content is still readable if this manager raises on entry.
-    """
-    handler = logging.StreamHandler(buf)
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    targets = [logging.getLogger()]
-    targets += [
-        lg
-        for lg in logging.root.manager.loggerDict.values()
-        if isinstance(lg, logging.Logger) and (lg.handlers or not lg.propagate)
-    ]
-    levels = {}
-    try:
-        for lg in targets:
-            lg.addHandler(handler)
-            levels[lg] = lg.level
-            if lg.level > logging.INFO:
-                lg.setLevel(logging.INFO)
-        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-            yield
-    finally:
-        for lg, level in levels.items():
-            lg.removeHandler(handler)
-            lg.setLevel(level)
-
-
-@contextlib.contextmanager
-def _capture_output_fd():
-    """Capture at the file-descriptor level, for output this process does not itself produce.
-
-    ``torchrun``'s workers are separate processes writing to the inherited fds, so Python-level
-    redirection cannot see them.
+    Tee rather than buffer: a job-level timeout SIGKILLs the runner without running any ``finally``,
+    and that is exactly when the log is wanted.
     """
     holder = [""]
-    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as tmp:
+    chunks: list[str] = []
+    read_fd, write_fd = os.pipe()
+    live = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # the fd we do not touch
+
+    def _drain():
+        with os.fdopen(read_fd, "r", errors="replace") as pipe:
+            for line in pipe:
+                live.write(line)
+                chunks.append(line)
+
+    reader = threading.Thread(target=_drain, daemon=True)
+    reader.start()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_out, saved_err = os.dup(1), os.dup(2)
+    os.dup2(write_fd, 1)
+    os.dup2(write_fd, 2)
+    sink = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")  # now the pipe
+    handler = logging.StreamHandler(sink)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root = logging.getLogger()
+    others = [lg for lg in root.manager.loggerDict.values() if isinstance(lg, logging.Logger)]
+    # Lower levels only for loggers that own their output; doing it for every logger switches on
+    # torch dynamo/inductor INFO and floods the pipe, which cost the 1-GPU suite 3m43 -> 9m01.
+    # A propagating logger still needs its own level lowered, or it drops the record before root.
+    levels = {lg: lg.level for lg in [root, *others] if lg.handlers or not lg.propagate}
+    # Attach the handler only where the record cannot reach root, or it is written twice.
+    handled = [root, *(lg for lg in others if not lg.propagate)]
+    try:
+        for lg in levels:
+            if lg.level > logging.INFO:
+                lg.setLevel(logging.INFO)
+        for lg in handled:
+            lg.addHandler(handler)
+        with contextlib.redirect_stdout(sink), contextlib.redirect_stderr(sink):
+            yield holder
+    finally:
+        for lg in handled:
+            lg.removeHandler(handler)
+        for lg, level in levels.items():
+            lg.setLevel(level)
+        sink.close()
         sys.stdout.flush()
         sys.stderr.flush()
-        saved_out, saved_err = os.dup(1), os.dup(2)
-        os.dup2(tmp.fileno(), 1)
-        os.dup2(tmp.fileno(), 2)
-        try:
-            yield holder
-        finally:
-            sys.stdout.flush()
-            sys.stderr.flush()
-            os.dup2(saved_out, 1)
-            os.dup2(saved_err, 2)
-            os.close(saved_out)
-            os.close(saved_err)
-            tmp.seek(0)
-            holder[0] = tmp.read()
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_out)
+        os.close(saved_err)
+        os.close(write_fd)  # EOF for the reader
+        reader.join(_ORPHAN_PIPE_TIMEOUT_S)  # bounded: an orphan may still hold the pipe
+        live.close()
+        holder[0] = "".join(chunks)
 
 
 def reset_megatron_global_state() -> None:
@@ -199,27 +204,25 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
     example_dir = str(MODELOPT_ROOT / "examples" / example_path)
     cwd = os.getcwd()
     os.chdir(example_dir)  # match the subprocess path, which runs with the example dir as cwd
-    buf, native = io.StringIO(), [""]  # bound up front: readable even if a capture fails to start
+    native = [""]  # bound up front: readable even if the capture fails to start
     try:
         module = _load_example_module(str(script), example_path)
         reset_megatron_global_state()  # a previous step left its own parallel state behind
         with patch.object(sys, "argv", argv):
             args = module.get_args()
         try:
-            with _capture_output_fd() as native, _capture_output(buf):
+            with _capture_output() as native:
                 module.main(args)
         except SystemExit as e:
             if e.code not in (0, None):
                 raise RuntimeError(f"{script} exited with code {e.code}") from e
-        return buf.getvalue() + native[0]
+        return native[0]
     except BaseException as e:
-        # The caller matches transient-HuggingFace markers on this; str(e) alone would not show
-        # a 503 raised deep inside the script.
-        e.captured_output = buf.getvalue() + native[0]
+        # The caller matches transient-HuggingFace markers on this alongside the traceback.
+        e.captured_output = native[0]
         raise
     finally:
         os.chdir(cwd)
-        print(buf.getvalue() + native[0])  # keep the script's output in the test log
 
 
 def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
@@ -247,7 +250,7 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
     os.chdir(example_dir)
     cap = [""]
     try:
-        with _capture_output_fd() as cap, patch.object(sys, "argv", argv):
+        with _capture_output() as cap, patch.object(sys, "argv", argv):
             torchrun_main()
         return cap[0]
     except BaseException as e:
@@ -259,7 +262,6 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
         for sig, handler in saved_handlers.items():
             signal.signal(sig, handler)
         os.chdir(cwd)
-        print(cap[0])
 
 
 def run_example_step(cmd_parts: list[str], example_path: str) -> str:

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -47,6 +47,22 @@ from _test_utils.torch.distributed.utils import get_free_port
 
 import modelopt.torch.utils.distributed as dist
 
+_SINK = None  # never closed: a handler built inside a capture keeps a reference to it
+
+
+def _sink():
+    """One long-lived stream on the real stdout, whose fd is redirected per step.
+
+    A per-step stream closed on exit would leave a permanently-closed file behind for anything that
+    captured it -- e.g. the common module-level ``logging.StreamHandler(sys.stdout)``, where
+    ``sys.stdout`` is this sink while a step runs and the handler outlives it in ``sys.modules``.
+    """
+    global _SINK
+    if _SINK is None:
+        _SINK = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")
+    return _SINK
+
+
 # torchrun's PContext installs handlers for these and never restores them.
 _LAUNCHER_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT)
 
@@ -75,20 +91,24 @@ def _capture_output():
                 lg for lg in root.manager.loggerDict.values() if isinstance(lg, logging.Logger)
             ]
         # Lower levels only for loggers that own their output: a propagating logger still needs its
-        # own level lowered, or it drops the record before root sees it.
+        # own level lowered, or it drops the record before root sees it. The boost is load-bearing:
+        # without it test_distill_validate_only cannot see "skipping training ...". It does mean the
+        # capture is a superset of what a torchrun user sees, so these assertions check that the
+        # step did the right work, not that its logging is user-visible.
         levels = {lg: lg.level for lg in [root, *others] if lg.handlers or not lg.propagate}
         # Attach the handler only where the record cannot reach root, or it is written twice.
         handled = [root, *(lg for lg in others if not lg.propagate)]
         sys.stdout.flush()
         sys.stderr.flush()
-        saved_out, saved_err = os.dup(1), os.dup(2)
-        sink = None
+        sink = _sink()  # before the swap, so it holds the real stdout
+        saved_out, saved_err, saved_sink = os.dup(1), os.dup(2), os.dup(sink.fileno())
         try:
             # Inside the try: a raise between here and the restore would otherwise leave fds 1/2
             # pointing at a temp file the ``with`` then closes, silencing the rest of the session.
             os.dup2(tmp.fileno(), 1)
             os.dup2(tmp.fileno(), 2)
-            sink = os.fdopen(os.dup(1), "w", buffering=1, errors="replace")
+            sink.flush()
+            os.dup2(tmp.fileno(), sink.fileno())  # move its fd rather than replacing the object
             handler.setStream(sink)
             for lg in levels:
                 if lg.level > logging.INFO:
@@ -102,8 +122,9 @@ def _capture_output():
                 lg.removeHandler(handler)
             for lg, level in levels.items():
                 lg.setLevel(level)
-            if sink is not None:
-                sink.close()
+            sink.flush()
+            os.dup2(saved_sink, sink.fileno())
+            os.close(saved_sink)
             sys.stdout.flush()
             sys.stderr.flush()
             os.dup2(saved_out, 1)
@@ -228,12 +249,16 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
         module = _load_example_module(str(script), example_path)
         reset_megatron_global_state()  # a previous step left its own parallel state behind
         try:
-            with _preserved_signal_handlers(), _capture_output() as native:
-                # Inside the guard: argparse calls parser.error() -> SystemExit on a flag that has
-                # drifted from the example's parser, which is the failure this suite most wants to
-                # report clearly rather than raise bare out of the runner.
-                with patch.object(sys, "argv", argv):
-                    args = module.get_args()
+            # get_args() inside the guard: argparse calls parser.error() -> SystemExit on a flag
+            # that has drifted from the example's parser, which is the failure this suite most
+            # wants to report clearly rather than raise bare out of the runner. argv stays patched
+            # across main() as well, which the subprocess path had.
+            with (
+                _preserved_signal_handlers(),
+                _capture_output() as native,
+                patch.object(sys, "argv", argv),
+            ):
+                args = module.get_args()
                 module.main(args)
         except SystemExit as e:
             if e.code not in (0, None):
@@ -257,6 +282,7 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
     """
     from torch.distributed.run import main as torchrun_main
 
+    reset_megatron_global_state()  # release device 0 before the workers claim it
     example_dir = MODELOPT_ROOT / "examples" / example_path
     script = next(p for p in cmd_parts if str(p).endswith(".py"))
     argv = [str(p) for p in cmd_parts]

--- a/tests/_test_utils/examples/megatron_example_runner.py
+++ b/tests/_test_utils/examples/megatron_example_runner.py
@@ -38,7 +38,6 @@ import os
 import signal
 import sys
 import tempfile
-import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -161,14 +160,13 @@ def _load_example_module(script: str, example_path: str):
     return module
 
 
-def _drivable(script: str, example_path: str) -> bool:
-    """Whether the script exposes the ``get_args()`` + ``main()`` shape this runner drives."""
-    try:
-        module = _load_example_module(script, example_path)
-    except Exception as e:
-        warnings.warn(f"{script} is not drivable in-process ({e!r}); falling back to torchrun")
-        return False
-    return callable(getattr(module, "get_args", None)) and callable(getattr(module, "main", None))
+def _require_drivable(script: str, example_path: str) -> None:
+    """Check the script exposes the ``get_args()`` + ``main()`` shape this runner drives."""
+    module = _load_example_module(script, example_path)
+    if not callable(getattr(module, "get_args", None)) or not callable(
+        getattr(module, "main", None)
+    ):
+        raise AssertionError(f"{script} must define get_args() and main(args)")
 
 
 def requested_world_size(cmd_parts: list[str]) -> int | None:
@@ -253,17 +251,22 @@ def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
         print(cap[0])
 
 
-def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
-    """Run an example step without shelling out. ``None`` falls back to a subprocess."""
+def run_example_step(cmd_parts: list[str], example_path: str) -> str:
+    """Run an example step without shelling out.
+
+    Every step must be ``torchrun --nproc_per_node=<int> <script>.py``, with the script exposing
+    ``get_args()`` + ``main()``. Anything else raises: falling back to a subprocess would still
+    pass, only ~6x slower, so a step that breaks the convention has to fail instead of quietly
+    costing the suite its speed-up.
+    """
     script = next((str(p) for p in cmd_parts if str(p).endswith(".py")), None)
     if script is None:
-        return None
+        raise AssertionError(f"step must invoke a .py script: {cmd_parts}")
     world_size = requested_world_size(cmd_parts)
     if world_size is None:
-        return None
+        raise AssertionError(f"--nproc_per_node must be a plain integer: {cmd_parts}")
     if world_size > 1:
         # torchrun imports the script in fresh children, so get_args()/main() need not exist here.
         return run_torchrun_in_process(cmd_parts, example_path)
-    if _drivable(script, example_path):
-        return run_example_in_process(cmd_parts, example_path)
-    return None
+    _require_drivable(script, example_path)
+    return run_example_in_process(cmd_parts, example_path)

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -168,11 +168,9 @@ def run_example_command(
 
     for attempt in range(hf_max_retries + 1):
         if setup_free_port:
-            # env is a copy, so an in-process runner reading os.environ would not see it.
-            port = str(get_free_port())  # fresh port per attempt
-            env["MASTER_PORT"] = port
-            if in_process is not None:
-                os.environ["MASTER_PORT"] = port
+            # Subprocess steps only: an in-process runner picks its own free port, since env is a
+            # copy it never sees.
+            env["MASTER_PORT"] = str(get_free_port())  # fresh port per attempt
         if in_process is not None:
             # Inside the loop so in-process steps get the same transient-HuggingFace retries;
             # these tests do hit the Hub (e.g. calib_dataset_name="cnn_dailymail").

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -168,7 +168,11 @@ def run_example_command(
 
     for attempt in range(hf_max_retries + 1):
         if setup_free_port:
-            env["MASTER_PORT"] = str(get_free_port())  # fresh port per attempt
+            # env is a copy, so an in-process runner reading os.environ would not see it.
+            port = str(get_free_port())  # fresh port per attempt
+            env["MASTER_PORT"] = port
+            if in_process is not None:
+                os.environ["MASTER_PORT"] = port
         if in_process is not None:
             # Inside the loop so in-process steps get the same transient-HuggingFace retries;
             # these tests do hit the Hub (e.g. calib_dataset_name="cnn_dailymail").

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -162,7 +162,7 @@ def run_example_command(
         # The in-process runner uses the ambient environment, so a caller-supplied env would be
         # silently dropped. Fall back to a subprocess rather than run with the wrong environment.
         warnings.warn(f"[{example_path}] env= given; running this step as a subprocess")
-    env = env or os.environ.copy()
+    env = os.environ.copy() if env is None else env
     cwd = MODELOPT_ROOT / "examples" / example_path
 
     for attempt in range(hf_max_retries + 1):

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -176,7 +176,10 @@ def run_example_command(
             except Exception as e:
                 # Re-raise unless it looks transient, so a real failure keeps its traceback
                 # instead of being flattened into CalledProcessError.
-                text = f"{type(e).__name__}: {e}"
+                # An in-process runner attaches what the step printed; the marker is usually
+                # there rather than in str(e), which may be only a launcher-level failure table.
+                captured = getattr(e, "captured_output", "")
+                text = f"{type(e).__name__}: {e}\n{captured}"
                 if attempt == hf_max_retries or not any(
                     marker in text for marker in _HF_TRANSIENT_MARKERS
                 ):

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -157,22 +157,43 @@ def run_example_command(
 ) -> str | None:
     """Run an example command, retrying transient HuggingFace access errors."""
     print(f"[{example_path}] Running command: {cmd_parts}")
-    if _in_process_runner is not None:
-        output = _in_process_runner(cmd_parts, example_path)
-        if output is not None:
-            return output
+    in_process = _in_process_runner if env is None else None
+    if _in_process_runner is not None and env is not None:
+        # The in-process runner uses the ambient environment, so a caller-supplied env would be
+        # silently dropped. Fall back to a subprocess rather than run with the wrong environment.
+        warnings.warn(f"[{example_path}] env= given; running this step as a subprocess")
     env = env or os.environ.copy()
     cwd = MODELOPT_ROOT / "examples" / example_path
 
     for attempt in range(hf_max_retries + 1):
         if setup_free_port:
             env["MASTER_PORT"] = str(get_free_port())  # fresh port per attempt
-        returncode, output = _run_capturing(cmd_parts, cwd, env)
+        if in_process is not None:
+            # Inside the loop so in-process steps get the same transient-HuggingFace retries;
+            # these tests do hit the Hub (e.g. calib_dataset_name="cnn_dailymail").
+            try:
+                result = in_process(cmd_parts, example_path)
+            except Exception as e:
+                # Re-raise unless it looks transient, so a real failure keeps its traceback
+                # instead of being flattened into CalledProcessError.
+                text = f"{type(e).__name__}: {e}"
+                if attempt == hf_max_retries or not any(
+                    marker in text for marker in _HF_TRANSIENT_MARKERS
+                ):
+                    raise
+                returncode, output = 1, text
+            else:
+                if result is not None:
+                    return result
+                in_process = None  # not drivable in-process; use the subprocess path
+                returncode, output = _run_capturing(cmd_parts, cwd, env)
+        else:
+            returncode, output = _run_capturing(cmd_parts, cwd, env)
         if returncode == 0:
             return output
         transient = any(marker in output for marker in _HF_TRANSIENT_MARKERS)
         if not transient or attempt == hf_max_retries:
-            raise subprocess.CalledProcessError(returncode, cmd_parts)
+            raise subprocess.CalledProcessError(returncode, cmd_parts, output=output)
         warnings.warn(
             f"[{example_path}] transient HuggingFace access error; retrying in "
             f"{hf_retry_delay_s}s (attempt {attempt + 1}/{hf_max_retries})"

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -137,7 +137,7 @@ def _run_capturing(cmd_parts: list[str], cwd: Path, env: dict[str, str]) -> tupl
 
 
 # Set by a suite's conftest to run a command without spawning a subprocess (see
-# ``_test_utils.torch.megatron.example_runner``). ``None`` means always use a subprocess.
+# ``_test_utils.examples.megatron_example_runner``). ``None`` means always use a subprocess.
 _in_process_runner = None
 
 

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -20,6 +20,7 @@ import signal
 import subprocess
 import threading
 import time
+import traceback
 import warnings
 from pathlib import Path
 
@@ -137,12 +138,12 @@ def _run_capturing(cmd_parts: list[str], cwd: Path, env: dict[str, str]) -> tupl
 
 
 # Set by a suite's conftest to run a command without spawning a subprocess (see
-# ``_test_utils.examples.megatron_example_runner``). ``None`` means always use a subprocess.
+# ``_test_utils.examples.megatron_example_runner``). Unset means always use a subprocess.
 _in_process_runner = None
 
 
 def set_in_process_runner(runner) -> None:
-    """Register ``runner(cmd_parts, example_path) -> str | None``; ``None`` result falls through."""
+    """Register ``runner(cmd_parts, example_path) -> str``; it must not fall back to a subprocess."""
     global _in_process_runner
     _in_process_runner = runner
 
@@ -176,20 +177,20 @@ def run_example_command(
             except Exception as e:
                 # Re-raise unless it looks transient, so a real failure keeps its traceback
                 # instead of being flattened into CalledProcessError.
-                # An in-process runner attaches what the step printed; the marker is usually
-                # there rather than in str(e), which may be only a launcher-level failure table.
+                # format_exc() walks __cause__/__context__: most markers are exception type
+                # names that only ever appear in a formatted traceback, never in str(e) -- a Hub
+                # ConnectionError typically surfaces wrapped in a DatasetGenerationError. The
+                # runner also attaches what the step printed, for launcher-level failures.
                 captured = getattr(e, "captured_output", "")
-                text = f"{type(e).__name__}: {e}\n{captured}"
+                text = f"{traceback.format_exc()}\n{captured}"
                 if attempt == hf_max_retries or not any(
                     marker in text for marker in _HF_TRANSIENT_MARKERS
                 ):
                     raise
                 returncode, output = 1, text
             else:
-                if result is not None:
-                    return result
-                in_process = None  # not drivable in-process; use the subprocess path
-                returncode, output = _run_capturing(cmd_parts, cwd, env)
+                assert result is not None, "an in-process runner must return output, not fall back"
+                return result
         else:
             returncode, output = _run_capturing(cmd_parts, cwd, env)
         if returncode == 0:

--- a/tests/_test_utils/examples/run_command.py
+++ b/tests/_test_utils/examples/run_command.py
@@ -136,6 +136,17 @@ def _run_capturing(cmd_parts: list[str], cwd: Path, env: dict[str, str]) -> tupl
     return returncode, "".join(chunks)
 
 
+# Set by a suite's conftest to run a command without spawning a subprocess (see
+# ``_test_utils.torch.megatron.example_runner``). ``None`` means always use a subprocess.
+_in_process_runner = None
+
+
+def set_in_process_runner(runner) -> None:
+    """Register ``runner(cmd_parts, example_path) -> str | None``; ``None`` result falls through."""
+    global _in_process_runner
+    _in_process_runner = runner
+
+
 def run_example_command(
     cmd_parts: list[str],
     example_path: str,
@@ -146,6 +157,10 @@ def run_example_command(
 ) -> str | None:
     """Run an example command, retrying transient HuggingFace access errors."""
     print(f"[{example_path}] Running command: {cmd_parts}")
+    if _in_process_runner is not None:
+        output = _in_process_runner(cmd_parts, example_path)
+        if output is not None:
+            return output
     env = env or os.environ.copy()
     cwd = MODELOPT_ROOT / "examples" / example_path
 

--- a/tests/_test_utils/torch/megatron/example_runner.py
+++ b/tests/_test_utils/torch/megatron/example_runner.py
@@ -12,55 +12,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Run ``examples/megatron_bridge`` scripts in-process instead of via ``torchrun``.
+"""Run ``examples/megatron_bridge`` scripts without a ``torchrun`` launch per step.
 
-A ``torchrun`` launch spends ~25s importing torch/megatron/modelopt before doing any work, and one
-example test runs several. Driving the script's ``main()`` in the pytest process instead takes the
-full suite from ~26min to ~4min on one GPU.
+A launch spends ~25s importing torch/megatron/modelopt before doing any work, and one example test
+runs several. Single-rank commands drive the script's ``main()`` directly in the pytest process,
+which is where that cost disappears (the suite goes from ~21min to ~4min on one GPU). Multi-rank
+commands drive ``torchrun`` itself in-process, which only saves the launcher's own imports -- the
+pytest process cannot be more than one rank -- but keeps torchrun's fresh worker processes.
 
 The script's own ``get_args()`` still runs, so CLI flags and recipe strings stay covered. Not
 covered: the ``torchrun`` invocation and the ``__main__`` block (``dist.setup()``/``dist.abort()``).
-Multi-rank commands are left alone -- the pytest process is a single rank.
+
+Megatron and torch.distributed.run are imported lazily on purpose: this module is imported at
+collection time, and importing ``megatron.bridge`` initialises CUDA in the pytest process, which
+would hold a context on device 0 for the whole session even when every step runs under torchrun.
 """
 
 import contextlib
 import gc
 import importlib
+import importlib.util
 import io
 import logging
 import os
+import signal
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
 import torch
 from _test_utils.examples.run_command import MODELOPT_ROOT
 from _test_utils.torch.distributed.utils import get_free_port
-from megatron.bridge.training.config import CheckpointConfig
-from megatron.core import parallel_state
-from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue
-from megatron.core.rerun_state_machine import destroy_rerun_state_machine
-from torch.distributed.run import main as torchrun_main
 
 import modelopt.torch.utils.distributed as dist
 
-
-def _use_spawn_for_async_checkpointing() -> None:
-    """Stop async checkpoint saving from forking a process that already owns CUDA/NCCL.
-
-    ``CheckpointConfig.async_write_results_mp_mode`` defaults to ``"fork"``. Under ``torchrun`` that
-    is fine -- the fork happens in a fresh process. Reusing a worker means the fork happens after
-    CUDA and NCCL are initialised, and it deadlocks: the manager server reaches ``serve_forever``
-    while the caller never returns from ``get_write_results_queue``. Confirmed with py-spy.
-    """
-    with contextlib.suppress(Exception):
-        CheckpointConfig.async_write_results_mp_mode = "spawn"
+# torchrun's PContext installs handlers for these and never restores them.
+_LAUNCHER_SIGNALS = (signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT)
 
 
 @contextlib.contextmanager
 def _capture_output():
-    """Capture what a step writes here, including lines emitted through logging handlers."""
+    """Capture what a step writes in this process, including lines from logging handlers.
+
+    ``redirect_stdout`` alone misses them: Megatron-Bridge logs some lines that tests assert on
+    through a logger rather than ``print``. stderr is redirected too, so the captured string
+    matches the subprocess path, which combines both streams.
+    """
     buf = io.StringIO()
     handler = logging.StreamHandler(buf)
     handler.setFormatter(logging.Formatter("%(message)s"))
@@ -77,7 +76,7 @@ def _capture_output():
         if lg.level > logging.INFO:
             lg.setLevel(logging.INFO)
     try:
-        with contextlib.redirect_stdout(buf):
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
             yield buf
     finally:
         for lg, level in levels.items():
@@ -87,10 +86,10 @@ def _capture_output():
 
 @contextlib.contextmanager
 def _capture_output_fd():
-    """Capture at the file-descriptor level, for use inside a worker process.
+    """Capture at the file-descriptor level, for output this process does not itself produce.
 
-    Loggers configured *during* the step (Megatron-Bridge sets its own up in ``setup()``) are
-    invisible to handlers installed beforehand, so the in-process approach misses them here.
+    ``torchrun``'s workers are separate processes writing to the inherited fds, so Python-level
+    redirection cannot see them.
     """
     holder = [""]
     with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as tmp:
@@ -113,24 +112,21 @@ def _capture_output_fd():
 
 
 def reset_megatron_global_state() -> None:
-    """Drop the global state a finished example step leaves behind.
+    """Drop the global state a finished single-rank step leaves behind.
 
-    Steps share one interpreter, so anything global has to be put back or it leaks into the next
-    test. Failure-tolerant on purpose: this also runs after a failed step, where the model may be
-    half-built, and it must not mask the error that got us here.
+    Steps that run here share one interpreter, so anything global has to be put back or it leaks
+    into the next test. Failure-tolerant on purpose: this also runs after a failed step, where the
+    model may be half-built, and it must not mask the error that got us here.
     """
     with contextlib.suppress(Exception):
+        from megatron.core import parallel_state
+
         parallel_state.destroy_model_parallel()
     with contextlib.suppress(Exception):
         # A separate singleton from the parallel state, initialised by the training path.
+        from megatron.core.rerun_state_machine import destroy_rerun_state_machine
+
         destroy_rerun_state_machine()
-    with contextlib.suppress(Exception):
-        # The async checkpoint worker is a *class-level* singleton, so it outlives the step that
-        # started it and the next one inherits a stale process. Under torchrun the process exits
-        # and takes it with it; a reused worker has to close it explicitly.
-        if AsyncCallsQueue._persistent_caller is not None:
-            AsyncCallsQueue._persistent_caller.close(abort=True)
-            AsyncCallsQueue._persistent_caller = None
     with contextlib.suppress(Exception):
         # Collect first: empty_cache() only returns blocks nothing references, and a finished step
         # can leave its model reachable from the imported module. Without this a later test ran
@@ -140,25 +136,71 @@ def reset_megatron_global_state() -> None:
             torch.cuda.empty_cache()
 
 
+def _load_example_module(script: str, example_path: str):
+    """Import an example script under a namespaced module name.
+
+    ``import_module("quantize")`` would consult ``sys.modules`` first and could pick up an
+    unrelated top-level module of the same name, and would leave the example cached under a
+    generic name.
+    """
+    example_dir = str(MODELOPT_ROOT / "examples" / example_path)
+    name = f"_modelopt_example_{example_path.replace('/', '_')}_{Path(script).stem}"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, Path(example_dir) / Path(script).name)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    sys.path.insert(0, example_dir)  # the script's own sibling imports
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        del sys.modules[name]
+        raise
+    finally:
+        sys.path.remove(example_dir)
+    return module
+
+
+def _drivable(script: str, example_path: str) -> bool:
+    """Whether the script exposes the ``get_args()`` + ``main()`` shape this runner drives."""
+    try:
+        module = _load_example_module(script, example_path)
+    except Exception as e:
+        warnings.warn(f"{script} is not drivable in-process ({e!r}); falling back to torchrun")
+        return False
+    return callable(getattr(module, "get_args", None)) and callable(getattr(module, "main", None))
+
+
+def requested_world_size(cmd_parts: list[str]) -> int | None:
+    """World size a ``torchrun`` command asks for, or ``None`` if it is not a plain integer."""
+    for part in cmd_parts:
+        if str(part).startswith("--nproc_per_node="):
+            value = str(part).split("=", 1)[1]
+            return int(value) if value.isdigit() else None  # "gpu"/"auto": keep torchrun
+    return None
+
+
 def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
-    """Drive an example script's real ``get_args()`` + ``main()`` here. Returns its stdout."""
+    """Drive a single-rank step's real ``get_args()`` + ``main()`` here. Returns its stdout."""
+    # Set unconditionally: the per-test environment restore drops these while the process group
+    # stays initialised, so a later step would otherwise run with a live group and no launch vars.
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ["RANK"] = "0"
+    os.environ["WORLD_SIZE"] = "1"
+    os.environ["LOCAL_RANK"] = "0"
     if not dist.is_initialized():
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
         os.environ.setdefault("MASTER_PORT", str(get_free_port()))
-        os.environ.setdefault("RANK", "0")
-        os.environ.setdefault("WORLD_SIZE", "1")
-        os.environ.setdefault("LOCAL_RANK", "0")
         dist.setup()
         torch.cuda.set_device(dist.local_rank())
 
-    _use_spawn_for_async_checkpointing()
     script = next(p for p in cmd_parts if str(p).endswith(".py"))
     argv = [str(p) for p in cmd_parts[cmd_parts.index(script) :]]
     example_dir = str(MODELOPT_ROOT / "examples" / example_path)
-    sys.path.insert(0, example_dir)
+    cwd = os.getcwd()
+    os.chdir(example_dir)  # match the subprocess path, which runs with the example dir as cwd
     output = ""
     try:
-        module = importlib.import_module(Path(script).stem)
+        module = _load_example_module(str(script), example_path)
         reset_megatron_global_state()  # a previous step left its own parallel state behind
         with patch.object(sys, "argv", argv):
             args = module.get_args()
@@ -172,58 +214,43 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
             output = buf.getvalue()
         return output
     finally:
-        sys.path.remove(example_dir)
+        os.chdir(cwd)
         print(output)  # keep the script's output in the test log
-
-
-def requested_world_size(cmd_parts: list[str]) -> int | None:
-    """World size a ``torchrun`` command asks for, if it says."""
-    for part in cmd_parts:
-        if str(part).startswith("--nproc_per_node="):
-            return int(str(part).split("=", 1)[1])
-    return None
 
 
 def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
     """Drive ``torchrun`` itself in-process, letting it spawn fresh workers as usual.
 
-    Used for multi-rank steps, where the pytest process cannot be more than one rank. This only
-    saves the launcher's own interpreter, not the workers' imports, but the workers are fresh
-    processes -- so none of the global state a reused worker would inherit applies here. Borrowed
-    from Megatron-Bridge's own functional tests.
+    Used for multi-rank steps. Only the launcher's imports are saved, but the workers are fresh
+    processes, so none of the global state a reused process would inherit applies. Borrowed from
+    Megatron-Bridge's own functional tests.
     """
+    from torch.distributed.run import main as torchrun_main
+
     example_dir = MODELOPT_ROOT / "examples" / example_path
     script = next(p for p in cmd_parts if str(p).endswith(".py"))
     argv = [str(p) for p in cmd_parts]
     argv[argv.index(str(script))] = str(example_dir / Path(script).name)
+    if not any(a.startswith(("--master_port", "--master-port")) for a in argv):
+        # The rendezvous store now lives in a long-lived process, so do not rely on torchrun's
+        # fixed default port being free by the time the next step starts.
+        argv.insert(1, f"--master_port={get_free_port()}")
+    # PContext.start() installs its own handlers for these and never puts them back; with a
+    # subprocess launcher the process exit did that for us. Losing them would break pytest's
+    # Ctrl-C and CI cancellation handling for the rest of the session.
+    saved_handlers = {s: signal.getsignal(s) for s in _LAUNCHER_SIGNALS}
     cwd = os.getcwd()
     os.chdir(example_dir)
+    cap = [""]
     try:
         with _capture_output_fd() as cap, patch.object(sys, "argv", argv):
             torchrun_main()
         return cap[0]
     finally:
+        for sig, handler in saved_handlers.items():
+            signal.signal(sig, handler)
         os.chdir(cwd)
         print(cap[0])
-
-
-def _drivable(script: str, example_path: str) -> bool:
-    """Whether the script exposes the ``get_args()`` + ``main()`` shape this runner drives.
-
-    Duck-typed rather than an allowlist so a new script needs no bookkeeping, and one that does not
-    follow the convention (``generate_vllm.py`` has no ``get_args``) simply keeps using torchrun.
-    """
-    example_dir = str(MODELOPT_ROOT / "examples" / example_path)
-    sys.path.insert(0, example_dir)
-    try:
-        module = importlib.import_module(Path(script).stem)
-        return callable(getattr(module, "get_args", None)) and callable(
-            getattr(module, "main", None)
-        )
-    except Exception:
-        return False
-    finally:
-        sys.path.remove(example_dir)
 
 
 def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
@@ -231,11 +258,14 @@ def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
     if os.environ.get("MODELOPT_NO_INPROCESS_EXAMPLES"):
         return None
     script = next((str(p) for p in cmd_parts if str(p).endswith(".py")), None)
-    if script is None or not _drivable(script, example_path):
+    if script is None:
         return None
     world_size = requested_world_size(cmd_parts)
-    if world_size == 1:
-        return run_example_in_process(cmd_parts, example_path)
-    if world_size and world_size > 1:
+    if world_size is None:
+        return None
+    if world_size > 1:
+        # torchrun imports the script in fresh children, so get_args()/main() need not exist here.
         return run_torchrun_in_process(cmd_parts, example_path)
+    if _drivable(script, example_path):
+        return run_example_in_process(cmd_parts, example_path)
     return None

--- a/tests/_test_utils/torch/megatron/example_runner.py
+++ b/tests/_test_utils/torch/megatron/example_runner.py
@@ -31,7 +31,6 @@ import logging
 import os
 import sys
 import tempfile
-from functools import partial
 from pathlib import Path
 from unittest.mock import patch
 
@@ -42,6 +41,7 @@ from megatron.bridge.training.config import CheckpointConfig
 from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue
 from megatron.core.rerun_state_machine import destroy_rerun_state_machine
+from torch.distributed.run import main as torchrun_main
 
 import modelopt.torch.utils.distributed as dist
 
@@ -176,18 +176,6 @@ def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
         print(output)  # keep the script's output in the test log
 
 
-# --- Multi-rank dispatch ---------------------------------------------------------------------
-# The pytest process is a single rank, so a command asking for N>1 ranks cannot run in-process.
-# A pool of persistent workers gives real ranks while still paying the import cost once.
-_pool_provider = None
-
-
-def set_worker_pool_provider(provider) -> None:
-    """Register ``provider(world_size) -> DistributedWorkerPool | None``."""
-    global _pool_provider
-    _pool_provider = provider
-
-
 def requested_world_size(cmd_parts: list[str]) -> int | None:
     """World size a ``torchrun`` command asks for, if it says."""
     for part in cmd_parts:
@@ -196,60 +184,27 @@ def requested_world_size(cmd_parts: list[str]) -> int | None:
     return None
 
 
-def _reinit_process_group(rank: int, world_size: int, master_port: int) -> None:
-    """Give the step a fresh process group, as a ``torchrun`` launch would.
+def run_torchrun_in_process(cmd_parts: list[str], example_path: str) -> str:
+    """Drive ``torchrun`` itself in-process, letting it spawn fresh workers as usual.
 
-    Megatron-Bridge tears down what it calls framework-owned distributed resources when a run ends
-    ("Bridge is aborting framework-owned distributed resources..."), which includes the pool's own
-    group. The next step then finds a dead group and its rendezvous is refused. Persistent
-    *processes* are what save the import cost; the group itself is cheap to rebuild per step.
+    Used for multi-rank steps, where the pytest process cannot be more than one rank. This only
+    saves the launcher's own interpreter, not the workers' imports, but the workers are fresh
+    processes -- so none of the global state a reused worker would inherit applies here. Borrowed
+    from Megatron-Bridge's own functional tests.
     """
-    if world_size <= 1:
-        return
-    with contextlib.suppress(Exception):
-        if dist.is_initialized():
-            torch.distributed.destroy_process_group()
-    os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "127.0.0.1")
-    os.environ["MASTER_PORT"] = str(master_port)
-    os.environ["RANK"] = str(rank)
-    os.environ["WORLD_SIZE"] = str(world_size)
-    os.environ["LOCAL_RANK"] = str(rank)
-    torch.distributed.init_process_group("cpu:gloo,cuda:nccl", rank=rank, world_size=world_size)
-    torch.cuda.set_device(rank)
-
-
-def run_example_step_in_worker(rank, world_size, cmd_parts, example_path, output_path, master_port):
-    """Run one example step inside a persistent worker. Top-level so it stays picklable."""
-    _use_spawn_for_async_checkpointing()
-    reset_megatron_global_state()
-    _reinit_process_group(rank, world_size, master_port)
-    env_before = os.environ.copy()
+    example_dir = MODELOPT_ROOT / "examples" / example_path
     script = next(p for p in cmd_parts if str(p).endswith(".py"))
-    argv = [str(p) for p in cmd_parts[cmd_parts.index(script) :]]
-    example_dir = str(MODELOPT_ROOT / "examples" / example_path)
-    sys.path.insert(0, example_dir)
-    output = ""
+    argv = [str(p) for p in cmd_parts]
+    argv[argv.index(str(script))] = str(example_dir / Path(script).name)
+    cwd = os.getcwd()
+    os.chdir(example_dir)
     try:
-        module = importlib.import_module(Path(script).stem)
-        with patch.object(sys, "argv", argv):
-            args = module.get_args()
-        try:
-            with _capture_output_fd() as cap:
-                module.main(args)
-        except SystemExit as e:
-            if e.code not in (0, None):
-                raise RuntimeError(f"{script} exited with code {e.code}") from e
-        finally:
-            output = cap[0]
+        with _capture_output_fd() as cap, patch.object(sys, "argv", argv):
+            torchrun_main()
+        return cap[0]
     finally:
-        sys.path.remove(example_dir)
-        print(output)
-        # Every rank writes: Megatron prints some lines tests assert on with ``print_rank_last``,
-        # so rank 0's output alone is incomplete whenever world_size > 1.
-        Path(f"{output_path}.{rank}").write_text(output, encoding="utf-8")
-        os.environ.clear()
-        os.environ.update(env_before)
-        reset_megatron_global_state()
+        os.chdir(cwd)
+        print(cap[0])
 
 
 def _drivable(script: str, example_path: str) -> bool:
@@ -272,10 +227,7 @@ def _drivable(script: str, example_path: str) -> bool:
 
 
 def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
-    """Dispatch an example step in-process (1 rank) or to a worker pool (N ranks).
-
-    Returns the script's stdout, or ``None`` to fall back to a ``torchrun`` subprocess.
-    """
+    """Run an example step without shelling out. ``None`` falls back to a subprocess."""
     if os.environ.get("MODELOPT_NO_INPROCESS_EXAMPLES"):
         return None
     script = next((str(p) for p in cmd_parts if str(p).endswith(".py")), None)
@@ -284,23 +236,6 @@ def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
     world_size = requested_world_size(cmd_parts)
     if world_size == 1:
         return run_example_in_process(cmd_parts, example_path)
-    pool = _pool_provider(world_size) if (world_size and _pool_provider) else None
-    if pool is None:
-        return None
-    with tempfile.TemporaryDirectory() as td:
-        out_file = Path(td) / "stdout.txt"
-        pool.run(
-            partial(
-                run_example_step_in_worker,
-                cmd_parts=cmd_parts,
-                example_path=example_path,
-                output_path=str(out_file),
-                master_port=get_free_port(),  # one port for all ranks, fresh each step
-            )
-        )
-        parts = [
-            Path(f"{out_file}.{r}").read_text(encoding="utf-8")
-            for r in range(world_size)
-            if Path(f"{out_file}.{r}").exists()
-        ]
-        return "\n".join(parts)
+    if world_size and world_size > 1:
+        return run_torchrun_in_process(cmd_parts, example_path)
+    return None

--- a/tests/_test_utils/torch/megatron/example_runner.py
+++ b/tests/_test_utils/torch/megatron/example_runner.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run ``examples/megatron_bridge`` scripts in-process instead of via ``torchrun``.
+
+A ``torchrun`` launch spends ~25s importing torch/megatron/modelopt before doing any work, and one
+example test runs several. Driving the script's ``main()`` in the pytest process instead takes the
+full suite from ~26min to ~4min on one GPU.
+
+The script's own ``get_args()`` still runs, so CLI flags and recipe strings stay covered. Not
+covered: the ``torchrun`` invocation and the ``__main__`` block (``dist.setup()``/``dist.abort()``).
+Multi-rank commands are left alone -- the pytest process is a single rank.
+"""
+
+import contextlib
+import gc
+import importlib
+import io
+import logging
+import os
+import sys
+import tempfile
+from functools import partial
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from _test_utils.examples.run_command import MODELOPT_ROOT
+from _test_utils.torch.distributed.utils import get_free_port
+from megatron.bridge.training.config import CheckpointConfig
+from megatron.core import parallel_state
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue
+from megatron.core.rerun_state_machine import destroy_rerun_state_machine
+
+import modelopt.torch.utils.distributed as dist
+
+
+def _use_spawn_for_async_checkpointing() -> None:
+    """Stop async checkpoint saving from forking a process that already owns CUDA/NCCL.
+
+    ``CheckpointConfig.async_write_results_mp_mode`` defaults to ``"fork"``. Under ``torchrun`` that
+    is fine -- the fork happens in a fresh process. Reusing a worker means the fork happens after
+    CUDA and NCCL are initialised, and it deadlocks: the manager server reaches ``serve_forever``
+    while the caller never returns from ``get_write_results_queue``. Confirmed with py-spy.
+    """
+    with contextlib.suppress(Exception):
+        CheckpointConfig.async_write_results_mp_mode = "spawn"
+
+
+@contextlib.contextmanager
+def _capture_output():
+    """Capture what a step writes here, including lines emitted through logging handlers."""
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    targets = [logging.getLogger()]
+    targets += [
+        lg
+        for lg in logging.root.manager.loggerDict.values()
+        if isinstance(lg, logging.Logger) and (lg.handlers or not lg.propagate)
+    ]
+    levels = {}
+    for lg in targets:
+        lg.addHandler(handler)
+        levels[lg] = lg.level
+        if lg.level > logging.INFO:
+            lg.setLevel(logging.INFO)
+    try:
+        with contextlib.redirect_stdout(buf):
+            yield buf
+    finally:
+        for lg, level in levels.items():
+            lg.removeHandler(handler)
+            lg.setLevel(level)
+
+
+@contextlib.contextmanager
+def _capture_output_fd():
+    """Capture at the file-descriptor level, for use inside a worker process.
+
+    Loggers configured *during* the step (Megatron-Bridge sets its own up in ``setup()``) are
+    invisible to handlers installed beforehand, so the in-process approach misses them here.
+    """
+    holder = [""]
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as tmp:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        saved_out, saved_err = os.dup(1), os.dup(2)
+        os.dup2(tmp.fileno(), 1)
+        os.dup2(tmp.fileno(), 2)
+        try:
+            yield holder
+        finally:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os.dup2(saved_out, 1)
+            os.dup2(saved_err, 2)
+            os.close(saved_out)
+            os.close(saved_err)
+            tmp.seek(0)
+            holder[0] = tmp.read()
+
+
+def reset_megatron_global_state() -> None:
+    """Drop the global state a finished example step leaves behind.
+
+    Steps share one interpreter, so anything global has to be put back or it leaks into the next
+    test. Failure-tolerant on purpose: this also runs after a failed step, where the model may be
+    half-built, and it must not mask the error that got us here.
+    """
+    with contextlib.suppress(Exception):
+        parallel_state.destroy_model_parallel()
+    with contextlib.suppress(Exception):
+        # A separate singleton from the parallel state, initialised by the training path.
+        destroy_rerun_state_machine()
+    with contextlib.suppress(Exception):
+        # The async checkpoint worker is a *class-level* singleton, so it outlives the step that
+        # started it and the next one inherits a stale process. Under torchrun the process exits
+        # and takes it with it; a reused worker has to close it explicitly.
+        if AsyncCallsQueue._persistent_caller is not None:
+            AsyncCallsQueue._persistent_caller.close(abort=True)
+            AsyncCallsQueue._persistent_caller = None
+    with contextlib.suppress(Exception):
+        # Collect first: empty_cache() only returns blocks nothing references, and a finished step
+        # can leave its model reachable from the imported module. Without this a later test ran
+        # against a fragmented allocator ~9x slower.
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+
+def run_example_in_process(cmd_parts: list[str], example_path: str) -> str:
+    """Drive an example script's real ``get_args()`` + ``main()`` here. Returns its stdout."""
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", str(get_free_port()))
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("LOCAL_RANK", "0")
+        dist.setup()
+        torch.cuda.set_device(dist.local_rank())
+
+    _use_spawn_for_async_checkpointing()
+    script = next(p for p in cmd_parts if str(p).endswith(".py"))
+    argv = [str(p) for p in cmd_parts[cmd_parts.index(script) :]]
+    example_dir = str(MODELOPT_ROOT / "examples" / example_path)
+    sys.path.insert(0, example_dir)
+    output = ""
+    try:
+        module = importlib.import_module(Path(script).stem)
+        reset_megatron_global_state()  # a previous step left its own parallel state behind
+        with patch.object(sys, "argv", argv):
+            args = module.get_args()
+        try:
+            with _capture_output() as buf:
+                module.main(args)
+        except SystemExit as e:
+            if e.code not in (0, None):
+                raise RuntimeError(f"{script} exited with code {e.code}") from e
+        finally:
+            output = buf.getvalue()
+        return output
+    finally:
+        sys.path.remove(example_dir)
+        print(output)  # keep the script's output in the test log
+
+
+# --- Multi-rank dispatch ---------------------------------------------------------------------
+# The pytest process is a single rank, so a command asking for N>1 ranks cannot run in-process.
+# A pool of persistent workers gives real ranks while still paying the import cost once.
+_pool_provider = None
+
+
+def set_worker_pool_provider(provider) -> None:
+    """Register ``provider(world_size) -> DistributedWorkerPool | None``."""
+    global _pool_provider
+    _pool_provider = provider
+
+
+def requested_world_size(cmd_parts: list[str]) -> int | None:
+    """World size a ``torchrun`` command asks for, if it says."""
+    for part in cmd_parts:
+        if str(part).startswith("--nproc_per_node="):
+            return int(str(part).split("=", 1)[1])
+    return None
+
+
+def _reinit_process_group(rank: int, world_size: int, master_port: int) -> None:
+    """Give the step a fresh process group, as a ``torchrun`` launch would.
+
+    Megatron-Bridge tears down what it calls framework-owned distributed resources when a run ends
+    ("Bridge is aborting framework-owned distributed resources..."), which includes the pool's own
+    group. The next step then finds a dead group and its rendezvous is refused. Persistent
+    *processes* are what save the import cost; the group itself is cheap to rebuild per step.
+    """
+    if world_size <= 1:
+        return
+    with contextlib.suppress(Exception):
+        if dist.is_initialized():
+            torch.distributed.destroy_process_group()
+    os.environ["MASTER_ADDR"] = os.environ.get("MASTER_ADDR", "127.0.0.1")
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_RANK"] = str(rank)
+    torch.distributed.init_process_group("cpu:gloo,cuda:nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+
+
+def run_example_step_in_worker(rank, world_size, cmd_parts, example_path, output_path, master_port):
+    """Run one example step inside a persistent worker. Top-level so it stays picklable."""
+    _use_spawn_for_async_checkpointing()
+    reset_megatron_global_state()
+    _reinit_process_group(rank, world_size, master_port)
+    env_before = os.environ.copy()
+    script = next(p for p in cmd_parts if str(p).endswith(".py"))
+    argv = [str(p) for p in cmd_parts[cmd_parts.index(script) :]]
+    example_dir = str(MODELOPT_ROOT / "examples" / example_path)
+    sys.path.insert(0, example_dir)
+    output = ""
+    try:
+        module = importlib.import_module(Path(script).stem)
+        with patch.object(sys, "argv", argv):
+            args = module.get_args()
+        try:
+            with _capture_output_fd() as cap:
+                module.main(args)
+        except SystemExit as e:
+            if e.code not in (0, None):
+                raise RuntimeError(f"{script} exited with code {e.code}") from e
+        finally:
+            output = cap[0]
+    finally:
+        sys.path.remove(example_dir)
+        print(output)
+        # Every rank writes: Megatron prints some lines tests assert on with ``print_rank_last``,
+        # so rank 0's output alone is incomplete whenever world_size > 1.
+        Path(f"{output_path}.{rank}").write_text(output, encoding="utf-8")
+        os.environ.clear()
+        os.environ.update(env_before)
+        reset_megatron_global_state()
+
+
+def _drivable(script: str, example_path: str) -> bool:
+    """Whether the script exposes the ``get_args()`` + ``main()`` shape this runner drives.
+
+    Duck-typed rather than an allowlist so a new script needs no bookkeeping, and one that does not
+    follow the convention (``generate_vllm.py`` has no ``get_args``) simply keeps using torchrun.
+    """
+    example_dir = str(MODELOPT_ROOT / "examples" / example_path)
+    sys.path.insert(0, example_dir)
+    try:
+        module = importlib.import_module(Path(script).stem)
+        return callable(getattr(module, "get_args", None)) and callable(
+            getattr(module, "main", None)
+        )
+    except Exception:
+        return False
+    finally:
+        sys.path.remove(example_dir)
+
+
+def run_example_step(cmd_parts: list[str], example_path: str) -> str | None:
+    """Dispatch an example step in-process (1 rank) or to a worker pool (N ranks).
+
+    Returns the script's stdout, or ``None`` to fall back to a ``torchrun`` subprocess.
+    """
+    if os.environ.get("MODELOPT_NO_INPROCESS_EXAMPLES"):
+        return None
+    script = next((str(p) for p in cmd_parts if str(p).endswith(".py")), None)
+    if script is None or not _drivable(script, example_path):
+        return None
+    world_size = requested_world_size(cmd_parts)
+    if world_size == 1:
+        return run_example_in_process(cmd_parts, example_path)
+    pool = _pool_provider(world_size) if (world_size and _pool_provider) else None
+    if pool is None:
+        return None
+    with tempfile.TemporaryDirectory() as td:
+        out_file = Path(td) / "stdout.txt"
+        pool.run(
+            partial(
+                run_example_step_in_worker,
+                cmd_parts=cmd_parts,
+                example_path=example_path,
+                output_path=str(out_file),
+                master_port=get_free_port(),  # one port for all ranks, fresh each step
+            )
+        )
+        parts = [
+            Path(f"{out_file}.{r}").read_text(encoding="utf-8")
+            for r in range(world_size)
+            if Path(f"{out_file}.{r}").exists()
+        ]
+        return "\n".join(parts)

--- a/tests/examples/megatron_bridge/conftest.py
+++ b/tests/examples/megatron_bridge/conftest.py
@@ -24,9 +24,14 @@ from _test_utils.examples.megatron_example_runner import (
 from _test_utils.examples.run_command import set_in_process_runner
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(autouse=True)
 def _fast_example_runner():
-    """Run example steps without shelling out to ``torchrun``."""
+    """Run example steps without shelling out to ``torchrun``.
+
+    Per test, not per session: the hook is a module-global in ``run_command``, and this runner
+    raises rather than falling back, so leaving it installed would break any other example suite
+    collected later in the same session (``pytest tests/examples``).
+    """
     set_in_process_runner(run_example_step)
     try:
         yield

--- a/tests/examples/megatron_bridge/conftest.py
+++ b/tests/examples/megatron_bridge/conftest.py
@@ -12,13 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Run example steps without a ``torchrun`` launch; see ``_test_utils.torch.megatron.example_runner``."""
+"""Run example steps without a ``torchrun`` launch; see ``_test_utils.examples.megatron_example_runner``."""
 
 import os
 
 import pytest
+from _test_utils.examples.megatron_example_runner import (
+    reset_megatron_global_state,
+    run_example_step,
+)
 from _test_utils.examples.run_command import set_in_process_runner
-from _test_utils.torch.megatron.example_runner import reset_megatron_global_state, run_example_step
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/examples/megatron_bridge/conftest.py
+++ b/tests/examples/megatron_bridge/conftest.py
@@ -17,43 +17,18 @@
 import os
 
 import pytest
-import torch
 from _test_utils.examples.run_command import set_in_process_runner
-from _test_utils.torch.distributed.utils import DistributedWorkerPool, default_worker_teardown
-from _test_utils.torch.megatron.example_runner import (
-    reset_megatron_global_state,
-    run_example_step,
-    set_worker_pool_provider,
-)
+from _test_utils.torch.megatron.example_runner import reset_megatron_global_state, run_example_step
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def _fast_example_runner():
-    """Single-rank steps run in-process; N-rank steps go to a pool of persistent workers.
-
-    Pools are module-scoped (as in ``tests/gpu_megatron``) so workers are never shared across test
-    files, and are torn down with the module.
-    """
-    pools: dict[int, DistributedWorkerPool] = {}
-
-    def provider(world_size: int):
-        if world_size > torch.cuda.device_count():
-            return None  # cannot honour it here; fall back to torchrun
-        if world_size not in pools:
-            pools[world_size] = DistributedWorkerPool(
-                world_size=world_size, teardown_fn=default_worker_teardown
-            )
-        return pools[world_size]
-
-    set_worker_pool_provider(provider)
+    """Run example steps without shelling out to ``torchrun``."""
     set_in_process_runner(run_example_step)
     try:
         yield
     finally:
         set_in_process_runner(None)
-        set_worker_pool_provider(None)
-        for pool in pools.values():
-            pool.shutdown()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/examples/megatron_bridge/conftest.py
+++ b/tests/examples/megatron_bridge/conftest.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run example steps without a ``torchrun`` launch; see ``_test_utils.torch.megatron.example_runner``."""
+
+import os
+
+import pytest
+import torch
+from _test_utils.examples.run_command import set_in_process_runner
+from _test_utils.torch.distributed.utils import DistributedWorkerPool, default_worker_teardown
+from _test_utils.torch.megatron.example_runner import (
+    reset_megatron_global_state,
+    run_example_step,
+    set_worker_pool_provider,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _fast_example_runner():
+    """Single-rank steps run in-process; N-rank steps go to a pool of persistent workers.
+
+    Pools are module-scoped (as in ``tests/gpu_megatron``) so workers are never shared across test
+    files, and are torn down with the module.
+    """
+    pools: dict[int, DistributedWorkerPool] = {}
+
+    def provider(world_size: int):
+        if world_size > torch.cuda.device_count():
+            return None  # cannot honour it here; fall back to torchrun
+        if world_size not in pools:
+            pools[world_size] = DistributedWorkerPool(
+                world_size=world_size, teardown_fn=default_worker_teardown
+            )
+        return pools[world_size]
+
+    set_worker_pool_provider(provider)
+    set_in_process_runner(run_example_step)
+    try:
+        yield
+    finally:
+        set_in_process_runner(None)
+        set_worker_pool_provider(None)
+        for pool in pools.values():
+            pool.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_megatron_global_state():
+    """Reset shared state around every test so a failure cannot cascade into the next one.
+
+    In-process steps share the interpreter. Besides Megatron's singletons, Transformer-Engine
+    records its chosen attention backend in ``NVTE_*``, which failed a Mamba hybrid that ran after
+    an attention model -- so the environment is restored wholesale rather than by naming variables.
+    """
+    env_before = os.environ.copy()
+    reset_megatron_global_state()
+    try:
+        yield
+    finally:
+        reset_megatron_global_state()
+        os.environ.clear()
+        os.environ.update(env_before)


### PR DESCRIPTION
### What does this PR do?

Type of change: Test infrastructure / CI time

`tests/examples/megatron_bridge` spends most of its time importing Python, not testing. Each step of
a test spawns `torchrun`, and the new process spends **~25s importing torch/megatron/modelopt**
before doing any work. A single `test_qad` run pays that **six** times — three steps, plus a spawned
child per distributed checkpoint save, because Megatron-Core's async writer uses `mp_mode="spawn"`
and spawn re-imports `__main__`.

Profiled with phase timers in the example scripts:

| | share of `test_qad[qwen3]` |
|---|---|
| Python imports (6 process launches × ~26s) | **~76%** |
| actual compute (`mtq.quantize` 4.2s, model build 0.24s, export 0.06s) | ~5s |

`run_example_command` now dispatches each step internally instead of shelling out:

- **single-rank steps** run directly in the pytest process, driving the script's own `get_args()` +
  `main()` — no new interpreter, no re-import;
- **multi-rank steps** drive `torch.distributed.run.main()` in-process with patched `sys.argv`,
  the same pattern Megatron-Bridge uses in its own functional tests.

### Results

| suite | before | after |
|---|---|---|
| `tests/examples/megatron_bridge`, **1 GPU** | **21m27** | **4m03 - 6m17** |
| `tests/examples/megatron_bridge`, **2 GPU** | 26m10 | 25m03 |

Both figures are on current `main` (17 tests). The 2-GPU number is up from 20m41 before merging
#2276, which added a test and made one previously single-rank step multi-rank.

The 1-GPU figure is a range, not a best case. Across ten runs on a verified-idle box the suite
lands at ~4m most of the time and at ~6m otherwise, always with the same result (17 passed).
Per-test durations show the entire spread is one test: `test_qad[qwen3]` runs at ~15s or at ~149s.
It is 25s in isolation, 15s after `test_distill.py` and ~25s after `test_prune_minitron.py`, so it
needs the full sequence and does not reproduce on demand — three attempts to catch it under
instrumentation all landed on fast runs. In those, CUDA state immediately before it is 46 MiB
allocated / 68 MiB reserved / 7 segments / 22 MiB inactive-split, and the preceding test's 498/984
MiB is fully reclaimed, so a fragmented allocator is measured *not* to be the cause in the fast
path at least. Left documented rather than guessed at: correctness is unaffected across every run,
and the worst case sits inside the 30-minute PR budget (CI `Run tests` 902s).

The single-GPU path is the big win, and it is the one the per-PR runner uses — that job now
finishes in **8 minutes** in CI. Multi-rank steps still launch worker processes that re-import, so
the 2-GPU nightly improves far less.

This also fixes the timeouts under coverage. With `--cov` (how CI runs it), on the same three tests:
in-process **3 passed in 1m15**, subprocess **3 failed on `Timeout (>360.0s)` in 18m57**.

### CI timeout

The 2-GPU nightly runs every test multi-GPU and measured **58 minutes against a 60-minute cap** —
too close to be reliable. `timeout_minutes` is now ref-conditional, mirroring the `runner` line
directly below it: **30 minutes on PRs** (single-GPU, ~8 min) and **75 on nightly**.

Keeping the nightly at full multi-GPU coverage is deliberate. Making individual tests single-rank
cut it to ~7 minutes, but it gives up the parallel-path coverage that is the whole point of the
2-GPU job, and it surfaced a real fragility: `test_prune_minitron[nemotron_h]` fails with
*"No scores collected for importance estimation"* when it runs single-rank after the full distill
file. It passes alone and after any single preceding test — multi-rank tests are immune because
`torchrun` gives them fresh worker processes. Nightly is the right place to spend the wall-clock.

### What is and isn't covered

Each script's real `get_args()` still runs, so CLI flags, defaults and recipe-string resolution stay
covered. Not covered for single-rank steps: the `torchrun` invocation itself and the `__main__`
block (`dist.setup()` / `dist.abort()`). Multi-rank steps still go through the real launcher.

**No test file changes.** The tests still read as "launch this torchrun command" and their
assertions are untouched.

### Keeping it that way

There is no toggle and no fallback. Every step in this suite must be
`torchrun --nproc_per_node=<int> <script>.py` with the script exposing `get_args()` + `main()`, and
`run_example_step` raises otherwise — it returns `str`, not `str | None`, so a step cannot quietly
become a subprocess. That matters because a silent fallback still *passes*, just ~6x slower, so a
new script or test could cost the suite its speed-up with nothing to show for it.

Both guards verified by breaking them on purpose, each failing in ~1.4s rather than burning a run:

| broken convention | result |
|---|---|
| `--nproc_per_node=gpu` | `AssertionError: --nproc_per_node must be a plain integer: [...]` |
| step invoking `generate_vllm.py` (no `get_args`) | `AssertionError: generate_vllm.py must define get_args() and main(args)` |

### Layout

The runner lives in `tests/_test_utils/examples/megatron_example_runner.py`, next to the
`run_command.py` it plugs into and the other per-example helpers. It is deliberately not under
`tests/_test_utils/torch/megatron/`: both files there import megatron at module top, whereas this
one must not, since importing `megatron.bridge` would initialise CUDA in the pytest process and hold
a context on device 0 for the whole session.

### Isolation

Sharing one interpreter means anything global has to be put back between steps, or one failing test
cascades into the next. Each of these was previously cleaned up by `torchrun` simply exiting:

- **`NVTE_*`** — Transformer-Engine records its chosen attention backend in the environment, so a
  Mamba hybrid failed after an attention model ran. The environment is restored wholesale rather
  than by naming variables.
- **Allocator** — `empty_cache()` frees nothing while a finished step's model is still reachable; a
  later test ran **9x slower** (162s vs 18s) against a fragmented allocator until `gc.collect()` was
  added first.
- **Parallel state and the rerun state machine** — two separate singletons; `destroy_model_parallel()`
  does not touch the latter.
- **Signal handlers** — `PContext.start()` installs its own `SIGTERM`/`SIGINT`/`SIGHUP`/`SIGQUIT`
  handlers and never restores them. With a subprocess launcher, process exit did that for us;
  in-process they are saved and put back, or pytest's Ctrl-C and CI cancellation would break for the
  rest of the session.

Verified rather than assumed: injecting a failure mid-test (after a model was built and parallel
state left live) gives **1 failed, 2 passed**, with the surviving tests at full speed.

### Coverage

Coverage of the exercised code **improves**. In subprocess mode the child imports modelopt as
`site-packages/modelopt/...` while pytest measures `modelopt/...`, so the data never merges — which
is also why the subprocess report showed exactly double the statement count.

| module | subprocess | in-process |
|---|---|---|
| `unified_export_megatron.py` | 8% | **43%** |
| `mcore_custom.py` | 34% | **44%** |

### Testing

All in `nvcr.io/nvidia/nemo:26.08` on 2x RTX 6000 Ada, with per-test caps enforced.

| run | result |
|---|---|
| `tests/examples/megatron_bridge`, 1 GPU | 17 passed — 4m03 (6m17 worst of 10 runs) |
| same, subprocess baseline | 15 passed, 1 skipped — 21m27 |
| `tests/examples/megatron_bridge`, 2 GPU | 17 passed — 25m03 |
| CI 1-GPU example job (`megatron / run-test`) | passed — `Run tests` 902s, job ~20m (30m cap) |
| CI 2-GPU nightly | passed — `Run tests` 3162s, job 58m (75m cap) |
| cascade check (injected mid-test failure) | 1 failed, 2 passed, survivors at full speed |
| pre-commit | clean |

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — test-only; no source or public API changes
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A — no new dependencies (`pytest-forked` was evaluated and rejected: `import megatron.bridge` initialises CUDA, and CUDA cannot be re-initialised in a forked child)
- Did you write any new necessary tests?: N/A — this changes how existing tests are executed
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — internal test infrastructure, not user-facing
- Did you get Claude approval on this PR?: ✅ — reviewed by Claude and CodeRabbit, all threads addressed
