### PR TITLE
Prune low-value Puzzletron test coverage

### DIFF
--- a/tests/unit/torch/puzzletron/evaluation/vlm/test_run.py
+++ b/tests/unit/torch/puzzletron/evaluation/vlm/test_run.py
@@ -43,12 +43,10 @@ def test_direct_launcher_does_not_shadow_standard_library_profile():
 
 
 def test_vlm_parser_exposes_only_suite_owned_sample_limits():
-    help_text = evaluation._build_parser().format_help()
+    parser = evaluation._build_parser()
+    help_text = parser.format_help()
     assert "--limit" not in help_text
     assert "--full" not in help_text
     assert "--tasks" not in help_text
     assert "--evaluation-profile" not in help_text
-
-
-def test_vlm_parser_defaults_to_short_suite():
-    assert evaluation._build_parser().get_default("suite") == "short"
+    assert parser.get_default("suite") == "short"

--- a/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
+++ b/tests/unit/torch/puzzletron/test_aiperf_context_capacity.py
@@ -34,7 +34,6 @@ from modelopt.torch.puzzletron.benchmarks.aiperf import (
     _PeakGpuMemorySampler,
     _prepare_vllm_checkpoint,
     _profile_command,
-    _resolve_executable,
     _run_profile_command_async,
     _server_max_model_len,
     _topology_vllm_args,
@@ -81,15 +80,6 @@ def test_profile_command_terminates_child_when_cancelled(monkeypatch):
 
     assert process.killed
     assert process.returncode == -9
-
-
-def test_resolve_executable_uses_program_specific_configuration_hint(monkeypatch):
-    monkeypatch.setattr(
-        "modelopt.torch.puzzletron.benchmarks.aiperf.shutil.which", lambda *_args, **_kwargs: None
-    )
-
-    with pytest.raises(FileNotFoundError, match="Cannot find executable vllm; add vLLM to PATH"):
-        _resolve_executable("vllm", configuration_hint="add vLLM to PATH")
 
 
 def test_aiperf_server_environment_installs_vllm_torch_compatibility(monkeypatch):

--- a/tests/unit/torch/puzzletron/test_benchmark_report.py
+++ b/tests/unit/torch/puzzletron/test_benchmark_report.py
@@ -78,8 +78,6 @@ def test_aiperf_report_plots_repetition_medians_by_workload(tmp_path):
         ("student", "profile", "topology-a"): (2, {"output_token_throughput": 10.0}),
         ("teacher", "profile", "topology"): (2, {"output_token_throughput": 12.0}),
     }
-    assert "id='workload'" in report
-
     json_rows = json.loads((tmp_path / "aiperf_results.json").read_text())
     assert json_rows[0]["repetition"] == 0
     assert json_rows[0]["checkpoint_identity"] == {

--- a/tests/unit/torch/puzzletron/test_bypass_losses.py
+++ b/tests/unit/torch/puzzletron/test_bypass_losses.py
@@ -23,7 +23,6 @@ from modelopt.torch.puzzletron.bypass_distillation.losses import (
     normalized_mse_loss,
     vectorwise_normalized_mse_loss,
 )
-from modelopt.torch.puzzletron.utils.parsing import format_stitched_losses
 
 
 def test_vectorwise_normalized_mse_loss_matches_batched_last_dim():
@@ -89,34 +88,3 @@ def test_batched_normalized_mse_loss_rejects_invalid_inputs():
     ]:
         with pytest.raises(ValueError, match=match):
             batched_normalized_mse_loss(*args, **kwargs)
-
-
-def test_format_stitched_losses_reports_expected_summary_states():
-    non_finite_out = format_stitched_losses(
-        {"block_0": float("nan"), "block_1": 1.0},
-        initial_values_dict={"block_0": 0.5, "block_1": 2.0},
-        not_trainable_names={"block_2"},
-        step_number=3,
-    )
-    assert "nan" in non_finite_out
-    assert "non-finite" in non_finite_out
-    assert "Skipped=1" in non_finite_out
-    assert "No trainable blocks found" not in non_finite_out
-
-    empty_out = format_stitched_losses({}, not_trainable_names={"block_0", "block_1"})
-    assert empty_out == "No trainable losses found; skipped 2 non-trainable blocks"
-
-    delta_out = format_stitched_losses(
-        {"block_0": 1.0, "block_1": 3.0},
-        best_steps_dict={"block_0": 5, "block_9": 99},
-        best_values_dict={"block_0": 0.5, "block_9": 9.0},
-        initial_values_dict={"block_0": 2.0, "block_1": 3.0, "block_9": 9.0},
-        not_trainable_names={"block_2"},
-        step_number=8,
-    )
-    assert "↓ -1.0e+00 (-50%)" in delta_out
-    assert "↔ 0.0e+00" in delta_out
-    assert "Step 5" in delta_out
-    assert "Step 99" not in delta_out
-    assert "Skipped=1" in delta_out
-    assert "Avg=2.00e+00" in delta_out

--- a/tests/unit/torch/puzzletron/test_bypass_observations.py
+++ b/tests/unit/torch/puzzletron/test_bypass_observations.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import importlib
 import json
@@ -8,9 +20,7 @@ import pytest
 
 
 def _observations_module():
-    return importlib.import_module(
-        "modelopt.torch.puzzletron.bypass_distillation.observations"
-    )
+    return importlib.import_module("modelopt.torch.puzzletron.bypass_distillation.observations")
 
 
 def _selection(candidate_id, *, active=75, teacher=100):
@@ -133,4 +143,3 @@ def test_observation_writer_recovers_partial_line_and_truncates_after_step(tmp_p
     writer.truncate_after_step(2)
 
     assert writer.steps() == [1, 2]
-    assert path.read_text().endswith("\n")

--- a/tests/unit/torch/puzzletron/test_ci_image_contract.py
+++ b/tests/unit/torch/puzzletron/test_ci_image_contract.py
@@ -100,38 +100,6 @@ def test_lmms_eval_compatibility_patch_reconciles_worker_dependencies(project_ro
     patch = puzzletron_root / "patches" / lmms_source["compatibility_patch"]
     patch_bytes = patch.read_bytes()
     assert hashlib.sha256(patch_bytes).hexdigest() == lmms_source["compatibility_patch_sha256"]
-    changed_lines = [
-        line
-        for line in patch_bytes.decode().splitlines()
-        if line.startswith(("+", "-"))
-        and line not in {"+", "-"}
-        and not line.startswith(("+++ ", "--- "))
-    ]
-    assert changed_lines == [
-        "-from typing import Any, Dict, List, Literal, Tuple",
-        "+from typing import Any, Dict, List, Tuple",
-        '-def get_wandb_printer() -> Literal["Printer"]:',
-        '-    """Returns a wandb printer instance for pretty stdout."""',
-        "-    from wandb.sdk.wandb_settings import Settings",
-        "-    try:",
-        "-        from wandb.sdk.lib.printer import get_printer",
-        "-    except ImportError:",
-        "-        from wandb.sdk.lib.printer import new_printer as get_printer",
-        "-    printer = get_printer(Settings()._jupyter)",
-        "-    return printer",
-        "-        self.printer = get_wandb_printer()",
-        "-                sampling_params = SamplingParams(**params)",
-        "-from latex2sympy2 import latex2sympy",
-        "+from latex2sympy2_extended import latex2sympy",
-        "-from latex2sympy2 import latex2sympy",
-        "+from latex2sympy2_extended import latex2sympy",
-        "-from latex2sympy2 import latex2sympy",
-        "+from latex2sympy2_extended import latex2sympy",
-        '-    "latex2sympy2",',
-        '+    "latex2sympy2-extended==1.11.0",',
-        '-    "wandb==0.25.0",',
-        '+    "wandb>=0.28.0,<0.30",',
-    ]
     assert lmms_source["compatibility_patch_files"] == [
         "lmms_eval/loggers/wandb_logger.py",
         "lmms_eval/models/simple/vllm.py",

--- a/tests/unit/torch/puzzletron/test_common.py
+++ b/tests/unit/torch/puzzletron/test_common.py
@@ -25,24 +25,12 @@ import modelopt.torch.puzzletron as mtpz
     ("input_dtype", "expected"),
     [
         ("torch.bfloat16", torch.bfloat16),
-        ("torch.float16", torch.float16),
         ("torch.float32", torch.float32),
         ("bfloat16", torch.bfloat16),
         ("float16", torch.float16),
-        ("float32", torch.float32),
-        (torch.bfloat16, torch.bfloat16),
         (torch.float32, torch.float32),
     ],
-    ids=[
-        "str-bf16",
-        "str-fp16",
-        "str-fp32",
-        "bare-bf16",
-        "bare-fp16",
-        "bare-fp32",
-        "dtype-bf16",
-        "dtype-fp32",
-    ],
+    ids=["qualified", "qualified-fp32", "bare", "bare-fp16", "dtype"],
 )
 def test_resolve_torch_dtype(input_dtype, expected):
     assert mtpz.tools.resolve_torch_dtype(input_dtype) is expected

--- a/tests/unit/torch/puzzletron/test_data_config.py
+++ b/tests/unit/torch/puzzletron/test_data_config.py
@@ -91,16 +91,10 @@ def test_pipeline_boundary_rejects_stage_local_legacy_varlen():
         )
 
 
-def test_pipeline_defaults_sort_sanity_to_include_reverse():
-    canonical = normalize_pipeline_config({})
-
-    assert canonical["sort_sanity"]["include_reverse"] is True
-
-
-def test_pipeline_preserves_explicit_reverse_sort_opt_out():
-    canonical = normalize_pipeline_config({"sort_sanity": {"include_reverse": False}})
-
-    assert canonical["sort_sanity"]["include_reverse"] is False
+def test_pipeline_normalizes_reverse_sort_sanity_policy():
+    assert normalize_pipeline_config({})["sort_sanity"]["include_reverse"] is True
+    explicit = normalize_pipeline_config({"sort_sanity": {"include_reverse": False}})
+    assert explicit["sort_sanity"]["include_reverse"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/torch/puzzletron/test_dataset_acquisition.py
+++ b/tests/unit/torch/puzzletron/test_dataset_acquisition.py
@@ -24,7 +24,6 @@ from PIL import Image
 from modelopt.torch.puzzletron.dataset.acquisition import (
     NEMOTRON_VLM_DATASET,
     PUZZLE_KD_DATASET,
-    VLM_HEADER_SUBSETS,
     TextAcquisitionSpec,
     VlmAcquisitionSpec,
     largest_remainder_quotas,
@@ -48,6 +47,15 @@ def _messages(image_name: str, *, answer: str = "answer"):
         },
         {"role": "assistant", "content": [{"type": "text", "text": answer}]},
     ]
+
+
+def _one_vlm_row(**kwargs):
+    del kwargs
+    yield {
+        "id": "only",
+        "messages": _messages("only.png"),
+        "image": Image.new("RGB", (2, 2)),
+    }
 
 
 def test_vlm_acquisition_rejects_invalid_bounds_and_duplicate_subsets(tmp_path):
@@ -209,14 +217,6 @@ def test_nemotron_materializer_redistributes_exhausted_subset_quota(tmp_path):
 
 
 def test_nemotron_materializer_rejects_shortfall_and_cache_mismatch(tmp_path):
-    def one_row(**kwargs):
-        del kwargs
-        yield {
-            "id": "only",
-            "messages": _messages("only.png"),
-            "image": Image.new("RGB", (2, 2)),
-        }
-
     with pytest.raises(RuntimeError, match="only found 1/2"):
         materialize_nemotron_vlm_dataset(
             VlmAcquisitionSpec(
@@ -225,7 +225,7 @@ def test_nemotron_materializer_rejects_shortfall_and_cache_mismatch(tmp_path):
                 num_samples=2,
                 revision="sha",
             ),
-            sample_loader=one_row,
+            sample_loader=_one_vlm_row,
         )
 
     materialize_nemotron_vlm_dataset(
@@ -235,7 +235,7 @@ def test_nemotron_materializer_rejects_shortfall_and_cache_mismatch(tmp_path):
             num_samples=1,
             revision="sha",
         ),
-        sample_loader=one_row,
+        sample_loader=_one_vlm_row,
     )
     with pytest.raises(ValueError, match="does not match"):
         materialize_nemotron_vlm_dataset(
@@ -245,20 +245,12 @@ def test_nemotron_materializer_rejects_shortfall_and_cache_mismatch(tmp_path):
                 num_samples=1,
                 revision="sha",
             ),
-            sample_loader=one_row,
+            sample_loader=_one_vlm_row,
         )
 
 
 @pytest.mark.parametrize("missing_manifest", ["manifest.json", "puzzletron_acquisition.json"])
 def test_existing_vlm_materialization_reuses_pinned_revision_offline(tmp_path, missing_manifest):
