### PR TITLE
Gate CodeRabbit reviews by Puzzletron label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -44,8 +44,10 @@ reviews:
            tests under tests/unit instead of tests/gpu*).
   auto_review:
     auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
     drafts: false
     base_branches: ["main", "release/.*", "feature/.*"]
+    labels: ["puzzletron_v2"]
   pre_merge_checks:
     custom_checks:
       - name: "Security anti-patterns"


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

CodeRabbit currently auto-reviews every non-draft pull request targeting a configured branch. This change limits automatic initial and incremental reviews to non-draft pull requests labeled `puzzletron_v2` and disables automatic pausing after reviewed commits.

This is temporary branch-specific configuration. Restore the repository-wide automatic review configuration before `feature/puzzletron_v2` is merged into `main`.

### Testing

Parsed the configuration as YAML, verified the new values against the CodeRabbit schema documentation, and ran the repository pre-commit hooks for `.coderabbit.yaml`.

### Before your PR is "Ready for review"

- Is this change backward compatible?: yes
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code review automation now continues after reviewed commits.
  * Reviews are labeled with `puzzletron_v2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->