### PR TITLE
Add Megatron KV cache scale export toggle [OMNIML-5819]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
 
 *Megatron Framework (M-LM / M-Bridge)*
 
+- Add ``clamp_kv_cache_scales`` to ``export_mcore_gpt_to_hf``. Set it to ``False`` when exporting a QAT Megatron-Core model to preserve its learned FP8 KV-cache scales; the default retains the existing minimum scale of 1.0.
 - Add SFT-masked data support to ``examples/megatron_bridge/distill.py``: ``--sft --sft_dataset_root <dir>`` distills on raw prompt-completion JSONL (``{"input", "output"}`` records) with the loss masked to the response tokens, using Megatron-Bridge's ``FinetuningDatasetConfig`` and the model's own HuggingFace tokenizer instead of the pretraining ``GPTDataset`` and ``NullTokenizer``.
 - Add per-expert weight quantization for Transformer Engine ``TEGroupedMLP`` (fused MoE experts): each expert now has its own ``weight_quantizer`` (a ``GroupedQuantizer`` holding one ``TensorQuantizer`` per expert) with an independent ``amax``, instead of a single shared ``amax`` across all experts. Applies to ``mtq.quantize`` calibration, HF / Megatron export, and QAD.
 - Add opt-in ``torch.compile`` execution for Transformer Engine grouped-linear per-expert weight quantizers while preserving their native checkpoint amax shapes. Set ``MODELOPT_TEGROUPED_COMPILE_WEIGHT_LOOP=1`` before quantized-module conversion; the default path remains eager.

--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -370,11 +370,14 @@ def get_kv_cache_bias(kv_module: nn.Module) -> list[torch.Tensor]:
     return kv_bias
 
 
-def get_kv_cache_scaling_factor(self_attention_module: nn.Module) -> list[torch.Tensor | None]:
+def get_kv_cache_scaling_factor(
+    self_attention_module: nn.Module, clamp_fp8_scales: bool = True
+) -> list[torch.Tensor | None]:
     """Get the K and V BMM scaling factors for the self attention module.
 
     Args:
         self_attention_module: The self attention module to get the K and V BMM scaling factors from.
+        clamp_fp8_scales: Whether to clamp FP8 KV cache scaling factors to at least 1.0.
 
     Returns:
         The K and V BMM scaling factors.
@@ -390,7 +393,7 @@ def get_kv_cache_scaling_factor(self_attention_module: nn.Module) -> list[torch.
     ]
 
     # For FP8, we recommend default kv cache scaling factor to be 1.
-    if get_kv_cache_dtype(self_attention_module) == KV_CACHE_FP8:
+    if clamp_fp8_scales and get_kv_cache_dtype(self_attention_module) == KV_CACHE_FP8:
         for i, factor in enumerate(scaling_factors):
             if factor is None:
                 continue

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -121,6 +121,7 @@ class GPTModelExporter:
         dtype: The weights data type to export the unquantized layers.
         trust_remote_code: Whether to trust remote code in the HuggingFace pretrained model.
         moe_router_dtype: The data type of the MoE router. Can be "fp32", "fp64", or None (default to the model dtype).
+        clamp_kv_cache_scales: Whether to clamp FP8 KV cache scaling factors to at least 1.0.
     """
 
     def __init__(
@@ -131,6 +132,7 @@ class GPTModelExporter:
         dtype=torch.bfloat16,
         trust_remote_code: bool = False,
         moe_router_dtype: str | None = None,
+        clamp_kv_cache_scales: bool = True,
     ):
         """Create a GPTModel exporter instance."""
         if not isinstance(model, (GPTModel, HybridModel, LLaVAModel)):
@@ -168,6 +170,7 @@ class GPTModelExporter:
         self.model = model.language_model if self.is_multimodal else model
         self.dtype = dtype
         self.trust_remote_code = trust_remote_code
+        self.clamp_kv_cache_scales = clamp_kv_cache_scales
         self.arch = self._hf_config.architectures[0]
         # TODO: May modify this later according to what quantization exported ckpt is, currently only support BF16.
         if self.arch == "GptOssForCausalLM":
@@ -1450,7 +1453,9 @@ class GPTModelExporter:
         k_scale_key = prefix + k_scale_name
         v_scale_key = prefix + v_scale_name
         if hasattr(module, "k_bmm_quantizer") and hasattr(module, "v_bmm_quantizer"):
-            kv_scales = get_kv_cache_scaling_factor(module)
+            kv_scales = get_kv_cache_scaling_factor(
+                module, clamp_fp8_scales=self.clamp_kv_cache_scales
+            )
             if all(s is not None for s in kv_scales):
                 self._state_dict[k_scale_key] = kv_scales[0]
                 self._state_dict[v_scale_key] = kv_scales[1]
