### PR TITLE
[chore]: release-branch housekeeping — auto-close stale uv.lock bump PRs, document cherry-pick labels

### DIFF
--- a/.github/workflows/bump_uv_lock.yml
+++ b/.github/workflows/bump_uv_lock.yml
@@ -45,28 +45,13 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Close stale bump PRs and delete their branches
-        if: steps.changes.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BASE="${{ github.ref_name }}"
-          SAFE_BASE=$(echo "$BASE" | tr '/' '-')
-          PREFIX="auto/bump-uv-lock-${SAFE_BASE}-"
-          # Superseded by the PR created below, so close them and clean up the branches.
-          gh pr list --state open --base "$BASE" --json number,headRefName \
-            --jq ".[] | select(.headRefName | startswith(\"${PREFIX}\")) | .number" \
-          | while read -r PR; do
-              echo "Closing stale PR #${PR}"
-              gh pr close "$PR" --delete-branch \
-                --comment "Superseded by a newer automated uv.lock bump."
-            done
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.ref_name }}
         run: |
-          BASE="${{ github.ref_name }}"
+          BASE="$BASE_BRANCH"
           SAFE_BASE=$(echo "$BASE" | tr '/' '-')
           BRANCH="auto/bump-uv-lock-${SAFE_BASE}-$(date +%Y-%m-%d)"
           git checkout -b "$BRANCH"
@@ -94,3 +79,20 @@ jobs:
           EOF
           )" \
             --base "$BASE"
+          # Now that the replacement exists, close the bump PRs it supersedes and
+          # delete their branches. Fork PRs are skipped: their heads live in another
+          # repo and only branch name would match.
+          gh pr list --state open --base "$BASE" --limit 100 \
+            --json number,headRefName,isCrossRepository \
+          | jq -r --arg prefix "auto/bump-uv-lock-${SAFE_BASE}-" --arg branch "$BRANCH" '
+              .[]
+              | select(.isCrossRepository | not)
+              | select(.headRefName | startswith($prefix))
+              | select(.headRefName != $branch)
+              | .number
+            ' \
+          | while read -r PR; do
+              echo "Closing superseded PR #${PR}"
+              gh pr close "$PR" --delete-branch \
+                --comment "Superseded by a newer automated uv.lock bump."
+            done

--- a/.github/workflows/bump_uv_lock.yml
+++ b/.github/workflows/bump_uv_lock.yml
@@ -45,6 +45,22 @@ jobs:
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: Close stale bump PRs and delete their branches
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="${{ github.ref_name }}"
+          SAFE_BASE=$(echo "$BASE" | tr '/' '-')
+          PREFIX="auto/bump-uv-lock-${SAFE_BASE}-"
+          # Superseded by the PR created below, so close them and clean up the branches.
+          gh pr list --state open --base "$BASE" --json number,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"${PREFIX}\")) | .number" \
+          | while read -r PR; do
+              echo "Closing stale PR #${PR}"
+              gh pr close "$PR" --delete-branch \
+                --comment "Superseded by a newer automated uv.lock bump."
+            done
       - name: Create pull request
         if: steps.changes.outputs.changed == 'true'
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,3 +266,6 @@ nox -s "unit-3.12(torch_211, tf_latest)"
 - Submit a pull request and let auto-assigned reviewers (based on [CODEOWNERS](./.github/CODEOWNERS)) review your PR.
 - If any CI/CD checks fail, fix the issues and push again.
 - Once your PR is approved and all checks pass, one of the reviewers will merge the PR.
+- If your PR is a bug fix that should also land in an ongoing release branch, add the
+  `cherry-pick-<X.Y.Z>` label (e.g. `cherry-pick-0.47.0`) matching that release. Labeled PRs are
+  cherry-picked into the release branch so the fix is included in the next release candidate.


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix, documentation

Two pieces of release/CI housekeeping.

**1. Close stale uv.lock bump PRs (`.github/workflows/bump_uv_lock.yml`)**

The weekly `Bump uv.lock` workflow opens a new PR every Monday but never cleans up
the previous one, so un-merged bump PRs (and their `auto/bump-uv-lock-*` branches)
pile up in the repo.

A new step runs just before the new PR is created: it lists open PRs against the
same base whose head branch matches this workflow's own `auto/bump-uv-lock-<base>-`
prefix, closes each with `gh pr close --delete-branch`, and leaves a comment saying
it was superseded.

- Only PRs whose head branch carries the workflow's own prefix are touched, so
  unrelated PRs can't be closed.
- The step is gated on `steps.changes.outputs.changed == 'true'`, so a pending bump
  PR is only dropped when a replacement is actually about to be opened. If
  `uv lock --upgrade` produces no changes, nothing is closed.
- It runs before the new branch is pushed, so the newly created PR can never close
  itself.
- No new permissions needed: the job already has `contents: write` and
  `pull-requests: write`.

**2. Document the `cherry-pick-<X.Y.Z>` label (`CONTRIBUTING.md`)**

The "Submitting your code" section now tells contributors that a bug fix which
should also land in an ongoing release branch needs the matching
`cherry-pick-<X.Y.Z>` label (e.g. `cherry-pick-0.47.0`), so the fix gets picked into
the release branch and tested in the next release candidate. This convention was
already in use but wasn't written down anywhere.

### Usage

N/A — CI workflow and contributor-docs change, no user-facing API.

### Testing

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/bump_uv_lock.yml'))"` passes.
- `pre-commit run` on both changed files passes (markdownlint included).
- The cleanup path itself only exercises on the next scheduled or manually
  dispatched run of the workflow, which has not happened yet.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — CI and docs only, not user facing.
- Did you get Claude approval on this PR?: ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Automated dependency update pull requests are now superseded after a replacement is created, keeping updates aligned with the latest lockfile state.
  - Superseded updates are cleaned up more safely, while active and externally sourced pull requests are preserved.

- **Documentation**
  - Added guidance for labeling bug-fix pull requests that should be included in an ongoing release branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->