### PR TITLE
Fix selected layers being skipped by post-init sparsity

### DIFF
--- a/modelopt/torch/puzzletron/tools/post_init_sparse.py
+++ b/modelopt/torch/puzzletron/tools/post_init_sparse.py
@@ -82,9 +82,9 @@ class SparsityMethod:
 
         if mask_dict is None:
             state_dict_for_sparsifying = {
-                k.rstrip(".weight"): v
+                k.removesuffix(".weight"): v
                 for k, v in model.state_dict().items()
-                if k.rstrip(".weight") in full_name_layers
+                if k.removesuffix(".weight") in full_name_layers
             }
             mask_dict = self.calculate_masks(state_dict_for_sparsifying)
         # print('Apply sparsity')

--- a/tests/unit/torch/puzzletron/test_post_init_sparse.py
+++ b/tests/unit/torch/puzzletron/test_post_init_sparse.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for post-initialization structured sparsity."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from modelopt.torch.puzzletron.tools.post_init_sparse import SparsityMethod2o4
+
+
+@pytest.mark.parametrize("layer_name", ["dense", "gate", "proj"])
+def test_do_sparsity_preserves_layer_name(layer_name):
+    block = nn.Module()
+    block.mlp = nn.Module()
+    linear = nn.Linear(4, 2, bias=False)
+    block.mlp.add_module(layer_name, linear)
+
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList([block])
+    model.config = SimpleNamespace(
+        block_configs=[
+            SimpleNamespace(
+                ffn=SimpleNamespace(sparsify=[layer_name]),
+                attention=SimpleNamespace(sparsify=[]),
+            )
+        ]
+    )
+    with torch.no_grad():
+        linear.weight.copy_(torch.arange(1, 9, dtype=torch.float32).reshape(2, 4))
+
+    SparsityMethod2o4().do_sparsity(model)
+
+    expected_mask = torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]], dtype=torch.float32)
+    torch.testing.assert_close(linear.weight_mask, expected_mask)
+    torch.testing.assert_close(linear.weight, linear.weight_orig * expected_mask)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

<!-- Details about the change. -->

`do_sparsity()` silently skips selected layers such as `dense` and `gate`: `rstrip(".weight")` treats its argument as a set of characters, turning `dense.weight` into `dens` and `gate.weight` into `ga`. Those names no longer match the selected modules. Remove the literal suffix instead.

### Usage

No API changes. The regression test builds a small model and applies `SparsityMethod2o4().do_sparsity(model)` to each selected layer.

### Testing
<!-- Mention how have you tested your change if applicable. -->

On main, the regression test fails for `dense` and `gate` because no pruning mask is attached; the `proj` control passes. With the fix, all three cases pass and verify the mask and resulting weights. All 13 tests in `test_post_init_sparse.py` and `test_common.py` pass on CPU. Pre-commit checks pass for both changed files.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information
<!-- E.g. related issue. -->

Found while inspecting the layer-name filtering in the post-initialization sparsity helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sparsity processing for layers whose names include `.weight`, ensuring the correct model parameters are matched and updated.

* **Tests**
  * Added coverage for structured 2:4 sparsity across `dense`, `gate`, and `proj` MLP layers, including mask placement and resulting weight values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->