@@ -1692,6 +1697,7 @@ def export_mcore_gpt_to_hf(
     export_dir: Path | str = tempfile.gettempdir(),
     trust_remote_code: bool = False,
     moe_router_dtype: torch.dtype | None = None,
+    clamp_kv_cache_scales: bool = True,
 ):
     """Export Megatron Core GPTModel to unified checkpoint and save to export_dir.
 
@@ -1705,6 +1711,7 @@ def export_mcore_gpt_to_hf(
             eagle_module. Otherwise, only export the base model.
         dtype: The weights data type to export the unquantized layers.
         export_dir: The target export path.
+        clamp_kv_cache_scales: Whether to clamp FP8 KV cache scaling factors to at least 1.0.
     """
     exporter = GPTModelExporter(
         model,
@@ -1713,6 +1720,7 @@ def export_mcore_gpt_to_hf(
         dtype=dtype,
         trust_remote_code=trust_remote_code,
         moe_router_dtype=moe_router_dtype,
+        clamp_kv_cache_scales=clamp_kv_cache_scales,
     )
     if exporter.export_extra_modules:
         exporter.save_pretrained_extra_modules(export_dir)

--- a/tests/unit/torch/export/test_get_quantization.py
+++ b/tests/unit/torch/export/test_get_quantization.py
@@ -24,6 +24,7 @@ from _test_utils.torch.export.utils import (
     partial_w4a8_config,
 )
 
+import modelopt.torch.export.unified_export_megatron as unified_export_megatron
 import modelopt.torch.quantization as mtq
 from modelopt.torch.export.layer_utils import get_quantization_format
 from modelopt.torch.export.model_config import (
@@ -31,8 +32,59 @@ from modelopt.torch.export.model_config import (
     QUANTIZATION_NVFP4,
     QUANTIZATION_W4A8_AWQ,
 )
-from modelopt.torch.export.quant_utils import get_quant_config
+from modelopt.torch.export.quant_utils import get_kv_cache_scaling_factor, get_quant_config
 from modelopt.torch.quantization.nn import NVFP4StaticQuantizer
+
+
+class _FakeKVCacheQuantizer(torch.nn.Module):
+    """Minimal FP8 KV cache quantizer for scaling-factor tests."""
+
+    is_enabled = True
+    num_bits = (4, 3)
+    maxbound = 448.0
+
+    def export_amax(self):
+        return torch.tensor([224.0])
+
+
+def test_get_kv_cache_scaling_factor_can_disable_fp8_clamping():
+    """FP8 KV cache scales below 1.0 are retained when explicitly requested."""
+    attention = torch.nn.Module()
+    attention.k_bmm_quantizer = _FakeKVCacheQuantizer()
+    attention.v_bmm_quantizer = _FakeKVCacheQuantizer()
+
+    clamped_scales = get_kv_cache_scaling_factor(attention)
+    unclamped_scales = get_kv_cache_scaling_factor(attention, clamp_fp8_scales=False)
+
+    assert all(torch.equal(scale, torch.tensor([1.0])) for scale in clamped_scales)
+    assert all(torch.equal(scale, torch.tensor([0.5])) for scale in unclamped_scales)
+
+
+@pytest.mark.parametrize("clamp_kv_cache_scales", [True, False])
+def test_export_mcore_gpt_to_hf_passes_kv_cache_clamping_option(
+    monkeypatch, tmp_path, clamp_kv_cache_scales
+):
+    """The public Megatron export API forwards the KV cache clamping option."""
+    exporter_args = {}
+
+    class FakeExporter:
+        def __init__(self, *args, **kwargs):
+            exporter_args.update(kwargs)
+            self.export_extra_modules = False
+
+        def save_pretrained(self, *args):
+            pass
+
+    monkeypatch.setattr(unified_export_megatron, "GPTModelExporter", FakeExporter)
+
+    unified_export_megatron.export_mcore_gpt_to_hf(
+        object(),
+        tmp_path,
+        export_dir=tmp_path,
+        clamp_kv_cache_scales=clamp_kv_cache_scales,
+    )
+
+    assert exporter_args["clamp_kv_cache_scales"] is clamp_kv_cache_scales
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

During QAT/QAD with quantized FP8 KV cache, Megatron export inherits the HF export behavior of clamping FP8 KV scales to 1.0. This throws away any scales learned during QAT/QAD. Instead we add a toggle to enable disabling KV scale clamping during Megatron export.

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Very short summary of changes only for new features, backward breaking changes, deprecations, or fixes for critical bugs present in previous releases. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for Megatron-to-Hugging Face exports to preserve learned FP8 KV-cache scale values below 1.0.
  * By default, FP8 KV-cache scales continue to be clamped to a minimum of 1.0.

* **Tests**
  * Added coverage for default clamping, disabled clamping, and export option handling.

* **Documentation**
  * Updated the 0.47 release notes with the new export option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->