### PR TITLE
Raise puzzletron Hydra minimum to hydra-core~=1.3.4 (CVE-2026-68508)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ hf = [
 
 puzzletron = [ # Dependedencies for modelopt.torch.puzzletron subpackage
     "fire",
-    "hydra-core==1.3.2",
+    "hydra-core~=1.3.4",
     "immutabledict",
     "lru-dict",
     "pandas",


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Raises the `puzzletron` extra's Hydra minimum from `==1.3.2` to `~=1.3.4`, picking up the `hydra.utils.instantiate()` target blocking added in Hydra 1.3.4 for CVE-2026-68508.

**Are we affected?** Not exploitable in practice, but the vulnerable code was in the dependency tree. ModelOpt calls `hydra.utils.instantiate()` in four places, all inside `modelopt/torch/puzzletron`:

- `modelopt/torch/puzzletron/entrypoint.py:58`
- `modelopt/torch/puzzletron/scoring.py:82`
- `modelopt/torch/puzzletron/puzzletron_nas_plugin.py:126` and `:227`

In every case the config is composed by `initialize_hydra_config_for_dir()` from a local directory path the caller supplies, and the only overrides ModelOpt injects are the fixed `puzzle_dir` and `dataset_path`. Nothing reads a Hydra config out of model metadata, a checkpoint, or any downloaded artifact, which is the model-loader scenario the advisory calls out. Every `_target_` in the shipped `examples/puzzletron/configs/` resolves to a ModelOpt descriptor or pruning mixin class.

Two things worth recording for future readers:

- `modelopt/torch/puzzletron/scoring.py` is decorated with `@hydra.main`, so running it directly accepts arbitrary CLI overrides such as `+x._target_=os.system`. That crosses no privilege boundary since the operator can already run Python.
- `modelopt/torch/puzzletron/tools/hydra_utils.py:102` registers a `${get_object:...}` OmegaConf resolver that imports arbitrary dotted paths during `OmegaConf.resolve`. The 1.3.4 fix does not cover that resolver, so it remains an equivalent gadget under the same assumption: a Hydra config directory is trusted input, equivalent to executable code.

**Why `~=1.3.4` and not `~=1.3.0`:** the compatible-release form `~=1.3.0` would still admit 1.3.0 through 1.3.3, which are the vulnerable releases. `~=1.3.4` means `>=1.3.4,<1.4.0`, so it enforces the fix while keeping us off the 1.4 line.

`uv.lock` is intentionally not regenerated here; it still pins `hydra-core==1.3.2`. The weekly `bump_uv_lock.yml` job will pick up the new constraint.

### Usage

```python
# No user-facing API change. Install the puzzletron extra as usual:
# pip install "nvidia-modelopt[puzzletron]"
```

### Testing

Verified in a clean throwaway venv, not in the repo environment:

- `pip install "hydra-core~=1.3.4"` resolves to 1.3.6, the current stable release.
- Confirmed 1.3.6 ships `hydra/_internal/target_policy.py`, absent in 1.3.2, and that 1.3.2's `_resolve_target` has no target checks.
- Confirmed the new policy is a **blocklist** of specific dangerous callables, not a deny-by-default allowlist, so third-party targets such as our `modelopt.torch.puzzletron.*` descriptors are unaffected. This was the main compatibility risk of the bump.
- Smoke-tested `instantiate()` on 1.3.6: benign targets (`collections.OrderedDict`, `pathlib.Path`) instantiate normally, while `builtins.eval` raises `InstantiationException`.
- Confirmed no `_target_` value in `examples/puzzletron/configs/` appears in `DEFAULT_BLOCKLISTED_MODULES` or `UNCONTROLLED_EXECUTION_TARGETS`.

I did not run the puzzletron pipeline end to end against 1.3.6; it needs multi-GPU and a model checkpoint.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ — dependency floor bump with no user-facing behavior change.
- Did you get Claude approval on this PR?: N/A

### Additional Information

Advisory: CVE-2026-68508, fixed in hydra-core 1.3.4. Latest stable is 1.3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an optional dependency to a compatible Hydra Core 1.3.x release range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->