### PR TITLE
fix(quantization): fix nvfp4 availability check

### DIFF
--- a/modelopt/torch/quantization/backends/nvfp4_gemm.py
+++ b/modelopt/torch/quantization/backends/nvfp4_gemm.py
@@ -20,7 +20,7 @@ from torch.autograd import Function
 
 import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.backends.gemm_registry import gemm_registry
-from modelopt.torch.quantization.backends.utils import fp4_compatible
+from modelopt.torch.quantization.backends.utils import check_attributes, fp4_compatible
 from modelopt.torch.quantization.qtensor import NVFP4QTensor, QTensorWrapper
 from modelopt.torch.quantization.utils import reduce_amax
 
@@ -234,20 +234,14 @@ def _nvfp4_availability_check(module, input, args, kwargs):
     for key, value in input_cfg.items():
         if key == "enable":
             continue
-        if (
-            not hasattr(module.input_quantizer, key)
-            or getattr(module.input_quantizer, key) != value
-        ):
+        if not check_attributes(module.input_quantizer, key, value):
             return False
 
     # Check weight quantizer config
     for key, value in weight_cfg.items():
         if key == "enable":
             continue
-        if (
-            not hasattr(module.weight_quantizer, key)
-            or getattr(module.weight_quantizer, key) != value
-        ):
+        if not check_attributes(module.weight_quantizer, key, value):
             return False
 
     # When the input.shape[1] is not the multiple of 64, GEMM will sometimes output NaN.

--- a/modelopt/torch/quantization/backends/utils.py
+++ b/modelopt/torch/quantization/backends/utils.py
@@ -30,3 +30,15 @@ def fp4_compatible():
     if not torch.cuda.is_available():
         return False
     return torch.cuda.get_device_capability(0) >= (10, 0)
+
+
+def check_attributes(obj: object, key: str, value: object) -> bool:
+    """Check the attributes of objects such as quantizers."""
+    _key = f"_{key}"
+
+    if hasattr(obj, key):
+        return getattr(obj, key) == value
+    elif hasattr(obj, _key):
+        return getattr(obj, _key) == value
+
+    return False


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix
<!-- Details about the change. -->

As described in #2330, `_nvfp4_availability_check` does not account for attributes prefixed with an underscore when checking quantizer attributes, resulting in a failed check. Consequently, after applying compression to an NVFP4-quantized model, the corresponding GEMM implementation cannot be located during inference, and the warning "RealQuantLinear: No real-quant GEMM found" is raised.

### Usage

```python
import modelopt
import torch

import modelopt.torch.quantization as mtq

from torch import nn

K_DTYPE = torch.bfloat16
K_BATCH = 128
K_DIM = 512


class Model(nn.Module):
    def __init__(self, dim: int) -> None:
        super().__init__()

        self.fc = nn.Linear(dim, dim)

    def forward(self, x: torch.Tensor) -> torch.Tensor:
        out = self.fc(x)

        return out


def main():
    device = torch.device("cuda:0")

    model = Model(K_DIM).to(K_DTYPE)
    model.to(device)

    inp = torch.randn(K_BATCH, K_DIM, dtype=K_DTYPE, device=device)

    qmodel = mtq.quantize(model, mtq.NVFP4_DEFAULT_CFG, lambda quantized_model: quantized_model(inp))
    mtq.compress(qmodel)

    qout = qmodel(inp)


if __name__ == "__main__":
    main()
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A 
- Did you write any new necessary tests?: N/A 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A 
- Did you get Claude approval on this PR?: N/A 

### Additional Information
Related issue: #2330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of quantization settings for NVFP4 operations.
  * Ensured configuration checks recognize both standard and internal attribute forms consistently.
  * Preserved validation behavior for unsupported or mismatched settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->