### PR TITLE
Replay VLM vision inputs in megatron_generate without KV cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Bug Fixes**
 
-- Fix ``megatron_generate`` dropping the VLM vision inputs (``pixel_values`` / ``image_grid_thw`` / ``image_sizes``) after the first step when KV-cache decoding is off, including the automatic fallback under sequence parallelism. Every step recomputes the full prefix there, so generation silently ignored the image; the inputs are now replayed on each of those steps. No other ModelOpt feature is affected -- calibration, MMLU scoring and the example scripts pass vision inputs through ``megatron_prefill`` or generate text-only.
+- Fix ``megatron_generate`` dropping the VLM vision inputs (``pixel_values`` / ``image_grid_thw`` / ``image_sizes``) after the first generated token when KV-cache decoding is off, including the automatic fallback under sequence parallelism, which made generation silently ignore the image. No other ModelOpt feature is affected.
 
 0.47 (2026-09-xx)
 ^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.48 (2026-10-xx)
+^^^^^^^^^^^^^^^^^
+
+**Bug Fixes**
+
+- Fix ``megatron_generate`` dropping the VLM vision inputs (``pixel_values`` / ``image_grid_thw`` / ``image_sizes``) after the first step when KV-cache decoding is off, including the automatic fallback under sequence parallelism. Every step recomputes the full prefix there, so generation silently ignored the image; the inputs are now replayed on each of those steps. No other ModelOpt feature is affected -- calibration, MMLU scoring and the example scripts pass vision inputs through ``megatron_prefill`` or generate text-only.
+
 0.47 (2026-09-xx)
 ^^^^^^^^^^^^^^^^^
 

--- a/modelopt/torch/utils/plugins/megatron_generate.py
+++ b/modelopt/torch/utils/plugins/megatron_generate.py
@@ -394,10 +394,12 @@ def megatron_generate(
             .expand(batch_size, -1)
         )
 
-        # Check if this is a VLM model (vision inputs only passed at step 0 / prefill)
-        _has_pixel_values = step == 0 and pixel_values is not None
-        _has_image_grid_thw = step == 0 and image_grid_thw is not None
-        _has_image_sizes = step == 0 and image_sizes is not None
+        # VLM vision inputs: KV-cache decoding consumes them in the prefill step only, but without
+        # a cache every step recomputes the full prefix and must replay them to stay grounded.
+        _replay_vision_inputs = step == 0 or inference_context is None
+        _has_pixel_values = _replay_vision_inputs and pixel_values is not None
+        _has_image_grid_thw = _replay_vision_inputs and image_grid_thw is not None
+        _has_image_sizes = _replay_vision_inputs and image_sizes is not None
         has_vision_inputs = _has_pixel_values or _has_image_grid_thw or _has_image_sizes
 
         # For PP, receive activations from the previous stage before calling forward.

--- a/tests/gpu_megatron/torch/utils/plugins/test_utils_megatron.py
+++ b/tests/gpu_megatron/torch/utils/plugins/test_utils_megatron.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 import pytest
+import torch
 from _test_utils.torch.megatron.models import get_mcore_qwen3_600m
 from _test_utils.torch.megatron.utils import initialize_for_megatron
+from megatron.core.transformer import MegatronModule, TransformerConfig
 from transformers import AutoTokenizer
 
 from modelopt.torch.utils.plugins import megatron_generate, megatron_mmlu
@@ -67,3 +69,68 @@ def test_megatron_generate_and_mmlu(dist_workers, parallelism, num_gpus):
     if num_gpus == 1 and parallelism != "tp":
         pytest.skip("Skipping as redundant test on 1 GPU")
     dist_workers.run(_test_megatron_generate_and_mmlu, parallelism=parallelism)