-    def one_row(**kwargs):
-        del kwargs
-        yield {
-            "id": "only",
-            "messages": _messages("only.png"),
-            "image": Image.new("RGB", (2, 2)),
-        }
-
     materialize_nemotron_vlm_dataset(
         VlmAcquisitionSpec(
             output_dir=tmp_path,
@@ -266,7 +258,7 @@ def test_existing_vlm_materialization_reuses_pinned_revision_offline(tmp_path, m
             num_samples=1,
             revision="pinned-sha",
         ),
-        sample_loader=one_row,
+        sample_loader=_one_vlm_row,
     )
     (tmp_path / missing_manifest).unlink()
 
@@ -286,14 +278,6 @@ def test_existing_vlm_materialization_reuses_pinned_revision_offline(tmp_path, m
 
 
 def test_existing_vlm_materialization_ignores_non_object_primary_manifest(tmp_path):
-    def one_row(**kwargs):
-        del kwargs
-        yield {
-            "id": "only",
-            "messages": _messages("only.png"),
-            "image": Image.new("RGB", (2, 2)),
-        }
-
     materialize_nemotron_vlm_dataset(
         VlmAcquisitionSpec(
             output_dir=tmp_path,
@@ -301,7 +285,7 @@ def test_existing_vlm_materialization_ignores_non_object_primary_manifest(tmp_pa
             num_samples=1,
             revision="pinned-sha",
         ),
-        sample_loader=one_row,
+        sample_loader=_one_vlm_row,
     )
     (tmp_path / "manifest.json").write_text("[]")
 
@@ -320,14 +304,6 @@ def test_existing_vlm_materialization_ignores_non_object_primary_manifest(tmp_pa
 
 @pytest.mark.parametrize("payload", ["samples", "sample_text", "image"])
 def test_existing_vlm_materialization_rejects_corrupt_payload(tmp_path, payload):
-    def one_row(**kwargs):
-        del kwargs
-        yield {
-            "id": "only",
-            "messages": _messages("only.png"),
-            "image": Image.new("RGB", (2, 2)),
-        }
-
     materialize_nemotron_vlm_dataset(
         VlmAcquisitionSpec(
             output_dir=tmp_path,
@@ -335,7 +311,7 @@ def test_existing_vlm_materialization_rejects_corrupt_payload(tmp_path, payload)
             num_samples=1,
             revision="pinned-sha",
         ),
-        sample_loader=one_row,
+        sample_loader=_one_vlm_row,
     )
     if payload == "samples":
         (tmp_path / "samples.json").write_text("[]")
@@ -368,14 +344,6 @@ def test_existing_vlm_materialization_rejects_corrupt_payload(tmp_path, payload)
 def test_existing_vlm_materialization_repairs_noncanonical_acquisition_manifest(
     tmp_path, cached_payload
 ):
-    def one_row(**kwargs):
-        del kwargs
-        yield {
-            "id": "only",
-            "messages": _messages("only.png"),
-            "image": Image.new("RGB", (2, 2)),
-        }
-
     expected = materialize_nemotron_vlm_dataset(
         VlmAcquisitionSpec(
             output_dir=tmp_path,
@@ -383,7 +351,7 @@ def test_existing_vlm_materialization_repairs_noncanonical_acquisition_manifest(
             num_samples=1,
             revision="pinned-sha",
         ),
-        sample_loader=one_row,
+        sample_loader=_one_vlm_row,
     )
     acquisition_path = tmp_path / "puzzletron_acquisition.json"
     acquisition_path.write_text(cached_payload)
@@ -438,7 +406,3 @@ def test_puzzle_kd_materializer_bounds_both_splits(tmp_path):
         (PUZZLE_KD_DATASET, "validation", "text-sha", True),
     ]
     assert json.loads((tmp_path / "puzzletron_acquisition.json").read_text()) == manifest
-
-
-def test_first_class_defaults_are_stable():
-    assert VLM_HEADER_SUBSETS == ("sparsetables", "plotqa_cot", "wiki_en")

--- a/tests/unit/torch/puzzletron/test_expected_results.py
+++ b/tests/unit/torch/puzzletron/test_expected_results.py
@@ -66,18 +66,27 @@ def _contract(tmp_path: Path) -> Path:
     return path
 
 
-def test_expectation_verifier_projects_fields_and_allows_one_directional_row_flip(
-    tmp_path: Path,
+def _write_observation(
+    contract: Path,
+    *,
+    identity: dict | None = None,
+    correct_rows: int = 7,
 ) -> None:
-    contract = _contract(tmp_path)
     _write(
         contract.with_name("observation.json"),
         {
             "schema": "modelopt.puzzletron-reference-observation/v1",
             "contract_id": "smoke-v1",
-            "values": {"identity": {"profile": "smoke-native-v1"}, "correct_rows": 7},
+            "values": {"identity": identity or {}, "correct_rows": correct_rows},
         },
     )
+
+
+def test_expectation_verifier_projects_fields_and_allows_one_directional_row_flip(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(tmp_path)
+    _write_observation(contract, identity={"profile": "smoke-native-v1"})
     run = tmp_path / "run"
     _write(
         run / "artifacts/result.json",
@@ -105,14 +114,7 @@ def test_expectation_verifier_distinguishes_regression_from_invalid_evidence(
     tmp_path: Path,
 ) -> None:
     contract = _contract(tmp_path)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {"profile": "smoke-native-v1"}, "correct_rows": 7},
-        },
-    )
+    _write_observation(contract, identity={"profile": "smoke-native-v1"})
     run = tmp_path / "run"
     result_path = run / "artifacts/result.json"
     _write(
@@ -134,14 +136,7 @@ def test_expectation_verifier_distinguishes_regression_from_invalid_evidence(
 
 def test_expectation_verifier_rejects_invalid_denominator_evidence(tmp_path: Path) -> None:
     contract = _contract(tmp_path)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {"profile": "smoke-native-v1"}, "correct_rows": 7},
-        },
-    )
+    _write_observation(contract, identity={"profile": "smoke-native-v1"})
     run = tmp_path / "run"
     _write(
         run / "artifacts/result.json",
@@ -189,18 +184,10 @@ def test_expectation_verifier_follows_root_confined_artifact_pointers(tmp_path: 
         }
     )
     _write(contract, contract_payload)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {
-                "identity": {"profile": "smoke-native-v1"},
-                "correct_rows": 7,
-                "profile": "smoke-native-v1",
-            },
-        },
-    )
+    _write_observation(contract, identity={"profile": "smoke-native-v1"})
+    observation = json.loads(contract.with_name("observation.json").read_text())
+    observation["values"]["profile"] = "smoke-native-v1"
+    _write(contract.with_name("observation.json"), observation)
     run = tmp_path / "run"
     manifest = run / "artifacts/curve.json"
     observations = run / "artifacts/observations.json"
@@ -230,14 +217,7 @@ def test_expectation_verifier_rejects_artifact_pointer_escape(tmp_path: Path) ->
         "follow": ["/observations_path"],
     }
     _write(contract, payload)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {}, "correct_rows": 0},
-        },
-    )
+    _write_observation(contract, correct_rows=0)
     run = tmp_path / "run"
     _write(run / "artifacts/result.json", {"identity": {}, "correct_rows": 0, "timing_ms": 1})
     _write(run / "artifacts/summary.json", {"observations_path": str(tmp_path / "outside.json")})
@@ -254,14 +234,7 @@ def test_verification_cli_returns_result_exit_code_and_json(
     capsys,
 ) -> None:
     contract = _contract(tmp_path)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {}, "correct_rows": 7},
-        },
-    )
+    _write_observation(contract)
     run = tmp_path / "run"
     result_path = run / "artifacts/result.json"
     _write(result_path, {"identity": {}, "correct_rows": 5, "timing_ms": 1})
@@ -277,14 +250,7 @@ def test_orchestrator_returns_expectation_regression_exit_code(
     capsys,
 ) -> None:
     contract = _contract(tmp_path)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {}, "correct_rows": 7},
-        },
-    )
+    _write_observation(contract)
     run = tmp_path / "run"
     _write(run / "artifacts/result.json", {"identity": {}, "correct_rows": 5, "timing_ms": 1})
     plan = SimpleNamespace(
@@ -375,14 +341,7 @@ def test_reusable_orchestrator_verifies_expectation_after_worker_completion(
     capsys,
 ) -> None:
     contract = _contract(tmp_path)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {}, "correct_rows": 7},
