### PR TITLE
fix: validate kd_loss_weight type and reject negative individual weights

### DIFF
--- a/modelopt/torch/distill/loss_balancers.py
+++ b/modelopt/torch/distill/loss_balancers.py
@@ -92,8 +92,13 @@ class StaticLossBalancer(DistillationLossBalancer):
             ValueError if kd_loss_weight is out of bounds.
         """
         super().__init__()
-        if isinstance(kd_loss_weight, float):
-            kd_loss_weight = [kd_loss_weight]
+        if isinstance(kd_loss_weight, (int, float)):
+            kd_loss_weight = [float(kd_loss_weight)]
+
+        if any(w < 0.0 for w in kd_loss_weight):
+            raise ValueError(
+                f"Individual kd_loss_weight values must be non-negative, got {kd_loss_weight}"
+            )
 
         sum_kd_loss_weight = sum(kd_loss_weight)
         if sum_kd_loss_weight < 0.0 or sum_kd_loss_weight > 1.0:

--- a/tests/unit/torch/distill/test_loss_balancers.py
+++ b/tests/unit/torch/distill/test_loss_balancers.py
@@ -1,0 +1,18 @@
+"""Test distillation loss balancers."""
+# pyrefly: ignore [missing-import]
+import pytest
+from modelopt.torch.distill.loss_balancers import StaticLossBalancer
+
+@pytest.mark.parametrize(
+    ("weight", "expected"),
+    [(1, [1.0]), (0.5, [0.5])],
+)
+def test_static_loss_balancer_weight_validation(weight, expected):
+    """Test that StaticLossBalancer correctly validates scalar and negative weights."""
+    # 1. Verify scalar weights are accepted (and cast to list of float)
+    balancer = StaticLossBalancer(weight)
+    assert balancer._kd_loss_weight == expected
+
+    # 2. Verify negative individual weights are rejected even if sum is valid
+    with pytest.raises(ValueError, match="non-negative"):
+        StaticLossBalancer([0.5, -0.3])


### PR DESCRIPTION
Addresses one item (Bug #4: loss-balancer validation gaps) from #1926.

### What does this PR do?

**Type of change:** Bug fix

This PR addresses two validation gaps in `StaticLossBalancer` that could lead to crashes or silent algorithmic errors during knowledge distillation.

### Root Cause & Rationale

**1. Fixes integer scalar input handling:**

`StaticLossBalancer` previously checked specifically for `float` to wrap scalar inputs into a list. Passing an integer (e.g., `1`) bypassed this check, resulting in a raw integer being passed to `sum()`, which raised `TypeError: 'int' object is not iterable`.

The check now accepts both `int` and `float` so scalar numeric inputs are handled consistently.

```diff
- if isinstance(kd_loss_weight, float):
+ if isinstance(kd_loss_weight, (int, float)):
```

**2. Fixes negative weight validation gap:**

The balancer validated that the *sum* of the weights was between `0.0` and `1.0`, but did not check the individual elements.

This meant a configuration like `[0.5, -0.3]` could pass the sum bounds check because the total is `0.2`, despite containing an invalid negative loss weight.

An explicit guard is added to reject individual negative weights:

```diff
+ if any(w < 0.0 for w in kd_loss_weight):
+     raise ValueError(
+         f"Individual kd_loss_weight values must be non-negative, got {kd_loss_weight}"
+     )
```

All existing `warnings.warn` logic and sum-bounds checks remain unchanged.

### Usage

```python
from modelopt.torch.distill.loss_balancers import StaticLossBalancer

# Integer scalar inputs are now handled correctly.
balancer = StaticLossBalancer(1)

# Negative individual weights are now rejected.
balancer = StaticLossBalancer([0.5, -0.3])
# Raises ValueError: Individual kd_loss_weight values must be non-negative
```

### Testing

Added a new test suite for distillation loss balancers.

* **What I ran:** `pytest tests/unit/torch/distill/test_loss_balancers.py`
* **Validation:** Both regression tests pass with this change and fail when run against the unmodified `main` branch.

### Before your PR is "*Ready for review*"

I have read and followed the [[Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md), and my commits are signed (`git commit -s -S`).

I have read and followed the [[Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors)](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors). This change does not introduce `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, or similar unsafe patterns.

* Is this change backward compatible?: ✅
* If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
* Did you write any new necessary tests?: ✅
* Did you update [[Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
* Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Related to #1926 (Bug #4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Static loss balancing now accepts integer weighting values.
  - Integer values are converted to the expected single-value format for consistent handling.
  - Negative individual weights are rejected with a validation error before total-weight checks, providing clearer validation behavior.

- **Tests**
  - Added coverage for integer and floating-point weight conversion.
  - Added validation coverage confirming that negative weights raise an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->