+
+
+class _VisionArgRecorder(MegatronModule):
+    """VLM stand-in recording the sequence length and vision kwargs of every forward call."""
+
+    vocab_size = 8
+
+    def __init__(self):
+        super().__init__(TransformerConfig(num_layers=1, hidden_size=8, num_attention_heads=1))
+        self.calls = []
+
+    def forward(
+        self,
+        input_ids,
+        position_ids=None,
+        attention_mask=None,
+        *,
+        pixel_values=None,
+        image_grid_thw=None,
+        image_sizes=None,
+        inference_context=None,
+        runtime_gather_output=None,
+    ):
+        self.calls.append(
+            {
+                "seq_len": input_ids.shape[-1],
+                "vision": tuple(x is not None for x in (pixel_values, image_grid_thw, image_sizes)),
+            }
+        )
+        return torch.zeros(*input_ids.shape, self.vocab_size, device=input_ids.device)
+
+    def pop_calls(self) -> tuple[list, list]:
+        calls, self.calls = self.calls, []
+        return [c["seq_len"] for c in calls], [c["vision"] for c in calls]
+
+
+def _test_megatron_generate_vlm_vision_inputs(rank, size):
+    initialize_for_megatron(seed=SEED)
+    model = _VisionArgRecorder().cuda()
+    input_ids = torch.zeros((1, 4), dtype=torch.long, device="cuda")
+    vision_inputs = {
+        "pixel_values": torch.zeros((4, 8), device="cuda"),
+        "image_grid_thw": torch.tensor([[1, 2, 2]], device="cuda"),
+        "image_sizes": torch.tensor([[8, 8]], device="cuda"),
+    }
+    osl = 3
+    all_vision, no_vision = (True, True, True), (False, False, False)
+
+    # KV-cache decoding: the prefill step consumes the vision inputs, decode steps feed one token.
+    megatron_generate(model, input_ids, osl=osl, enable_kv_cache=True, **vision_inputs)
+    assert model.pop_calls() == ([4, 1, 1], [all_vision, no_vision, no_vision])
+
+    # No KV cache: every step recomputes the full prefix and must replay the vision inputs,
+    # otherwise the image placeholder tokens stay unreplaced and generation loses the image.
+    megatron_generate(model, input_ids, osl=osl, enable_kv_cache=False, **vision_inputs)
+    assert model.pop_calls() == ([4, 5, 6], [all_vision] * osl)
+
+    # Sequence parallelism silently falls back to no-cache decoding, so it must replay too.
+    model.config.sequence_parallel = True
+    megatron_generate(model, input_ids, osl=osl, enable_kv_cache=True, **vision_inputs)
+    assert model.pop_calls() == ([4, 5, 6], [all_vision] * osl)
+
+
+def test_megatron_generate_vlm_vision_inputs(dist_workers):
+    dist_workers.run(_test_megatron_generate_vlm_vision_inputs)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes #2189. `megatron_generate` gated the VLM vision inputs (`pixel_values`, `image_grid_thw`, `image_sizes`) on `step == 0`, which is only correct for KV-cache decoding. With `enable_kv_cache=False` — including the automatic fallback when `config.sequence_parallel` is set — every step recomputes the full growing prefix, so from step 1 on the image placeholder tokens kept their text embeddings and generation silently drifted off the image. No exception, no warning: the call reports a successful generation.

Root cause on the model side: `reorganize_inputs` (Megatron-Bridge `modelling_qwen3_vl/utils.py`) returns `(None, None, None)` when `pixel_values is None`, so `vision_embeds` stays `None`, the `<|image_pad|>` placeholders keep their raw text embeddings, and MRoPE positions are recomputed without `image_grid_thw`.

The fix replays the vision inputs whenever there is no inference context, i.e. on every full-prefix recomputation:

```python
_replay_vision_inputs = step == 0 or inference_context is None
```

**Scope:** no existing ModelOpt feature was affected. Calibration (text-only and image-text) and MMLU scoring go through `megatron_prefill`, which passes the vision inputs on its single forward, and the example scripts' post-PTQ sanity generation is text-only on the language model. The bug was reachable only by calling `megatron_generate` directly with vision inputs, as the reporter did.

Three files change: the gate in `megatron_generate.py`, a regression test, and a `CHANGELOG.rst` entry (new 0.48 section).

### Usage

```python
# Unchanged API; the no-KV-cache path now stays grounded in the image.
output_ids = megatron_generate(
    model, input_ids, pixel_values=pixel_values, image_grid_thw=image_grid_thw,
    osl=32, enable_kv_cache=False,
)
```

### Testing

**New regression test** `test_megatron_generate_vlm_vision_inputs` asserts the per-step forward kwargs of a recorder module in all three modes:

| mode | seq lens | vision kwargs |
|---|---|---|
| `enable_kv_cache=True` | 4, 1, 1 | prefill only |
| `enable_kv_cache=False` | 4, 5, 6 | every step |
| `sequence_parallel=True` + cache requested | 4, 5, 6 | every step (fallback path) |

Confirmed it bites: with the `step == 0` gating restored the test fails; with the fix it passes (2 GPUs, 28s).

**Real-model verification**, tiny Qwen3.5-VL built through Megatron-Bridge (`nemo:26.08`). Because each step recomputes the same prompt prefix, its logits must be step-invariant:

| | prefix logits vs. step 0 |
|---|---|
| before | `max\|diff\| = 0.84`, argmax agreement 0.529 |
| after | `max\|diff\| = 0.0000`, agreement 1.000 |

Nearly half the prompt positions changed their predicted token after step 0 before the fix; recomputation is now bit-exact with prefill.

**Check that the untouched calibration paths still behave**, since they share this module: Qwen3.5-0.8B PTQ (`general/ptq/fp8_default-kv_fp8`, 128 samples) → unified HF export → MMLU `--limit 0.1`. No code in that path changes here; the run confirms both calibration modes are unaffected.

| calibration | MMLU |
|---|---|
| image-text (`scienceqa`) | 0.4797 ± 0.0127 |
| text-only (`cnn_dailymail`) | 0.4839 ± 0.0127 |
| BF16 reference | 0.4895 ± 0.0127 |

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ (new 0.48 section)
- Did you get Claude approval on this PR?: ❌

### Additional Information

Related, and not fixed here: for Qwen3-VL / Qwen3.5-VL the KV-cache mode is broken upstream as well — `modelling_qwen3_vl/model.py` does `del inference_context  # Unused, kept for API compatibility`, so with `enable_kv_cache=True` the decode steps receive a single token and no cache, silently producing wrong output. Until Megatron-Bridge wires the cache through those wrappers, `enable_kv_cache=False` (this path) is the only usable mode for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