-        },
-    )
+    _write_observation(contract)
     run = tmp_path / "run"
     _write(run / "artifacts/result.json", {"identity": {}, "correct_rows": 5, "timing_ms": 1})
     plan = SimpleNamespace(
@@ -428,14 +387,7 @@ def test_reusable_orchestrator_verifies_expectation_after_worker_completion(
 
 def test_exact_fields_preserve_json_types(tmp_path: Path) -> None:
     contract = _contract(tmp_path)
-    _write(
-        contract.with_name("observation.json"),
-        {
-            "schema": "modelopt.puzzletron-reference-observation/v1",
-            "contract_id": "smoke-v1",
-            "values": {"identity": {"profile": 1}, "correct_rows": 7},
-        },
-    )
+    _write_observation(contract, identity={"profile": 1})
     run = tmp_path / "run"
     _write(
         run / "artifacts/result.json",

--- a/tests/unit/torch/puzzletron/test_hf_dataset_catalog.py
+++ b/tests/unit/torch/puzzletron/test_hf_dataset_catalog.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from types import SimpleNamespace
 
@@ -9,7 +21,6 @@ from puzzletron_setup import SetupError
 from puzzletron_setup.v2.hf_datasets import (
     HfSubsetCatalog,
     discover_hf_subset_catalog,
-    format_subset_choice,
     proportional_subset_weights,
 )
 
@@ -115,22 +126,6 @@ def test_catalog_falls_back_to_hosted_or_parquet_bytes_when_original_size_is_abs
     assert all(item.selectable for item in catalog.subsets)
 
 
-def test_catalog_preserves_all_46_dynamic_configurations():
-    names = [f"subset_{index:02d}" for index in range(46)]
-
-    catalog = discover_hf_subset_catalog(
-        "nvidia/forty-six",
-        config_names_loader=lambda source, revision=None: names,
-        size_payload_loader=lambda source: _sizes(
-            *((name, index + 1, (index + 1) * 1000) for index, name in enumerate(names))
-        ),
-        api=_FakeApi(),
-    )
-
-    assert len(catalog.subsets) == 46
-    assert [item.name for item in catalog.subsets] == names
-
-
 def test_generic_catalog_does_not_require_nemotron_media_layout():
     catalog = discover_hf_subset_catalog(
         "owner/generic",
@@ -141,9 +136,6 @@ def test_generic_catalog_does_not_require_nemotron_media_layout():
     )
 
     assert catalog.subsets[0].selectable
-    assert format_subset_choice(catalog.subsets[0]) == (
-        "trainable — 5 rows — 2.00 KiB"
-    )
 
 
 def test_missing_or_zero_size_metadata_disables_subset():

--- a/tests/unit/torch/puzzletron/test_lmms_evaluation.py
+++ b/tests/unit/torch/puzzletron/test_lmms_evaluation.py
@@ -215,23 +215,6 @@ def test_command_maps_checkpoint_for_native_qwen35_backend(tmp_path):
     assert "tensor_parallel_size" not in model_args
 
 
-def test_command_forwards_unowned_model_and_evaluator_options(tmp_path):
-    argv, _, _ = lmms._build_command(
-        {
-            **_settings("ifeval"),
-            "model_args": {"new_vllm_option": "enabled"},
-            "extra_args": ["--new-lmms-option", "enabled"],
-        },
-        checkpoint="/ckpts/candidate",
-        output_path=tmp_path / "results",
-    )
-
-    model_args = argv[argv.index("--model_args") + 1]
-    evaluator_option = argv.index("--new-lmms-option")
-    assert "new_vllm_option=enabled" in model_args
-    assert argv[evaluator_option + 1] == "enabled"
-
-
 def test_command_splits_string_prefix(tmp_path):
     argv, _, _ = lmms._build_command(
         {**_settings("ifeval"), "command_prefix": "python -m lmms_eval"},

--- a/tests/unit/torch/puzzletron/test_orchestration_executors.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_executors.py
@@ -1556,54 +1556,6 @@ def test_post_mip_workers_share_one_packed_allocation(tmp_path: Path):
     assert attempt.command.argv[-2:] == ("--shard-count", "8")
 
 
-def test_replacement_pool_uses_one_four_node_gang_allocation(tmp_path: Path):
-    runner = RunnerEnvironment(
-        kind="slurm",
-        contract=ExecutionContract(repository=str(tmp_path), venv=str(tmp_path / ".venv")),
-        slurm=SlurmRunnerConfig(account="acct", partition="batch"),
-    )
-    node = StagePlanNode(
-        stage_id="replacement_scoring",
-        strategy=ExecutionStrategy.PERSISTENT_POOL,
-        instances=4,
-        failure_policy=FailurePolicy.STRICT,
-        mesh={"tp": 1, "cp": 1, "pp": 2, "ep": 4, "dp_shard": 4, "dp_replicate": 1},
-        gpus_per_instance=8,
-        gpus_per_node=8,
-        nodes=4,
-        total_gpus=32,
-        exclusive=True,
-        parents=("build_library",),
-        distributed=True,
-        partition="batch",
-    )
-    plan = CampaignPlan(
-        experiment_config_path=str(tmp_path / "experiment.yaml"),
-        puzzle_dir=tmp_path / "run",
-        experiment_config={"replacement_scoring": {}},
-        runner=runner,
-        execution_defaults={"gpus_per_node": 8},
-        stages=(node,),
-        contract_hash="contract",
-    )
-    adapter = adapter_for_stage(node)
-    work_plan = adapter.plan(plan, node)
-
-    assert [item.work_id for item in work_plan.items] == ["replacement_scoring:gang"]
-    attempt = adapter.command(
-        plan=plan,
-        node=node,
-        item=work_plan.items[0],
-        attempt_id="a1",
-        runner=runner,
-    )
-    assert attempt.allocation_nodes == 4
-    assert attempt.allocation_gpus == 32
-    assert attempt.metadata["kill_on_bad_exit"] is True
-    assert attempt.metadata["partition"] == "batch"
-    assert attempt.command.argv[-1].endswith("run_replacement_pool.sh")
-
-
 def test_replacement_pool_splits_workers_across_embedding_widths(tmp_path: Path):
     _, work_plan, attempts = _replacement_width_attempts(tmp_path, [2048, 1792])
 

--- a/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
+++ b/tests/unit/torch/puzzletron/test_orchestration_lightweight.py
@@ -31,25 +31,6 @@ from puzzletron_orchestrator.config import load_experiment_config
 REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 
 
-def test_orchestrator_help_explains_first_run_contracts() -> None:
-    result = subprocess.run(
-        [sys.executable, "examples/puzzletron/orchestrate.py", "--help"],
-        cwd=REPOSITORY_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
-    )
-
-    assert result.returncode == 0, result.stderr
-    help_text = " ".join(result.stdout.split())
-    assert "Experiment YAML: model, data, enabled stages, and output directory." in help_text
-    assert "Runner YAML: where and how worker jobs run" in help_text
-    assert "Execution YAML: how each stage runs" in help_text
-    assert "requires its parent artifacts" in help_text
-    assert "jobs keep running" in help_text
-
-
 def test_lightweight_package_does_not_import_torch() -> None:
     result = subprocess.run(
         [

--- a/tests/unit/torch/puzzletron/test_post_mip_execution_identity.py
+++ b/tests/unit/torch/puzzletron/test_post_mip_execution_identity.py
@@ -59,6 +59,9 @@ class _TrackingExecutor:
     def __init__(self) -> None:
         self.attempts = []
 
+    def can_submit_all(self, _attempts):
+        return True
+
     def submit(self, attempt):
         self.attempts.append(attempt)
         return JobHandle(

--- a/tests/unit/torch/puzzletron/test_post_mip_filters.py
+++ b/tests/unit/torch/puzzletron/test_post_mip_filters.py
@@ -25,7 +25,6 @@ from modelopt.torch.puzzletron.post_mip.records import (
     CandidateRevision,
     NodeObservation,
 )
-from modelopt.torch.puzzletron.post_mip.reporting import render_aiperf_report
 
 
 def _ledger(tmp_path, metrics_by_revision):
@@ -121,34 +120,6 @@ def test_multimodal_sweep_selection_resolves_one_image_workload(tmp_path):
     assert selected == ("revision-b",)
     assert excluded == {"revision-a": "outside top_k"}
     assert scores == {"revision-a": 25.0, "revision-b": 30.0}
-
-
-def test_aiperf_report_renders_multimodal_namespaced_metrics():
-    html = render_aiperf_report(
-        "vlm-serving",
-        {
-            "status": "completed",
-            "observations": [
-                {
-                    "label": "candidate-a",
-                    "status": "success",
-                    "selected_by": ["fastest_vlm"],
-                    "metrics": {
-                        "images_12.concurrency_1.request_throughput": 2.0,
-                        "images_12.concurrency_1.image_throughput": 24.0,
-                        "images_12.concurrency_1.output_token_throughput": 128.0,
-                        "images_12.concurrency_1.ttft_mean_ms": 10.0,
-                        "images_12.concurrency_1.tpot_mean_ms": 3.0,
-                    },
-                }
-            ],
-        },
-    )
-
-    assert "images 12 / concurrency 1" in html
-    assert "<td>24</td>" in html
-    assert "<td>128</td>" in html
-    assert "Selected by Fastest" in html
 
 
 def test_best_per_concurrency_unions_top_k_from_each_point(tmp_path):

--- a/tests/unit/torch/puzzletron/test_post_mip_reporting.py
+++ b/tests/unit/torch/puzzletron/test_post_mip_reporting.py
@@ -17,10 +17,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
-from modelopt.torch.puzzletron.post_mip.reporting import (
-    build_post_mip_report_payloads,
-    render_evaluation_report,
-)
+from modelopt.torch.puzzletron.post_mip.reporting import build_post_mip_report_payloads
 
 
 def _write_json(path: Path, payload: object) -> None:
@@ -28,7 +25,7 @@ def _write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def test_evaluation_report_compares_teacher_and_deduplicated_mip_origins(tmp_path: Path):
+def test_evaluation_payload_compares_teacher_and_deduplicated_mip_origins(tmp_path: Path):
     architecture_id = "architecture_shared"
     revision_id = "revision_candidate"
     execution_id = "post_mip_execution_test"
@@ -48,7 +45,6 @@ def test_evaluation_report_compares_teacher_and_deduplicated_mip_origins(tmp_pat
             "revisions": {
                 revision_id: {
                     "architecture_id": architecture_id,
-                    "artifact": {"hidden_width": 1024, "kind": "heterogeneous"},
                 },
                 "failed_revision": {"architecture_id": "architecture_invalid"},
             },
@@ -61,20 +57,10 @@ def test_evaluation_report_compares_teacher_and_deduplicated_mip_origins(tmp_pat
             {
                 "input_revision_id": revision_id,
                 "status": "success",
-                "metrics": {
-                    "candidate.lm_loss": 0.7,
-                    "candidate.token_accuracy_top_1": 0.8,
-                    "candidate.token_accuracy_top_10": 0.95,
-                    "reference.lm_loss": 0.5,
-                    "reference.token_accuracy_top_1": 0.9,
-                    "delta.lm_loss": 0.2,
-                },
             },
             {
                 "input_revision_id": "failed_revision",
                 "status": "failed",
-                "metrics": {"reference.lm_loss": None},
-                "error": "evaluation failed",
             },
         ],
     )
@@ -86,18 +72,6 @@ def test_evaluation_report_compares_teacher_and_deduplicated_mip_origins(tmp_pat
     )
 
     payload = build_post_mip_report_payloads(tmp_path, (node,))[node.stage_id]
-    rendered = render_evaluation_report(str(payload["section_id"]), payload)
 
     assert payload["observations"][0]["origin_kinds"] == ["heterogeneous", "homogeneous"]
     assert payload["observations"][1]["origin_kinds"] == []
-    assert rendered.count("Reference checkpoint") == 1
-    assert rendered.count("<td>Teacher</td>") == 1
-    assert "Heterogeneous" in rendered
-    assert "Homogeneous" in rendered
-    assert "Top-1 token accuracy" in rendered
-    assert "Top-10 token accuracy" in rendered
-    assert rendered.count("<td>0.8</td>") == 2
-    assert rendered.count("<td>0.9</td>") == 1
-    assert rendered.count("<td>0.95</td>") == 2
-    assert "evaluation failed" in rendered
-    assert rendered.count("Shared physical measurement (same architecture)") == 2

--- a/tests/unit/torch/puzzletron/test_post_mip_runner.py
+++ b/tests/unit/torch/puzzletron/test_post_mip_runner.py
@@ -112,37 +112,6 @@ def test_post_mip_kd_always_requests_a_consolidated_output():
     assert settings["max_steps"] == 8
 
 
-def test_worker_entrypoint_registers_configured_vlm_evaluation_profile(monkeypatch):
-    # Keep the examples-layer VLM dependencies out of core test collection.
-    from examples.puzzletron.evaluation.vlm import post_mip as vlm_post_mip
-
-    calls = []
-    monkeypatch.setattr(vlm_post_mip, "register_profiles", lambda: calls.append(True))
-
-    post_mip_entrypoint._register_evaluation_profiles(
-        {
-            "post_mip": {
-                "flows": {
-                    "params": {
-                        "nodes": {
-                            "checkpoint_eval": {
-                                "type": "downstream_evaluation",
-                                "config": {
-                                    "profile": (
-                                        "qwen35_vlm_realworldqa64_mmmu120_mvbench160_frozen_rows_v3"
-                                    )
-                                },
-                            },
-                        }
-                    },
-                }
-            }
-        }
-    )
-
-    assert calls == [True]
-
-
 def test_worker_entrypoint_leaves_unknown_vlm_profile_to_fail_closed(monkeypatch, tmp_path):
     from examples.puzzletron.evaluation.vlm import post_mip as vlm_post_mip
 
@@ -478,12 +447,8 @@ def test_aiperf_consumes_request_count_without_forwarding_setup_only_keys(
                 "minimum_request_count": 4,
                 "requests_per_concurrency": 2,
                 "best_selection_mode": "individual_best",
-                "allow_aiperf_v011_online_tokenizer_resolution": True,
                 "input_tokens": 1024,
                 "output_tokens": 128,
-                "image_batch_sizes": [1, 6, 12],
-                "image_width_mean": 1280,
-                "image_height_mean": 720,
                 "topology": {"gpu_group_size": 1},
             }
         },
@@ -500,18 +465,18 @@ def test_aiperf_consumes_request_count_without_forwarding_setup_only_keys(
         "execution",
     )
 
-    assert captured["checkpoint"] == str(tmp_path / "checkpoint")
     assert captured["concurrencies"] == (8,)
     assert captured["request_counts"] == {8: 23}
     assert captured["trust_remote_code"] is True
-    assert captured["allow_aiperf_v011_online_tokenizer_resolution"] is True
-    assert captured["image_batch_sizes"] == [1, 6, 12]
-    assert captured["image_width_mean"] == 1280
-    assert captured["image_height_mean"] == 720
-    assert "request_count" not in captured
-    assert "minimum_request_count" not in captured
-    assert "requests_per_concurrency" not in captured
-    assert "best_selection_mode" not in captured
+    assert (
+        not {
+            "request_count",
+            "minimum_request_count",
+            "requests_per_concurrency",
+            "best_selection_mode",
+        }
+        & captured.keys()
+    )
     assert result["metrics"] == {
         "output_token_throughput": 12.0,
         "images_12.concurrency_8.output_token_throughput": 12.0,
@@ -548,43 +513,6 @@ def test_aiperf_rejects_repetitions_with_different_metric_sets(monkeypatch, tmp_
 
     with pytest.raises(RuntimeError, match="repetitions produced different metrics"):
         runner._aiperf({"puzzle_dir": str(tmp_path)}, node, source, "execution")
-
-
-def test_downstream_evaluation_delegates_to_generic_checkpoint_evaluator(monkeypatch, tmp_path):
-    checkpoint = tmp_path / "checkpoint"
-    checkpoint.mkdir()
-    captured = {}
-
-    def fake_evaluate(checkpoint_path, *, output_root, settings):
-        captured.update(
-            checkpoint=checkpoint_path,
-            output_root=output_root,
-            settings=settings,
-        )
-        return {"metrics": {"ifeval.accuracy": 0.5}}
-
-    monkeypatch.setattr(runner, "run_lmms_eval_checkpoint", fake_evaluate)
-    node = SimpleNamespace(
-        node_id="lmms_eval",
-        config={"config": {"tasks": ["ifeval"], "limit": 4}},
-    )
-    source = SimpleNamespace(
-        architecture_id="architecture",
-        artifact_kind=ArtifactKind.CHECKPOINT,
-        artifact={"checkpoint": str(checkpoint)},
-    )
-
-    result = runner._downstream_evaluation({"puzzle_dir": str(tmp_path)}, node, source, "execution")
-
-    assert result == {"metrics": {"ifeval.accuracy": 0.5}}
-    assert captured == {
-        "checkpoint": str(checkpoint),
-        "output_root": (
-            tmp_path
-            / "artifacts/post_mip/nodes/lmms_eval/executions/execution/raw/architecture/lmms_eval"
-        ),
-        "settings": {"tasks": ["ifeval"], "limit": 4},
-    }
 
 
 def test_downstream_evaluation_routes_the_pinned_vlm_profile(monkeypatch, tmp_path):
@@ -1309,7 +1237,6 @@ def test_result_manifest_freezes_pre_kd_and_learning_curve(monkeypatch, tmp_path
     ledger = case.ledger
     node = case.node
     profile = case.profile
-    reference_fingerprint = case.reference_fingerprint
     revisions = case.revisions
 
     observations, output_set = runner._aggregate_result_manifest(
@@ -1329,66 +1256,51 @@ def test_result_manifest_freezes_pre_kd_and_learning_curve(monkeypatch, tmp_path
         evaluation_identity(256),
     ]
 
-    def expected_evaluation_result(accuracy):
-        return {
-            "candidate_evidence": evaluation_evidence(
-                "student-0" if accuracy == 0.1 else f"student-{int(accuracy * 1000)}"
-            ),
-            "metrics": {"accuracy": accuracy},
-            "reference_evidence": evaluation_evidence("teacher"),
-        }
-
-    assert manifest["exact_result"] == {
-        "axis_inventory": block_configs,
-        "checkpoint_and_lineage_identities": {
-            "architecture_id": architecture_id,
-            "milestones": [
-                {
-                    "checkpoint_fingerprint": f"student-{steps}",
-                    "content_manifest_sha256": f"step-{steps}",
-                    "producer_node": f"kd_{steps}",
-                    "steps": steps,
-                }
-                for steps in (64, 128, 256)
-            ],
-            "pre_kd_content_manifest_sha256": "pre-kd",
-            "pre_kd_checkpoint_fingerprint": "student-0",
-            "reference_checkpoint_fingerprint": reference_fingerprint,
-        },
-        "evaluation_results": {
-            "milestones": [
-                {"steps": steps, **expected_evaluation_result(steps / 1000)}
-                for steps in (64, 128, 256)
-            ],
-            "pre_kd": expected_evaluation_result(0.1),
-        },
-        "evaluator_contract": {
-            "contract": evaluator_contract,
-            "profile": profile,
-            "revision": "source-revision",
-        },
-        "kd_exposure": [{"cumulative_steps": steps} for steps in (64, 128, 256)],
-        "parameter_counts": {
-            "materialized_checkpoint": 6,
-            "mip_estimates": {"parameter_ratio": 0.9},
-        },
-        "realized_geometry_and_tensor_shapes": {
-            "geometry": {
-                "block_configs": block_configs,
-                "hidden_size": 8,
-                "num_hidden_layers": 1,
-            },
-            "tensor_count": 1,
-            "tensor_shapes": {"model.weight": {"dtype": "BF16", "shape": [2, 3]}},
-        },
-        "stage_completion": {
-            "milestones": [
-                {"evaluation": "success", "kd": "success", "steps": steps}
-                for steps in (64, 128, 256)
-            ],
-            "pre_kd": "success",
-        },
+    exact_result = manifest["exact_result"]
+    assert set(exact_result) == {
+        "axis_inventory",
+        "checkpoint_and_lineage_identities",
+        "evaluation_results",
+        "evaluator_contract",
+        "kd_exposure",
+        "parameter_counts",
+        "realized_geometry_and_tensor_shapes",
+        "stage_completion",
     }
+    assert exact_result["axis_inventory"] == block_configs
+    lineage = exact_result["checkpoint_and_lineage_identities"]
+    assert lineage["architecture_id"] == architecture_id
+    assert lineage["pre_kd_content_manifest_sha256"] == "pre-kd"
+    assert [row["content_manifest_sha256"] for row in lineage["milestones"]] == [
+        "step-64",
+        "step-128",
+        "step-256",
+    ]
+    assert exact_result["evaluator_contract"] == {
+        "contract": evaluator_contract,
+        "profile": profile,
+        "revision": "source-revision",
+    }
+    assert exact_result["kd_exposure"] == [{"cumulative_steps": steps} for steps in (64, 128, 256)]
+    assert exact_result["parameter_counts"] == {
+        "materialized_checkpoint": 6,
+        "mip_estimates": {"parameter_ratio": 0.9},
+    }
+    geometry = exact_result["realized_geometry_and_tensor_shapes"]
+    assert geometry["geometry"]["block_configs"] == block_configs
+    assert geometry["tensor_shapes"] == {"model.weight": {"dtype": "BF16", "shape": [2, 3]}}
+    evaluations = exact_result["evaluation_results"]
+    assert evaluations["pre_kd"]["metrics"] == {"accuracy": 0.1}
+    assert [row["metrics"]["accuracy"] for row in evaluations["milestones"]] == [
+        0.064,
+        0.128,
+        0.256,
+    ]
+    assert all(
+        row["reference_evidence"] == evaluation_evidence("teacher")
+        for row in evaluations["milestones"]
+    )
+    assert exact_result["stage_completion"]["pre_kd"] == "success"
 
 
 def test_result_manifest_rejects_changed_checkpoint_geometry(monkeypatch, tmp_path):

--- a/tests/unit/torch/puzzletron/test_profile_aiperf_worker.py
+++ b/tests/unit/torch/puzzletron/test_profile_aiperf_worker.py
@@ -24,7 +24,6 @@ from examples.puzzletron import run_profile_aiperf_worker as worker_module
 from examples.puzzletron.run_profile_aiperf_worker import (
     TOPOLOGIES,
     build_work_items,
-    expected_result_count,
     merge_results,
     run_worker,
     select_registry_solutions,
@@ -75,17 +74,6 @@ def test_profile_aiperf_work_shards_cover_every_item_once():
 
     assert sorted(row["id"] for shard in shards for row in shard) == list(range(15))
     assert max(map(len, shards)) == 2
-
-
-def test_profile_aiperf_expected_results_follow_registry_size():
-    registry = {
-        "solutions": [
-            {"solution_id": "best-loss"},
-            {"solution_id": "largest"},
-        ]
-    }
-
-    assert expected_result_count(registry) == 48
 
 
 def test_profile_aiperf_merge_honors_explicit_concurrency_subset(tmp_path):
@@ -177,7 +165,7 @@ def test_profile_aiperf_cli_forwards_explicit_security_flags(tmp_path, monkeypat
 
 @pytest.mark.parametrize(
     ("trust_remote_code", "online_tokenizer"),
-    [(False, False), (True, False), (False, True), (True, True)],
+    [(False, False), (True, True)],
 )
 def test_profile_aiperf_worker_forwards_security_policy_to_real_sweep(
     tmp_path, monkeypatch, trust_remote_code, online_tokenizer

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_example.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_example.py
@@ -41,40 +41,16 @@ CAMPAIGN_PATH = (
 )
 
 
-def test_qwen3p5_0p8b_model_identity_and_geometry_are_pinned() -> None:
+def test_qwen3p5_0p8b_model_and_default_search_are_pinned() -> None:
     model = yaml.safe_load(MODEL_PATH.read_text())
 
     assert model["input_hf_model_path"] == "Qwen/Qwen3.5-0.8B"
-    assert model["model_info"] == {
-        "hf_repo": model["input_hf_model_path"],
-        "hf_revision": "2fc06364715b967f1860aea9cf38778875588b17",
-        "model_type": "qwen3_5",
-        "architectures": ["Qwen3_5ForConditionalGeneration"],
-        "num_hidden_layers": 24,
-        "hidden_size": 1024,
-        "intermediate_size": 3584,
-        "num_attention_heads": 8,
-        "num_key_value_heads": 2,
-        "head_dim": 256,
-        "vocab_size": 248320,
-        "tie_word_embeddings": True,
-        "max_position_embeddings": 262144,
-        "mtp_num_hidden_layers": 1,
-        "layer_counts": {"linear_attention": 18, "full_attention": 6},
-        "full_attention_layer_indices": [3, 7, 11, 15, 19, 23],
-        "mamba": {
-            "linear_key_head_dim": 128,
-            "linear_num_key_heads": 16,
-            "linear_num_value_heads": 16,
-            "linear_value_head_dim": 128,
-            "linear_conv_kernel_dim": 4,
-        },
+    assert model["model_info"]["hf_revision"] == ("2fc06364715b967f1860aea9cf38778875588b17")
+    assert model["model_info"]["model_type"] == "qwen3_5"
+    assert model["model_info"]["layer_counts"] == {
+        "linear_attention": 18,
+        "full_attention": 6,
     }
-
-
-def test_qwen3p5_0p8b_default_search_matches_tracked_runtime_campaign() -> None:
-    model = yaml.safe_load(MODEL_PATH.read_text())
-
     assert model["pruning"] == {"intermediate_size_list": [3072, 2048]}
     assert model["search_space"]["axes"] == {
         "ffn_intermediate": {
@@ -85,24 +61,8 @@ def test_qwen3p5_0p8b_default_search_matches_tracked_runtime_campaign() -> None:
     }
 
 
-def test_qwen3p5_0p8b_vlm_campaign_keeps_mild_domains_explicit() -> None:
+def test_qwen3p5_0p8b_vlm_campaign_pins_width_and_depth_bounds() -> None:
     campaign = yaml.safe_load(CAMPAIGN_PATH.read_text())
-    axes = campaign["search_space"]["axes"]
-
-    expected_enabled_domains = {
-        "hidden_width": (1024, [960, 896]),
-        "kv_groups": (2, [1]),
-        "q_heads_per_group": (4, [3]),
-        "ffn_intermediate": (3584, [3328, 3072]),
-        "gdn_key_groups": (16, [14]),
-        "gdn_key_head_dim": (128, [112]),
-        "gdn_value_head_dim": (128, [112]),
-    }
-    enabled_domains = {
-        axis_id: (axis["teacher_value"], axis["values"])
-        for axis_id, axis in axes.items()
-        if axis["enabled"]
-    }
 
     assert campaign["embedding_pruning"]["widths"] == [1024, 960, 896]
     spec = Qwen3P5VLModelDescriptor.embedding_pruning_spec(
@@ -113,42 +73,13 @@ def test_qwen3p5_0p8b_vlm_campaign_keeps_mild_domains_explicit() -> None:
         alignment=campaign["embedding_pruning"]["alignment"],
     )
     assert [spec.validate_width(width) for width in spec.legal_widths] == [1024, 960, 896]
-    assert campaign["pruning"]["intermediate_size_list"] == [3328, 3072]
-    assert campaign["pruning"]["attn_heads_list"] == [[8, 2], [6, 2], [4, 1], [3, 1]]
-    assert campaign["pruning"]["attention_scored_axes"] == [
-        "kv_groups",
-        "q_heads_per_group",
-    ]
-    assert campaign["pruning"]["gdn_scored_axes"] == [
-        "gdn_key_groups",
-        "gdn_key_head_dim",
-        "gdn_value_head_dim",
-    ]
     assert campaign["depth_importance"]["enabled"] is True
-    assert campaign["depth_importance"]["max_removals"] == 2
     assert campaign["depth_importance"]["max_subblocks_to_remove"] == 2
     assert campaign["mip"]["runs"]["params-90"]["search_space"] == {
         "depth": [0, 1, 2],
         "embedding": [1024, 960, 896],
         "axes_default": "all",
         "axes": {"ffn.intermediate_size": "all"},
-    }
-    assert enabled_domains == expected_enabled_domains
-    assert {axis_id: axes[axis_id] for axis_id in ("gdn_value_heads_per_group",)} == {
-        "gdn_value_heads_per_group": {
-            "enabled": False,
-            "teacher_value": 1,
-            "values": [],
-        },
-    }
-    assert set(axes) == {
-        *expected_enabled_domains,
-        "kv_groups",
-        "q_heads_per_group",
-        "gdn_key_groups",
-        "gdn_value_heads_per_group",
-        "gdn_key_head_dim",
-        "gdn_value_head_dim",
     }
 
 

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_smoke_plan.py
@@ -62,10 +62,6 @@ def test_full_smoke_compiles_one_complete_bounded_lifecycle(monkeypatch, tmp_pat
         "post.params-90.final_eval",
         "post.params-90.best",
     )
-    assert nodes["online_eval"]["config"]["eval_samples"] == 2
-    assert nodes["checkpoint_eval"]["config"]["limit"] == 2
-    assert nodes["serving"]["config"]["request_count"] == 4
-    assert nodes["short_kd"]["config"]["max_steps"] == 2
     assert nodes["post_kd_checkpoint_eval"]["config"] == nodes["checkpoint_eval"]["config"]
     cpu_stages = [stage for stage in stages.values() if stage.resource == "cpu"]
     assert cpu_stages

--- a/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_vlm_smoke_plan.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_0p8b_full_vlm_smoke_plan.py
@@ -61,14 +61,10 @@ def test_full_vlm_smoke_compiles_one_complete_bounded_lifecycle(
     stages = {stage.stage_id: stage for stage in plan.stages}
     config = plan.experiment_config
     nodes = config["post_mip"]["flows"]["params-90"]["nodes"]
-    serving_args = nodes["vlm_serving"]["config"]["topology"]["extra_vllm_args"]
 
     assert plan.execution_mode is ExecutionMode.REUSABLE_ALLOCATION
     assert plan.execution_defaults["gpus_per_node"] == 2
     assert "tokenize_data" not in stages
-    assert config["dataset_path"] == str(tmp_path / "full_vlm_smoke/datasets/nemotron_vlm_v2")
-    assert config["prepare_dataset"]["output"] == config["dataset_path"]
-    assert serving_args[serving_args.index("--gdn-prefill-backend") + 1] == "triton"
     assert tuple(node for node in stages if node.startswith("post.")) == (
         "post.params-90.image_eval",
         "post.params-90.best_vlm_loss",
@@ -81,18 +77,10 @@ def test_full_vlm_smoke_compiles_one_complete_bounded_lifecycle(
         "post.params-90.final_image_eval",
         "post.params-90.best",
     )
-    assert config["prepare_dataset"]["num_samples"] == 8
-    assert config["sort_sanity"]["max_abs_lm_loss_delta"] == 0.003
-    assert config["sort_sanity"]["max_abs_reverse_lm_loss_delta"] == 0.003
-    assert nodes["image_eval"]["config"]["eval_samples"] == 2
-    assert nodes["checkpoint_eval"]["config"]["profile"] == "qwen35_vlm_core3_24row_smoke_v2"
-    assert nodes["checkpoint_eval"]["config"]["gdn_prefill_backend"] == "triton"
     assert nodes["post_kd_checkpoint_eval"]["config"] == nodes["checkpoint_eval"]["config"]
-    assert nodes["vlm_serving"]["config"]["request_count"] == 1
     assert nodes["fastest_vlm"]["metric"] == (
         "vlm_serving.images_12.concurrency_1.image_throughput"
     )
-    assert nodes["short_vlm_kd"]["config"]["max_steps"] == 2
     cpu_stages = [stage for stage in stages.values() if stage.resource == "cpu"]
     assert cpu_stages
     assert all(stage.total_gpus == 0 for stage in cpu_stages)
@@ -103,30 +91,14 @@ def test_vlm_campaign_compiles_the_multi_axis_flow(monkeypatch, tmp_path: Path) 
     plan = _compile(monkeypatch, tmp_path, CAMPAIGN_PATH, CAMPAIGN_EXECUTION_PATH)
     stages = {stage.stage_id: stage for stage in plan.stages}
     config = plan.experiment_config
-    assert config["dataset_path"] == str(tmp_path / "vlm_campaign/datasets/nemotron_vlm_v2")
-    assert config["prepare_dataset"]["output"] == config["dataset_path"]
-    assert config["prepare_dataset"]["evaluation_hf_home"] == str(tmp_path / "hf-home")
-    assert set(config["post_mip"]["flows"]) == {"candidates"}
     candidates = config["post_mip"]["flows"]["candidates"]["nodes"]
-    serving_args = candidates["serving"]["config"]["topology"]["extra_vllm_args"]
     assert plan.execution_mode is ExecutionMode.REUSABLE_ALLOCATION
     assert plan.execution_defaults["gpus_per_node"] == 8
-    assert serving_args[serving_args.index("--gdn-prefill-backend") + 1] == "triton"
-
-    assert set(config["mip"]["runs"]) == {"params-90"}
-    assert config["replacement_scoring"]["eval_samples"] == 16
     assert stages["replacement_scoring"].strategy is ExecutionStrategy.PERSISTENT_POOL
     assert stages["replacement_scoring"].instances == 8
     assert stages["replacement_scoring"].total_gpus == 8
-    assert candidates["best_image_loss"]["top_k"] == 5
-    assert candidates["kd"]["config"]["max_steps"] == 128
     assert candidates["pre_kd_eval"]["config"] == config["vlm_quality_evaluation"]
     assert candidates["pre_kd_eval"]["config"] == candidates["post_kd_eval"]["config"]
-    assert candidates["result"]["config"]["milestones"] == [
-        {"steps": 128, "kd": "kd", "evaluation": "post_kd_eval"}
-    ]
-    assert candidates["selected"]["input"] == "post_kd_eval"
-    assert candidates["selected"]["top_k"] == 1
     assert stages["post.candidates.serving"].parents == ("post.candidates.result",)
     concurrent_candidate_stages = {
         "post.candidates.image_eval",

--- a/tests/unit/torch/puzzletron/test_qwen3p5_4b_vlm_example.py
+++ b/tests/unit/torch/puzzletron/test_qwen3p5_4b_vlm_example.py
@@ -79,39 +79,14 @@ def test_qwen3p5_4b_model_pins_the_bounded_ffn_grid() -> None:
     model = yaml.safe_load(MODEL_PATH.read_text())
 
     assert model["input_hf_model_path"] == "Qwen/Qwen3.5-4B"
-    assert model["model_info"] == {
-        "hf_repo": model["input_hf_model_path"],
-        "hf_revision": "851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a",
-        "model_type": "qwen3_5",
-        "architectures": ["Qwen3_5ForConditionalGeneration"],
-        "num_hidden_layers": 32,
-        "hidden_size": 2560,
-        "intermediate_size": 9216,
-        "num_attention_heads": 16,
-        "num_key_value_heads": 4,
-        "head_dim": 256,
-        "vocab_size": 248320,
-        "tie_word_embeddings": True,
-        "max_position_embeddings": 262144,
-        "mtp_num_hidden_layers": 1,
-        "layer_counts": {"linear_attention": 24, "full_attention": 8},
-        "mamba": {
-            "linear_key_head_dim": 128,
-            "linear_num_key_heads": 16,
-            "linear_num_value_heads": 32,
-            "linear_value_head_dim": 128,
-            "linear_conv_kernel_dim": 4,
-        },
+    assert model["model_info"]["hf_revision"] == ("851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a")
+    assert model["model_info"]["model_type"] == "qwen3_5"
+    assert model["model_info"]["layer_counts"] == {
+        "linear_attention": 24,
+        "full_attention": 8,
     }
     widths = [8704, 8192, 7168, 6144, 5632, 5120, 4608]
     assert model["pruning"] == {"intermediate_size_list": widths}
-    assert model["search_space"]["axes"] == {
-        "ffn_intermediate": {
-            "enabled": True,
-            "teacher_value": 9216,
-            "values": widths,
-        }
-    }
 
 
 def test_qwen3p5_4b_default_compiles_the_complete_ffn_grid_and_stops_at_mip(
@@ -133,68 +108,11 @@ def test_qwen3p5_4b_default_compiles_the_complete_ffn_grid_and_stops_at_mip(
         "replacement_scoring",
         "mip",
     )
-    cpu_stages = {"convert", "build_library", "mip"}
-    assert all(stage.resource == "cpu" for stage in plan.stages if stage.stage_id in cpu_stages)
-    assert all(stage.total_gpus == 0 for stage in plan.stages if stage.stage_id in cpu_stages)
-    assert all(stage.total_gpus == 1 for stage in plan.stages if stage.stage_id not in cpu_stages)
-    assert config["model"]["source"] == "Qwen/Qwen3.5-4B"
-    assert config["model"]["revision"] == "851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a"
-    assert config["data"]["processor_identity"] == (
-        "Qwen/Qwen3.5-4B@851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a"
-    )
-    assert config["search_space"]["axes"]["ffn_intermediate"] == {
-        "enabled": True,
-        "teacher_value": 9216,
-        "values": [8704, 8192, 7168, 6144, 5632, 5120, 4608],
-    }
     assert config["vllm_stats"]["enabled"] is False
-    assert config["vllm_stats"]["runtime_stats"]["enabled"] is False
-    assert config["mip"]["runs"] == {
-        "params-80": {
-            "constraints": {"params": {"max": "82%"}},
-            "objectives": [
-                {
-                    "metric": "metrics.cosine_embedding_loss_hidden_states",
-                    "direction": "minimize",
-                }
-            ],
-            "search_space": {
-                "depth": [0],
-                "embedding": [2560],
-                "axes_default": "teacher",
-                "axes": {"ffn.intermediate_size": "all"},
-            },
-            "solver": {
-                "backend": "auto",
-                "num_solutions": 3,
-                "min_hamming_distance": 2,
-                "max_seconds_per_solution": 30,
-            },
-            "homogeneous": {"enabled": True, "keep": 2, "rank_by": "objective"},
-        },
-        "memory-85": {
-            "constraints": {"memory": {"at": {"serving-default": {"max": "85%"}}}},
-            "objectives": [
-                {
-                    "metric": "metrics.cosine_embedding_loss_hidden_states",
-                    "direction": "minimize",
-                }
-            ],
-            "search_space": {
-                "depth": [0],
-                "embedding": [2560],
-                "axes_default": "teacher",
-                "axes": {"ffn.intermediate_size": "all"},
-            },
-            "solver": {
-                "backend": "auto",
-                "num_solutions": 3,
-                "min_hamming_distance": 2,
-                "max_seconds_per_solution": 30,
-            },
-            "homogeneous": {"enabled": True, "keep": 2, "rank_by": "objective"},
-        },
-    }
+    runs = config["mip"]["runs"]
+    assert set(runs) == {"params-80", "memory-85"}
+    assert all(run["solver"]["num_solutions"] == 3 for run in runs.values())
+    assert all(run["homogeneous"]["keep"] == 2 for run in runs.values())
     assert config["post_mip"]["flows"] == {}
 
 
@@ -225,62 +143,15 @@ def test_qwen3p5_4b_opt_in_lifecycle_materializes_reloads_and_bounds_kd_and_eval
     assert post_stages[0].parents == ("mip",)
     for parent, stage in pairwise(post_stages):
         assert stage.parents == (parent.stage_id,)
-    assert nodes["materialized"] == {"type": "materialize", "input": "best_vlm_loss"}
+    assert nodes["materialized"]["input"] == "best_vlm_loss"
     assert nodes["checkpoint_eval"]["input"] == "materialized"
     assert nodes["checkpoint_eval"]["failure_policy"] == "strict"
-    assert nodes["checkpoint_eval"]["config"]["profile"] == "qwen35_vlm_realworldqa"
-    assert nodes["checkpoint_eval"]["config"]["batch_size"] == 1
-    assert nodes["checkpoint_eval"]["config"]["timeout_seconds"] == 900
-    assert nodes["checkpoint_eval"]["config"]["limit_mm_per_prompt"] == {"image": 1}
-    assert nodes["short_vlm_kd"] == {
-        "type": "global_kd",
-        "input": "checkpoint_eval",
-        "config": {
-            "freeze_policy": "vision_frozen",
-            "activation_checkpointing": True,
-            "automodel": {
-                "parallel": {
-                    "tp": 2,
-                    "cp": 1,
-                    "pp": 1,
-                    "ep": 1,
-                    "dp_shard": 1,
-                    "dp_replicate": 1,
-                    "sequence_parallel": False,
-                    "pipeline_schedule": "1f1b",
-                }
-            },
-            "objective": {
-                "main_ce": {"weight": 1.0},
-                "main_kd": {"weight": 1.0, "chunk_size": 64},
-                "mtp_ce": {"weight": 1.0},
-                "mtp_kd": {"weight": 1.0, "chunk_size": 64},
-            },
-            "max_steps": 2,
-            "global_batch_size": 1,
-            "local_batch_size": 1,
-            "checkpoint_every_steps": 2,
-        },
-    }
-    assert nodes["post_kd_checkpoint_eval"]["config"] == nodes["checkpoint_eval"]["config"]
-    assert nodes["final_image_eval"]["config"] == {"eval_samples": 2, "block_size": 512}
+    kd = nodes["short_vlm_kd"]
+    assert kd["input"] == "checkpoint_eval"
+    assert kd["config"]["automodel"]["parallel"]["tp"] == 2
     assert (
         next(stage for stage in plan.stages if stage.stage_id.endswith("short_vlm_kd")).total_gpus
         == 2
-    )
-    cpu_stages = {
-        "convert",
-        "build_library",
-        "mip",
-        "post.params-80.best_vlm_loss",
-        "post.params-80.best",
-    }
-    assert all(stage.resource == "cpu" for stage in plan.stages if stage.stage_id in cpu_stages)
-    assert all(stage.total_gpus == 0 for stage in plan.stages if stage.stage_id in cpu_stages)
-    assert all(
-        stage.total_gpus == 1
-        for stage in plan.stages
-        if stage.stage_id not in cpu_stages and not stage.stage_id.endswith("short_vlm_kd")
     )
 
 
@@ -327,67 +198,8 @@ def test_qwen3p5_4b_campaign_compares_pruning_bands_and_teacher(monkeypatch, tmp
     assert tuple(config["mip"]["runs"]) == ("params-80", "memory-85", "ffn-candidates")
     assert config["mip"]["runs"]["params-80"] is False
     assert config["mip"]["runs"]["memory-85"] is False
-    assert candidates["variants"] == {
-        "width-7168": {
-            "constraints": {"params": {"max": "92%"}},
-            "search_space": {"axes": {"ffn.intermediate_size": [7168]}},
-        },
-        "width-6144": {
-            "constraints": {"params": {"max": "87%"}},
-            "search_space": {"axes": {"ffn.intermediate_size": [6144]}},
-        },
-        "width-5120": {
-            "constraints": {"params": {"max": "82%"}},
-            "search_space": {"axes": {"ffn.intermediate_size": [5120]}},
-        },
-    }
-    assert nodes["screening_kd"]["config"]["max_steps"] == 64
-    assert nodes["screening_kd"]["config"]["checkpoint_every_steps"] == 64
-    assert nodes["global_kd"]["config"]["max_steps"] == 256
-    assert nodes["global_kd"]["config"]["checkpoint_every_steps"] == 256
-    assert config["global_distillation"]["automodel"]["activation_checkpointing"] is True
-    assert config["global_distillation"]["freeze_policy"] == "vision_frozen"
-    assert config["global_distillation"]["objective"]["main_kd"]["chunk_size"] == 64
-    assert config["global_distillation"]["objective"]["mtp_kd"]["chunk_size"] == 64
-    for node_id in ("screening_kd", "global_kd"):
-        assert nodes[node_id]["config"]["freeze_policy"] == "vision_frozen"
-        assert nodes[node_id]["config"]["activation_checkpointing"] is True
-        assert nodes[node_id]["config"]["automodel"]["parallel"] == {
-            "tp": 2,
-            "cp": 1,
-            "pp": 1,
-            "ep": 1,
-            "dp_shard": 1,
-            "dp_replicate": 1,
-            "sequence_parallel": False,
-            "pipeline_schedule": "1f1b",
-        }
-        assert nodes[node_id]["config"]["objective"] == config["global_distillation"]["objective"]
-    assert nodes["serving"]["config"]["allow_aiperf_v011_online_tokenizer_resolution"] is True
-    assert nodes["quality_screen"]["config"]["profile"] == (
-        "qwen35_vlm_realworldqa_mmmu_prefix100_x2"
-    )
-    assert nodes["quality_screen"]["config"]["disable_thinking"] is True
-    assert "reference_checkpoint" not in nodes["quality_screen"]["config"]
-    assert nodes["quality_benchmarks"]["config"]["disable_thinking"] is True
+    assert set(candidates["variants"]) == {"width-7168", "width-6144", "width-5120"}
     assert nodes["quality_benchmarks"]["config"]["reference_checkpoint"] == config["teacher_dir"]
-    assert nodes["selected"] == {
-        "type": "filter",
-        "input": "quality_screen",
-        "mode": "aggregate_rank",
-        "metrics": [
-            {"metric": "screening_eval.lm_loss", "direction": "minimize"},
-            {
-                "metric": "quality_screen.modelopt_vlm_benchmark_realworldqa.exact_match_flexible-extract",
-                "direction": "maximize",
-            },
-            {
-                "metric": "quality_screen.modelopt_vlm_benchmark_mmmu_val.mmmu_acc_none",
-                "direction": "maximize",
-            },
-        ],
-        "top_k": 1,
-    }
     assert nodes["global_kd"]["model_source"] == "materialized"
     assert tuple(stage.stage_id for stage in plan.stages)[-11:-1] == (
         "post.candidate-evaluation.online_eval",
@@ -412,14 +224,9 @@ def test_qwen3p5_4b_campaign_compares_pruning_bands_and_teacher(monkeypatch, tmp
         "post.candidate-evaluation.quality_screen",
     }
     assert all(stages[stage_id].instances == 4 for stage_id in candidate_stages)
-    one_gpu_candidate_stages = candidate_stages - {"post.candidate-evaluation.screening_kd"}
-    assert all(stages[stage_id].total_gpus == 4 for stage_id in one_gpu_candidate_stages)
     assert stages["post.candidate-evaluation.screening_kd"].total_gpus == 8
     assert all(stages[stage_id].gpus_per_node == 8 for stage_id in candidate_stages)
     assert stages["post.candidate-evaluation.global_kd"].total_gpus == 2
-    execution = load_execution_config(CAMPAIGN_EXECUTION_PATH)
-    assert execution["stages"]["width_importance"] == {"strategy": "single"}
-    assert "depth_importance" not in execution["stages"]
 
 
 def test_qwen3p5_4b_legacy_campaign_alias_resolves_to_named_search(

--- a/tests/unit/torch/puzzletron/test_resolve_descriptor_caching.py
+++ b/tests/unit/torch/puzzletron/test_resolve_descriptor_caching.py
@@ -33,29 +33,23 @@ REGISTRY_MODULE = "modelopt.torch.puzzletron.anymodel.registry"
 class TestResolveDescriptorCachesDynamicModules:
     """resolve_descriptor_from_pretrained must call force_cache_dynamic_modules."""
 
+    @pytest.mark.parametrize("trust_remote_code", [False, True])
     @patch(f"{REGISTRY_MODULE}.force_cache_dynamic_modules")
     @patch(f"{REGISTRY_MODULE}.AutoConfig")
-    def test_force_cache_called(self, mock_auto_config_cls, mock_force_cache):
-        mock_config = MagicMock()
-        mock_config.model_type = "llama"
-        mock_auto_config_cls.from_pretrained.return_value = mock_config
-
-        mtpz.anymodel.resolve_descriptor_from_pretrained("/fake/path", trust_remote_code=True)
-
-        mock_force_cache.assert_called_once_with(mock_config, "/fake/path", trust_remote_code=True)
-
-    @patch(f"{REGISTRY_MODULE}.force_cache_dynamic_modules")
-    @patch(f"{REGISTRY_MODULE}.AutoConfig")
-    def test_force_cache_called_without_trust_remote_code(
-        self, mock_auto_config_cls, mock_force_cache
+    def test_resolver_caches_dynamic_modules(
+        self, mock_auto_config_cls, mock_force_cache, trust_remote_code
     ):
         mock_config = MagicMock()
         mock_config.model_type = "llama"
         mock_auto_config_cls.from_pretrained.return_value = mock_config
 
-        mtpz.anymodel.resolve_descriptor_from_pretrained("/fake/path")
+        mtpz.anymodel.resolve_descriptor_from_pretrained(
+            "/fake/path", trust_remote_code=trust_remote_code
+        )
 
-        mock_force_cache.assert_called_once_with(mock_config, "/fake/path", trust_remote_code=False)
+        mock_force_cache.assert_called_once_with(
+            mock_config, "/fake/path", trust_remote_code=trust_remote_code
+        )
 
     @patch(f"{REGISTRY_MODULE}.register_native_config_aliases")
     @patch(f"{REGISTRY_MODULE}.force_cache_dynamic_modules")
@@ -85,17 +79,14 @@ class TestResolveDescriptorCachesDynamicModules:
         ("qwen3_6", "Qwen3P5VLModelDescriptor"),
     ],
 )
-@patch(f"{REGISTRY_MODULE}.force_cache_dynamic_modules")
 @patch(f"{REGISTRY_MODULE}.AutoConfig")
-def test_resolve_qwen3_5_and_qwen3_6_model_types(
-    mock_auto_config_cls, mock_force_cache, model_type, descriptor_name
-):
+def test_resolve_qwen3_5_and_qwen3_6_model_types(mock_auto_config_cls, model_type, descriptor_name):
     pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
     mock_config = MagicMock()
     mock_config.model_type = model_type
     mock_auto_config_cls.from_pretrained.return_value = mock_config
 
-    resolution = mtpz.anymodel.resolve_descriptor_from_pretrained("/fake/path")
+    with patch(f"{REGISTRY_MODULE}.force_cache_dynamic_modules"):
+        resolution = mtpz.anymodel.resolve_descriptor_from_pretrained("/fake/path")
 
     assert resolution.descriptor.__name__ == descriptor_name
-    mock_force_cache.assert_called_once_with(mock_config, "/fake/path", trust_remote_code=False)

--- a/tests/unit/torch/puzzletron/test_runtime_estimator.py
+++ b/tests/unit/torch/puzzletron/test_runtime_estimator.py
@@ -25,7 +25,6 @@ from modelopt.torch.puzzletron.subblock_stats.runtime_estimator import (
     candidate_slope,
     effective_repeat_count,
     fixed_intercept,
-    homogeneous_layout,
     median_measurement,
     scaffolded_layout,
 )
@@ -42,12 +41,6 @@ def test_effective_repeat_rejects_non_positive_values():
         effective_repeat_count(0, 2)
     with pytest.raises(ValueError, match="positive"):
         effective_repeat_count(4, 0)
-
-
-def test_homogeneous_layout_contains_only_candidate():
-    candidate = BlockConfig(subblock_configs=(FFNConfig(intermediate_size=16),))
-
-    assert homogeneous_layout(candidate, repeat_count=4) == (candidate,) * 4
 
 
 def test_scaffolded_layout_places_one_scaffold_in_each_pp_chunk():

--- a/tests/unit/torch/puzzletron/test_setup_bundle.py
+++ b/tests/unit/torch/puzzletron/test_setup_bundle.py
@@ -103,24 +103,15 @@ def test_batch_alignment_preserves_hydra_references() -> None:
     assert config["nested"]["micro_batch_size"] == 4
 
 
-def test_nemotron_nano_omits_latent_moe_activation_pass() -> None:
+@pytest.mark.parametrize("latent_moe", [False, True])
+def test_latent_moe_activation_pass_follows_model_capability(latent_moe: bool) -> None:
     experiment = render_experiment(
-        _nemotron_render_state(latent_moe=False),
+        _nemotron_render_state(latent_moe=latent_moe),
         "production",
     )
 
     pass_names = {item["name"] for item in experiment["pruning"]["activation_passes"]}
-    assert "moe_latent" not in pass_names
-
-
-def test_nemotron_super_keeps_latent_moe_activation_pass() -> None:
-    experiment = render_experiment(
-        _nemotron_render_state(latent_moe=True),
-        "production",
-    )
-
-    pass_names = {item["name"] for item in experiment["pruning"]["activation_passes"]}
-    assert "moe_latent" in pass_names
+    assert ("moe_latent" in pass_names) is latent_moe
 
 
 @pytest.mark.parametrize(
@@ -200,15 +191,6 @@ def test_first_class_vlm_acquisition_disables_text_token_memmaps() -> None:
     assert "packed_token_cache_path" not in experiment["bypass"]["data"]
 
 
-def test_render_experiment_uses_global_runtime_repeat_default() -> None:
-    experiment = render_experiment(
-        _nemotron_render_state(latent_moe=False),
-        "production",
-    )
-
-    assert experiment["vllm_stats"]["runtime_stats"]["repeat_block_n_times"] == 4
-
-
 def test_normal_aiperf_config_asks_shared_cp_and_maps_moe_ep_to_dp() -> None:
     prompts = _ServingPrompts(
         {
@@ -278,7 +260,7 @@ def test_advanced_aiperf_config_asks_split_cp_and_workload() -> None:
     assert config["concurrency"] == [8]
 
 
-def test_default_post_mip_flow_uses_fifteen_minute_aiperf_timeout() -> None:
+def test_default_post_mip_flow_uses_loss_metrics_for_selection() -> None:
     flow = _default_flow(
         "memory",
         {"objectives": [{"metric": "metrics.lm_loss", "direction": "minimize"}]},
@@ -288,7 +270,6 @@ def test_default_post_mip_flow_uses_fifteen_minute_aiperf_timeout() -> None:
         include_initial_filter=False,
     )
 
-    assert flow["nodes"]["serving"]["config"]["benchmark_timeout"] == 900
     assert flow["nodes"]["best_lm"]["metric"] == "online_eval.lm_loss"
     assert flow["nodes"]["best"]["metric"] == "final_eval.lm_loss"
 
@@ -663,149 +644,6 @@ def test_render_execution_preserves_gpu_mip_validation_topology() -> None:
     }
 
 
-def test_render_experiment_defaults_to_single_gpu_subblock_vllm() -> None:
-    state = {
-        "model": {"source": "Qwen/test", "resolved_revision": "revision"},
-        "inventory": {
-            "family": "qwen3_5",
-            "descriptor": "qwen3_5",
-            "family_config": "examples/puzzletron/configs/families/qwen3_5/family.yaml",
-            "num_layers": 4,
-            "num_sublayers": 8,
-        },
-        "answers": {
-            "data": {
-                "source": "/dataset",
-                "modality": "text",
-                "layout": "fixed",
-                "sequence_length": 2048,
-            },
-            "pruning": {
-                "width_importance_samples": 128,
-                "replacement_samples": 16,
-                "depth_remove": 0,
-                "axes": {
-                    "hidden_width": {
-                        "enabled": True,
-                        "teacher_value": 1024,
-                        "values": [1024, 768],
-                        "alignment": 256,
-                    },
-                    "ffn_intermediate": {
-                        "enabled": True,
-                        "teacher_value": 3584,
-                        "values": [3584, 3072],
-                        "alignment": 256,
-                    },
-                },
-                "bypass": {"enabled": True, "batch_size": 3},
-            },
-            "runtime": {
-                "vllm_enabled": True,
-                "isl": 2048,
-                "osl": 256,
-                "concurrency": 4,
-            },
-            "mip": {"runs": {}},
-            "post_mip": {
-                "flows": {
-                    "memory": {
-                        "source": {"run": "memory"},
-                        "nodes": {
-                            "serving": {
-                                "type": "aiperf",
-                                "config": {
-                                    "concurrency": [1],
-                                    "topology": {
-                                        "tensor_parallel_size": 4,
-                                        "pipeline_parallel_size": 1,
-                                        "prefill_context_parallel_size": 2,
-                                        "decode_context_parallel_size": 2,
-                                        "data_parallel_size": 1,
-                                        "expert_parallel_size": 1,
-                                        "distributed_executor_backend": "mp",
-                                        "gpu_group_size": 8,
-                                    },
-                                },
-                            },
-                            "short_kd": {
-                                "type": "global_kd",
-                                "input": "serving",
-                                "config": {"local_batch_size": 1},
-                            },
-                        },
-                    }
-                }
-            },
-            "infrastructure": {
-                "meshes": {
-                    "common": {"tp": 2, "pp": 2, "dp_shard": 2, "ep": 1},
-                    "bypass": {"pp": 1, "dp_shard": 2, "dp_replicate": 1},
-                    "global_kd": {
-                        "pp": 2,
-                        "dp_shard": 2,
-                        "dp_replicate": 2,
-                    },
-                }
-            },
-            "output": {"result_root": "/results"},
-        },
-    }
-
-    experiment = render_experiment(state, "production")
-    runtime = experiment["vllm_stats"]["runtime_stats"]
-    serving = experiment["post_mip"]["flows"]["memory"]["nodes"]["serving"]["config"]
-
-    assert runtime["granularity"] == "subblock"
-    assert experiment["embedding_pruning"]["widths"] == [1024, 768]
-    assert experiment["vllm_stats"]["model_hidden_sizes"] == [1024, 768]
-    assert experiment["search_space"]["axes"]["hidden_width"]["values"] == [1024, 768]
-    assert experiment["search_space"]["axes"]["ffn_intermediate"]["values"] == [3584, 3072]
-    assert {
-        key: runtime["topology"][key]
-        for key in (
-            "tensor_parallel_size",
-            "pipeline_parallel_size",
-            "prefill_context_parallel_size",
-            "decode_context_parallel_size",
-            "gpu_group_size",
-        )
-    } == {
-        "tensor_parallel_size": 1,
-        "pipeline_parallel_size": 1,
-        "prefill_context_parallel_size": 1,
-        "decode_context_parallel_size": 1,
-        "gpu_group_size": 1,
-    }
-    assert serving["topology"] == {
-        "tensor_parallel_size": 4,
-        "pipeline_parallel_size": 1,
-        "prefill_context_parallel_size": 2,
-        "decode_context_parallel_size": 2,
-        "data_parallel_size": 1,
-        "expert_parallel_size": 1,
-        "distributed_executor_backend": "mp",
-        "gpu_group_size": 8,
-    }
-    assert serving["topology"] != runtime["topology"]
-    assert experiment["data"]["calibration"]["micro_batch_size"] == 4
-    assert experiment["data"]["replacement_scoring"]["micro_batch_size"] == 4
-    assert experiment["pruning"]["micro_batch_size"] == 4
-    assert experiment["sort_sanity"]["micro_batch_size"] == 4
-    assert experiment["depth_importance"]["micro_batch_size"] == 4
-    assert experiment["replacement_scoring"]["micro_batch_size"] == 4
-    assert experiment["bypass"]["training"]["micro_batch_size"] == 4
-    assert experiment["bypass"]["training"]["val_micro_batch_size"] == 2
-    assert experiment["bypass"]["iter_num"] == 1
-    assert experiment["bypass"]["step_num"] == 1
-    assert experiment["bypass"]["training"]["training_tokens"] == 4096 * 2048
-    assert experiment["global_distillation"]["local_batch_size"] == 8
-    assert (
-        experiment["post_mip"]["flows"]["memory"]["nodes"]["short_kd"]["config"]["local_batch_size"]
-        == 8
-    )
-
-
 def test_normal_mip_flow_asks_for_embedding_widths(tmp_path) -> None:
     state = AnswerState.start(tmp_path / "campaign", detailed=False)
     state.record_many(
@@ -817,7 +655,6 @@ def test_normal_mip_flow_asks_for_embedding_widths(tmp_path) -> None:
     _ask_mip(prompts, state)
 
     run = next(iter(state.section("mip")["runs"].values()))
-    assert "Embedding widths for this MIP run (all or YAML list):" in prompts.messages
     assert run["search_space"]["embedding"] == [1024, 768]
     assert run["solver"]["num_solutions"] == 3
     assert run["homogeneous"] == {

--- a/tests/unit/torch/puzzletron/test_setup_v2_data.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_data.py
@@ -25,7 +25,7 @@ from puzzletron_setup import SetupError
 from puzzletron_setup.v2.bundle import _bundle_readme
 from puzzletron_setup.v2.defaults import DefaultsResolver
 from puzzletron_setup.v2.hf_datasets import HfSubsetCatalog, HfSubsetInfo
-from puzzletron_setup.v2.prompts import InteractiveBackend, PromptChoice, ScriptedBackend
+from puzzletron_setup.v2.prompts import PromptChoice, ScriptedBackend
 from puzzletron_setup.v2.session import WizardSession
 from puzzletron_setup.v2.state import WizardState
 from puzzletron_setup.v2.wizard import (
@@ -256,20 +256,6 @@ def test_resume_can_change_between_fixed_dataset_modalities(tmp_path):
     assert state.get_field("data.modality") == "multimodal"
 
 
-def test_nemotron_vlm_subset_prompt_uses_catalog_choices_and_defaults(tmp_path):
-    _, backend = _run_nemotron_vlm_data_section(tmp_path)
-
-    assert len(backend.checkbox_calls) == 1
-    choices, defaults = backend.checkbox_calls[0]
-    assert tuple(choice.value for choice in choices) == tuple(
-        subset.name for subset in _nemotron_catalog().subsets
-    )
-    assert next(choice for choice in choices if choice.value == "external").disabled == (
-        "external media required"
-    )
-    assert defaults == ("sparsetables", "plotqa_cot", "wiki_en")
-
-
 def test_generic_hugging_face_dataset_uses_dynamic_subset_checkbox(
     tmp_path,
     monkeypatch,
@@ -412,9 +398,6 @@ def test_bundle_readme_emits_bounded_vlm_materialization_command(tmp_path):
     assert "--revision sha" in document
     assert "--num-samples 64" in document
     assert "--max-shards-per-subset 2" in document
-    assert "Python 3.10+ controller venv" in document
-    assert "This is a worker command" in document
-    assert "vlm_checkpoint_evaluation.md" in document
 
 
 def test_checkbox_rejects_a_disabled_scripted_selection(tmp_path):
@@ -436,71 +419,3 @@ def test_checkbox_rejects_a_disabled_scripted_selection(tmp_path):
 
     assert selected == ["hosted"]
     assert backend.remaining == 0
-
-
-def test_interactive_checkbox_passes_disabled_reason_to_questionary(monkeypatch):
-    shown_choices = []
-
-    class _KeyBindings:
-        @staticmethod
-        def add(*args, **kwargs):
-            def decorator(callback):
-                return callback
-
-            return decorator
-
-    class _Application:
-        key_bindings = _KeyBindings()
-
-    class _Question:
-        application = _Application()
-
-        @staticmethod
-        def ask():
-            return ["hosted"]
-
-    class _Questionary:
-        @staticmethod
-        def Choice(**kwargs):  # noqa: N802 - mirrors questionary's public constructor
-            return kwargs
-
-        @staticmethod
-        def Separator(title):  # noqa: N802 - mirrors questionary's public constructor
-            return {"separator": title}
-
-        @staticmethod
-        def Style(rules):  # noqa: N802 - mirrors questionary's public constructor
-            return rules
-
-        @staticmethod
-        def checkbox(message, choices, *, instruction, style):
-            del message, instruction, style
-            shown_choices.extend(choices)
-            return _Question()
-
-    monkeypatch.setattr(
-        "puzzletron_setup.v2.prompts._questionary",
-        lambda: _Questionary(),
-    )
-    monkeypatch.setattr(
-        "puzzletron_setup.v2.prompts._bind_escape_back",
-        lambda question: question,
-    )
-
-    selected = InteractiveBackend().checkbox(
-        "Subsets:",
-        [
-            PromptChoice("hosted", "hosted"),
-            PromptChoice(
-                "external",
-                "external",
-                disabled="external media required",
-            ),
-        ],
-        defaults=("hosted",),
-    )
-
-    assert selected == ["hosted"]
-    assert shown_choices[0]["checked"]
-    assert shown_choices[0]["disabled"] is None
-    assert shown_choices[1]["disabled"] == "external media required"

--- a/tests/unit/torch/puzzletron/test_setup_v2_quick.py
+++ b/tests/unit/torch/puzzletron/test_setup_v2_quick.py
@@ -31,13 +31,12 @@ from puzzletron_orchestrator.compiler import (
     load_execution_config,
     load_runner_config,
 )
-from puzzletron_orchestrator.controller import dry_run_plan
 from puzzletron_setup import SetupError
 from puzzletron_setup.inspection import InspectedModel
 from puzzletron_setup.profiles import AxisInventory, ModelInventory
 from puzzletron_setup.v2.defaults import DefaultsResolver, validate_defaults
 from puzzletron_setup.v2.presets import get_setup_preset
-from puzzletron_setup.v2.prompts import NonInteractiveBackend, PromptChoice, ScriptedBackend
+from puzzletron_setup.v2.prompts import NonInteractiveBackend, ScriptedBackend
 from puzzletron_setup.v2.session import WizardSession
 from puzzletron_setup.v2.state import WizardState
 from puzzletron_setup.v2.wizard import (
@@ -134,18 +133,6 @@ def test_each_model_family_defines_every_guided_profile(family_config, preset_na
 # Non-interactive CLI behavior
 
 
-def test_non_interactive_backend_uses_semantic_defaults() -> None:
-    backend = NonInteractiveBackend()
-    choices = [PromptChoice("First", "first"), PromptChoice("Second", "second")]
-
-    assert backend.text("Path:", "/resolved/path") == "/resolved/path"
-    assert backend.text("Optional commands:", "") == ""
-    assert backend.select("Choice:", choices, "second") == "second"
-    assert backend.checkbox("Choices:", choices, ["first"]) == ["first"]
-    with pytest.raises(SetupError, match="requires a default"):
-        backend.text("Path:", None)
-
-
 @pytest.mark.parametrize(
     "argv",
     [
@@ -161,7 +148,7 @@ def test_cli_rejects_invalid_automation_argument_combinations(argv):
     assert error.value.code == 2
 
 
-def test_cli_incomplete_noninteractive_defaults_fail_fast(tmp_path, capsys):
+def test_cli_incomplete_noninteractive_defaults_fail_fast(tmp_path):
     defaults = tmp_path / "defaults.yaml"
     defaults.write_text("schema_version: 1\n")
 
@@ -177,7 +164,6 @@ def test_cli_incomplete_noninteractive_defaults_fail_fast(tmp_path, capsys):
         )
         == 2
     )
-    assert "Setup stopped: Enter a model path or Hugging Face URL." in capsys.readouterr().out
 
 
 def test_cli_invalid_noninteractive_vllm_topology_fails_fast(tmp_path, monkeypatch, capsys):
@@ -398,166 +384,6 @@ def test_width_sanity_samples_contribute_without_sort_sanity(tmp_path):
     assert _acquisition_sample_requirements(state) == (2, 11)
 
 
-def test_guided_wizard_runs_real_sections_and_generates_valid_bundles(
-    tmp_path,
-    monkeypatch,
-):
-    campaign = tmp_path / "campaign"
-    model_path = tmp_path / "model"
-    dataset = tmp_path / "dataset"
-    model_path.mkdir()
-    dataset.mkdir()
-    inspected = _qwen_inspected_model(model_path)
-    monkeypatch.setattr(wizard_module, "inspect_model", lambda source: inspected)
-    monkeypatch.setattr(
-        wizard_module,
-        "infer_dataset_modality",
-        lambda source: SimpleNamespace(modality="text", evidence="local fixture"),
-    )
-    defaults = tmp_path / "defaults.yaml"
-    defaults.write_text(
-        yaml.safe_dump(
-            {
-                "schema_version": 1,
-                "model": {"source": str(model_path)},
-                "data": {
-                    "source": str(dataset),
-                    "modality": "text",
-                    "layout": "fixed",
-                    "sequence_length": 32,
-                },
-                "infrastructure": {
-                    "gpus_per_node": 1,
-                    "runner": {
-                        "slurm": {"job_name_prefix": "acct-puzzletron"},
-                    },
-                    "execution_contract": {
-                        "repository": "/worker/modelopt",
-                        "venv": "/worker/venv",
-                    },
-                },
-            },
-            sort_keys=False,
-        )
-    )
-
-    result = wizard_module.run_wizard_v2(
-        resume=None,
-        defaults_path=defaults,
-        backend=NonInteractiveBackend(),
-        campaign_dir=campaign,
-        setup_profile="smoke",
-    )
-
-    assert result == campaign.resolve()
-    generated = WizardState.resume(campaign)
-    assert generated.collection("pruning")["depth_remove"] == 0
-    assert generated.collection("pruning")["width_importance_samples"] == 8
-    assert generated.collection("pruning")["replacement_samples"] == 4
-    assert generated.collection("default_resolutions")["pruning.depth_remove"] == {
-        "value": 0,
-        "source": "model_profile",
-    }
-    assert generated.collection("default_resolutions")["pruning.width_importance_samples"] == {
-        "value": 8,
-        "source": "model_profile",
-    }
-    assert (
-        generated.collection("default_resolutions")["post_mip.quality_comparison"]["source"]
-        == "model_profile"
-    )
-    smoke = yaml.safe_load((campaign / "smoke" / "experiment.yaml").read_text())
-    smoke_flow = next(iter(smoke["post_mip"]["flows"].values()))
-    assert (
-        smoke_flow["nodes"]["serving"]["config"]["topology"]["server_context_overhead_tokens"]
-        == 16384
-    )
-    assert smoke_flow["nodes"]["serving"]["config"]["topology"]["extra_vllm_args"] == [
-        "-cc.cudagraph_mode=NONE",
-        "--no-enable-flashinfer-autotune",
-        "--gdn-prefill-backend",
-        "triton",
-        "--gpu-memory-utilization",
-        "0.5",
-        "--reasoning-parser",
-        "qwen3",
-        "--default-chat-template-kwargs",
-        '{"enable_thinking": false}',
-    ]
-    smoke_comparison = smoke_flow["nodes"]["quality_benchmarks"]
-    assert "recorded_observation" not in smoke_comparison["config"]
-    smoke_runner = yaml.safe_load((campaign / "smoke" / "runner.yaml").read_text())
-    assert smoke_runner["runner"]["slurm"]["job_name_prefix"] == "acct-puzzletron"
-    production = yaml.safe_load((campaign / "production" / "experiment.yaml").read_text())
-    execution = yaml.safe_load((campaign / "production" / "execution.yaml").read_text())
-    assert execution["execution"]["schema_version"] == 1
-    assert production["model_info"]["hidden_size"] == 1024
-    assert production["model_info"]["num_hidden_layers"] == 24
-    assert production["embedding_pruning"] == {
-        "enabled": True,
-        "widths": [1024],
-        "alignment": 256,
-        "cycle_widths": True,
-    }
-    assert production["depth_importance"]["expected_initial_sublayers"] == 48
-    assert production["depth_importance"]["max_subblocks_to_remove"] == 0
-    mip_run = next(iter(production["mip"]["runs"].values()))
-    assert mip_run["search_space"]["embedding"] == [1024]
-    assert mip_run["search_space"]["depth"] == [0]
-    assert execution["execution"]["stages"]["mip"]["resource"] == "cpu"
-    plan = compile_campaign_plan(
-        experiment_config_path=campaign / "production" / "experiment.yaml",
-        runner=load_runner_config(campaign / "production" / "runner.yaml"),
-        execution=load_execution_config(campaign / "production" / "execution.yaml"),
-        stage_filter="mip",
-    )
-    submission = dry_run_plan(plan)[0]
-    assert submission.launcher == "direct"
-    assert submission.gpus == 0
-    assert any(
-        str(argument).endswith("examples/puzzletron/main.py") for argument in submission.argv
-    )
-    assert submission.argv[submission.argv.index("--worker-stage") + 1] == "mip"
-    flow = next(iter(production["post_mip"]["flows"].values()))
-    comparison = flow["nodes"]["quality_benchmarks"]
-    assert comparison["type"] == "downstream_evaluation"
-    assert comparison["input"] == "best"
-    assert comparison["failure_policy"] == "strict"
-    assert comparison["config"]["tasks"] == [
-        "ifeval",
-        "gsm8k",
-        "mmlu_pro_computer_science",
-        "mmlu_pro_history",
-    ]
-    assert comparison["config"]["limit"] == 256
-    assert "recorded_observation" not in comparison["config"]
-    resolved_defaults = yaml.safe_load((campaign / "resolved_defaults.yaml").read_text())
-    assert resolved_defaults["pruning.depth_remove"] == {
-        "value": 0,
-        "requested": None,
-        "effective": 0,
-        "source": "model_profile",
-    }
-    pruning = generated.collection("pruning")
-    pruning["depth_remove"] = 1
-    generated.set_collection("pruning", pruning)
-    profiles = generated.collection("parallel_profiles")
-    first_profile = next(iter(profiles.values()))
-    profiles["secondary"] = {**first_profile, "tp": 2}
-    generated.set_collection("parallel_profiles", profiles)
-
-    wizard_module.build_bundles_v2(campaign, generated)
-
-    resolved_defaults = yaml.safe_load((campaign / "resolved_defaults.yaml").read_text())
-    assert resolved_defaults["pruning.depth_remove"] == {
-        "value": 0,
-        "requested": None,
-        "effective": 1,
-        "source": "model_profile",
-    }
-    assert resolved_defaults["profiles"]["effective"] == profiles
-
-
 def test_guided_wizard_generates_the_complete_qwen_vlm_flow(tmp_path, monkeypatch):
     campaign = tmp_path / "campaign"
     model_path = tmp_path / "model"
@@ -620,13 +446,7 @@ def test_guided_wizard_generates_the_complete_qwen_vlm_flow(tmp_path, monkeypatc
     assert flow_id == "params-90"
     nodes = flow["nodes"]
     quality = nodes["quality_benchmarks"]
-    assert (
-        quality["config"]["profile"] == "qwen35_vlm_realworldqa64_mmmu120_mvbench160_frozen_rows_v3"
-    )
-    assert quality["config"]["limit_mm_per_prompt"] == {"image": 32}
-    assert quality["config"]["max_model_len"] == 32768
     assert "model" not in quality["config"]
-    assert "log_samples" not in quality["config"]
     assert "recorded_observation" not in quality["config"]
     assert production_execution["execution"]["stages"]["replacement_scoring"]["instances"] == 8
     assert production_execution["execution"]["stages"]["post.params-90.short_kd"]["instances"] == 8
@@ -650,14 +470,6 @@ def test_guided_wizard_generates_the_complete_qwen_vlm_flow(tmp_path, monkeypatc
     mip = next(stage for stage in plan.stages if stage.stage_id == "mip")
     assert mip.resource == "cpu"
     assert mip.total_gpus == 0
-    dry_run = (campaign / "production" / "dry-run-plan.txt").read_text()
-    assert "mip: 1 submission(s), strategy=single, resource=cpu" in dry_run
-    assert '"resource": "cpu"' in dry_run
-    assert "scheduler_script" in dry_run
-    assert str(campaign / "production" / "experiment.yaml") in dry_run
-    assert ".puzzletron-v2-" not in dry_run
-    readme = (campaign / "README.md").read_text()
-    assert "generation-time snapshot" in readme
     snapshots = {
         budget: (campaign / budget / "dry-run-plan.txt").read_text()
         for budget in ("smoke", "production")
@@ -745,83 +557,6 @@ def test_guided_infrastructure_records_cpu_partition_default(tmp_path):
 
     assert state.get_field("infrastructure.runner.slurm.partition") == "gpu"
     assert state.get_field("infrastructure.runner.slurm.partition_cpu") == "cpu"
-
-
-def test_customize_partition_prompt_renders_list_default_as_comma_separated(tmp_path):
-    state = WizardState.start(tmp_path / "campaign", defaults_path=None)
-    resolver = DefaultsResolver(
-        file_defaults={
-            "infrastructure": {
-                "runner": {
-                    "slurm": {
-                        "partition": ["gpu-a", "gpu-b"],
-                        "partition_cpu": ["cpu-a", "cpu-b"],
-                    }
-                },
-            }
-        }
-    )
-
-    class PartitionDefaultBackend(ScriptedBackend):
-        partition_default = None
-        cpu_partition_default = None
-
-        def text(self, message: str, default: str) -> str:
-            if message.startswith("Eligible Slurm partitions"):
-                self.partition_default = default
-                return default
-            if message.startswith("Eligible CPU-only Slurm partitions"):
-                self.cpu_partition_default = default
-                return default
-            return super().text(message, default)
-
-    backend = PartitionDefaultBackend(
-        [
-            "customize",
-            "/worker/modelopt",
-            "/worker/venv",
-            "",
-            "",
-            "acct",
-            "pt",
-            "4:00:00",
-            "6",
-            "24576",
-            "8",
-            "",
-        ]
-    )
-
-    assert infrastructure_section(
-        WizardSession(state, backend),
-        resolver,
-        {},
-    )
-
-    assert backend.partition_default == "gpu-a,gpu-b"
-    assert backend.cpu_partition_default == "cpu-a,cpu-b"
-    assert state.get_field("infrastructure.runner.slurm.partition") == "gpu-a,gpu-b"
-    assert state.get_field("infrastructure.runner.slurm.partition_cpu") == "cpu-a,cpu-b"
-    assert state.get_field("infrastructure.runner.slurm.cpu_cpus_per_task") == 6
-    assert state.get_field("infrastructure.runner.slurm.cpu_memory_mb") == 24576
-    assert backend.remaining == 0
-
-
-def test_resume_preserves_legacy_partition_fields(tmp_path):
-    state = WizardState.start(tmp_path / "campaign", defaults_path=None)
-    legacy = {
-        "partition_batch": "batch",
-        "partition_interactive": "interactive",
-        "partition_cpu": "cpu",
-        "interactive_max_nodes": 2,
-    }
-    for field, value in legacy.items():
-        state.set_field(f"infrastructure.runner.slurm.{field}", value, source="user")
-
-    resumed = WizardState.resume(state.path)
-
-    for field, value in legacy.items():
-        assert resumed.get_field(f"infrastructure.runner.slurm.{field}") == value
 
 
 def _qwen_inspected_model(model_path, *, multimodal: bool = False) -> InspectedModel:

--- a/tests/unit/torch/puzzletron/test_stage_graph.py
+++ b/tests/unit/torch/puzzletron/test_stage_graph.py
@@ -24,7 +24,6 @@ from modelopt.torch.puzzletron.stages.graph import (
     StageSpec,
     selected_parent_stage_ids,
     semantic_stage_config,
-    stage_display_name,
     topological_stage_ids,
 )
 
@@ -219,25 +218,9 @@ def test_registry_uses_the_approved_fixed_dependencies():
 
 
 def test_model_executing_sanity_stages_are_distributed():
-    assert STAGE_REGISTRY["sort_sanity"].distributed
-    assert STAGE_REGISTRY["width_sanity"].distributed
-    assert STAGE_REGISTRY["bypass_sanity"].distributed
+    for stage_id in ("sort_sanity", "width_sanity", "bypass_sanity", "build_library"):
+        assert STAGE_REGISTRY[stage_id].distributed
     assert not STAGE_REGISTRY["slicing_sanity"].distributed
-
-
-def test_block_library_stage_is_distributed():
-    assert STAGE_REGISTRY["build_library"].distributed
-
-
-def test_stage_labels_use_independent_granularity():
-    assert stage_display_name("vllm_stats", granularity="block") == "Block vLLM Stats"
-    assert stage_display_name("vllm_stats", granularity="subblock") == "Subblock vLLM Stats"
-    assert stage_display_name("bypass", granularity="subblock") == "Subblock Bypass"
-    assert (
-        stage_display_name("replacement_scoring", granularity="subblock")
-        == "Replace-one-subblock Scoring"
-    )
-    assert stage_display_name("build_library", granularity="subblock") == "Build Block Library"
 
 
 def test_topological_order_rejects_unknown_parents():


### PR DESCRIPTION
## Summary

- remove low-value formatting, call-shape, passthrough, configuration-echo, and same-oracle permutation tests
- consolidate repeated fixtures and parameter cases without introducing a new test framework
- retain behavior and failure propagation, security boundaries, strict configuration and migration, concurrency and resource leasing, deterministic recovery, stale identity handling, and evaluator and metric semantics

Accuracy regression coverage remains in the evaluator metric, expected-results, and comparison-contract tests. Their small synthetic expectations stay next to the test oracles; moving them into fixture files would add indirection without validating a real model run.

## Validation

- 399 changed-file tests passed
- full maintained CPU lane: 1,545 passed, 4 skipped, 18 deselected because the optional NeMo AutoModel dependency is unavailable
- repository pre-commit hooks passed, including Ruff, formatting, mypy, license checks, and Bandit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined and consolidated test coverage across VLM evaluation, dataset acquisition, reporting, orchestration, setup flows, and model examples.
  - Updated contract tests to focus on key behavioral, lifecycle, resource, and configuration invariants.
  - Simplified fixtures and shared test helpers to reduce duplication.
  - Removed obsolete, redundant, overly specific, and brittle assertions while preserving core validation.
  - Expanded parameterized coverage for supported model and activation-pass scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->