### PR TITLE
Review PRs on stacked branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,8 +46,8 @@ reviews:
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
     drafts: false
-    base_branches: ["main", "release/.*", "feature/.*"]
-    labels: ["puzzletron_v2"]
+    # Temporary for feature/puzzletron_v2 stacks. Revisit before merging this branch into main.
+    base_branches: [".*"]
   pre_merge_checks:
     custom_checks:
       - name: "Security anti-patterns"


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

CodeRabbit skips Puzzletron PRs when their base is another branch in a PR stack because its label and base branch filters are combined rather than treated as alternatives. This change removes the label filter and allows every base branch name, so PRs in the temporary Puzzletron lineage are automatically reviewed regardless of their stack position.

This broad policy is intentionally scoped by the configuration living on `feature/puzzletron_v2` and branches descended from it. Revisit it before merging that branch into `main`, unless repository-wide reviews on every target branch are desired.

### Testing

The YAML pre-commit hook passed. The resulting base branch filter was also checked against the default, release, feature, and stacked branch naming patterns.

### Before your PR is "Ready for review"

- Is this change backward compatible?: yes
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A, this is a configuration-only fix.
- Did you update `CHANGELOG.rst`?: N/A
- Did you get Claude approval on this PR?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated temporary branch matching to apply across all base branches.
  * Removed the previous branch-specific matching rules and associated label configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->