### PR TITLE
Speed up FSDP2 MoE calibration by dropping redundant expert-weight gathers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changelog
 
 **Bug Fixes**
 
-- Speed up ``mtq.quantize`` on FSDP2-sharded fused-MoE models. Promoting static-block weight quantizers gathered each expert's slice of the fused weight across ranks even though only quantizer state is read, adding tens of thousands of collectives to calibration on large MoE models.
+- Speed up ``mtq.quantize`` on FSDP2-sharded fused-MoE models. Promoting static-block weight quantizers gathered each expert's slice of the fused weight across ranks even though only quantizer state is read, adding a collective per expert to calibration.
 - Add FP8 and INT8 recipes that quantize timm ResNet shortcut inputs immediately before residual adds. The torch ONNX example now accepts PTQ and AutoQuantize recipes through ``--recipe`` and uses ``--qformat`` when no recipe is provided. ResNet supports only FP8 and INT8 because TensorRT has limited convolution kernel support; AutoQuantize and other quantization formats are no longer supported for ResNet.
 - Fix a DDP hang in DFlash training at scale where a rank whose batch contained no valid anchor skipped the draft forward, leaving its rotary buffer list shorter than other ranks' and causing ``broadcast_buffers`` to hang. The buffer is now created during ``modify()`` before training begins.
 - Fix ``megatron_generate`` dropping the VLM vision inputs (``pixel_values`` / ``image_grid_thw`` / ``image_sizes``) after the first generated token when KV-cache decoding is off, including the automatic fallback under sequence parallelism, which made generation silently ignore the image. No other ModelOpt feature is affected.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Bug Fixes**
 
+- Speed up ``mtq.quantize`` on FSDP2-sharded fused-MoE models. Promoting static-block weight quantizers gathered each expert's slice of the fused weight across ranks even though only quantizer state is read, adding tens of thousands of collectives to calibration on large MoE models.
 - Add FP8 and INT8 recipes that quantize timm ResNet shortcut inputs immediately before residual adds. The torch ONNX example now accepts PTQ and AutoQuantize recipes through ``--recipe`` and uses ``--qformat`` when no recipe is provided. ResNet supports only FP8 and INT8 because TensorRT has limited convolution kernel support; AutoQuantize and other quantization formats are no longer supported for ResNet.
 - Fix a DDP hang in DFlash training at scale where a rank whose batch contained no valid anchor skipped the draft forward, leaving its rotary buffer list shorter than other ranks' and causing ``broadcast_buffers`` to hang. The buffer is now created during ``modify()`` before training begins.
 - Fix ``megatron_generate`` dropping the VLM vision inputs (``pixel_values`` / ``image_grid_thw`` / ``image_sizes``) after the first generated token when KV-cache decoding is off, including the automatic fallback under sequence parallelism, which made generation silently ignore the image. No other ModelOpt feature is affected.

--- a/modelopt/torch/quantization/nn/modules/quant_module.py
+++ b/modelopt/torch/quantization/nn/modules/quant_module.py
@@ -128,6 +128,17 @@ class QuantModule(DynamicModule):
             weight_quantizer = getattr(self, quantizer_attr_names(weight_name).weight_quantizer)
             yield getattr(self, weight_name), weight_quantizer
 
+    def iter_weight_quantizers_for_calibration(self):
+        """Yield just the weight quantizers, without materializing the weight views.
+
+        Callers that only inspect quantizer state must use this rather than discarding the
+        weight from :meth:`iter_weights_for_calibration`. Reading a weight is free here, but a
+        subclass whose weight view costs something -- the fused-MoE modules slice a 3-D DTensor
+        per expert, one redistribute collective each under FSDP2 -- overrides this to skip it.
+        """
+        for _, weight_quantizer in self.iter_weights_for_calibration():
+            yield weight_quantizer
+
     @staticmethod
     @torch.no_grad()
     def _fold_weight_quantizer(

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1105,8 +1105,7 @@ class _QuantFusedExperts(_QuantFunctionalMixin):
 
         Overrides the base, which would go through :meth:`iter_weights_for_calibration` and
         evaluate ``weight[idx]``. Under FSDP2 that weight is a DTensor, so every expert slice
-        dispatches a redistribute collective -- tens of thousands of them on a large MoE, for
-        values a quantizer-only caller throws away.
+        dispatches a redistribute collective to produce a value a quantizer-only caller discards.
         """
         for weight_name, quantizers_name in (
             (self._first_proj_attr, self._first_proj_weight_quantizers_attr),

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1100,6 +1100,25 @@ class _QuantFusedExperts(_QuantFunctionalMixin):
             for idx, q in enumerate(quantizers):
                 yield weight[idx], q
 
+    def iter_weight_quantizers_for_calibration(self):
+        """Yield the per-expert weight quantizers without slicing the fused 3-D weight.
+
+        Overrides the base, which would go through :meth:`iter_weights_for_calibration` and
+        evaluate ``weight[idx]``. Under FSDP2 that weight is a DTensor, so every expert slice
+        dispatches a redistribute collective -- tens of thousands of them on a large MoE, for
+        values a quantizer-only caller throws away.
+        """
+        for weight_name, quantizers_name in (
+            (self._first_proj_attr, self._first_proj_weight_quantizers_attr),
+            ("down_proj", "down_proj_weight_quantizers"),
+        ):
+            # Same skip condition as iter_weights_for_calibration, so the two stay in lockstep.
+            # Fetching the attribute is free; only indexing into it would collective.
+            quantizers = getattr(self, quantizers_name, None)
+            if getattr(self, weight_name, None) is None or quantizers is None:
+                continue
+            yield from quantizers
+
     def fold_weight(self, keep_attrs: bool = False):
         """Bake each per-expert weight quantizer into its slice of the fused 3-D weight.
 

--- a/modelopt/torch/quantization/utils/core_utils.py
+++ b/modelopt/torch/quantization/utils/core_utils.py
@@ -17,6 +17,7 @@
 
 import copy
 import itertools
+import warnings
 from collections import namedtuple
 from contextlib import ExitStack, contextmanager, nullcontext
 from typing import TYPE_CHECKING, Any
@@ -1107,10 +1108,13 @@ def promote_static_block_weight_quantizers(model: nn.Module) -> int:
         for quantizer in state._member_quantizers()
     }
     converted = 0
+    # Quantizer-only iteration: this loop reads quantizer state and never the weight, and asking
+    # for weights here costs one DTensor collective per expert on a fused-MoE model under FSDP2.
+    warned_dtensor_amax = False
     for _name, module in list(model.named_modules()):
         if not isinstance(module, QuantModule):
             continue
-        for _, quantizer in module.iter_weights_for_calibration():
+        for quantizer in module.iter_weight_quantizers_for_calibration():
             if isinstance(quantizer, SequentialQuantizer):
                 if len(quantizer) == 0:
                     continue
@@ -1123,6 +1127,16 @@ def promote_static_block_weight_quantizers(model: nn.Module) -> int:
             amax = quantizer.amax
             if amax is None:
                 continue
+            if isinstance(amax, DTensor) and not warned_dtensor_amax:
+                # _amax is a buffer, so FSDP2 leaves it replicated and reduce_amax below stays
+                # local. If that ever stops holding, the reduction becomes a per-quantizer
+                # collective and this loop needs a batched reduction instead.
+                warned_dtensor_amax = True
+                warnings.warn(
+                    "promote_static_block_weight_quantizers: _amax is a DTensor, so the "
+                    "per-quantizer global-amax reduction is a collective. Batch the reduction "
+                    "before running this at scale."
+                )
             if quantizer.is_nvfp4_static:
                 # Grouped siblings share one canonical global_amax (common FP8 grid); otherwise
                 # fall back to this quantizer's own per-block amax.

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -385,6 +385,60 @@ class TestQuantFusedExperts:
 # ---------------------------------------------------------------------------
 # Tests for export
 # ---------------------------------------------------------------------------
+class TestIterWeightQuantizersForCalibration:
+    """The quantizer-only iterator must agree with the weight iterator and never index a weight.
+
+    Indexing the fused 3-D weight is what dispatches a redistribute collective per expert under
+    FSDP2, so callers that only read quantizer state go through the quantizer-only path.
+    """
+
+    @staticmethod
+    def _convert(model):
+        expert_type = type(model.moe.experts)
+        TestQuantFusedExperts._cleanup_registry(expert_type)
+        register_fused_experts_on_the_fly(model)
+        converted = QuantModuleRegistry.convert(model.moe.experts)
+        TestQuantFusedExperts._cleanup_registry(expert_type)
+        return converted
+
+    @pytest.mark.parametrize(
+        "model_cls", [_TinyMoEModel, _TinyNonGatedMoEModel], ids=["gated", "non_gated"]
+    )
+    def test_yields_the_same_quantizers_in_the_same_order(self, model_cls):
+        experts = self._convert(model_cls())
+
+        from_weights = [q for _, q in experts.iter_weights_for_calibration()]
+        quantizers_only = list(experts.iter_weight_quantizers_for_calibration())
+
+        assert quantizers_only, "expected per-expert weight quantizers"
+        assert [id(q) for q in quantizers_only] == [id(q) for q in from_weights]
+
+    @pytest.mark.parametrize(
+        "model_cls", [_TinyMoEModel, _TinyNonGatedMoEModel], ids=["gated", "non_gated"]
+    )
+    def test_does_not_index_the_fused_weight(self, model_cls):
+        """The point of the override: no ``weight[idx]``, which is the per-expert collective."""
+        experts = self._convert(model_cls())
+
+        class _NoIndexing(torch.Tensor):
+            @staticmethod
+            def __new__(cls, data):
+                return torch.Tensor._make_subclass(cls, data, False)
+
+            def __getitem__(self, item):
+                raise AssertionError("iter_weight_quantizers_for_calibration indexed the weight")
+
+        for name in (experts._first_proj_attr, "down_proj"):
+            weight = getattr(experts, name)
+            setattr(experts, name, nn.Parameter(_NoIndexing(weight.data), requires_grad=False))
+
+        assert list(experts.iter_weight_quantizers_for_calibration())
+        # The weight iterator is the expensive one; it must still slice, or the guard above is
+        # not actually testing anything.
+        with pytest.raises(AssertionError, match="indexed the weight"):
+            list(experts.iter_weights_for_calibration())
+
+
 class TestExportFusedExperts:
     @staticmethod
     def _cleanup_registry(mod_type):


### PR DESCRIPTION

### What does this PR do?

Type of change: Perf enhancement

`promote_static_block_weight_quantizers` runs at the end of `max_calibrate`. All it does is read
quantizer state -- it takes the weight the iterator hands it and throws it away. For this it goes through `iter_weights_for_calibration`, and on a fused-MoE module that iterator yields `weight[idx]`, once per expert.

Under FSDP2 the fused weight is a DTensor spread across ranks, so `weight[idx]` isn't a cheap view.
Slicing it makes PyTorch pull the whole fused expert weight back from every rank, just to hand over
one slice that the loop then drops. That happens once per expert, per projection, per layer -- tens
of thousands of round-trips on a large MoE.

The fix adds `iter_weight_quantizers_for_calibration`:

- The base `QuantModule` implementation delegates to `iter_weights_for_calibration` and drops
  the weight, so every subclass gets a correct implementation for free and the two iterators
  cannot drift apart.
- Only the fused-MoE class — the one where materializing the weight view is itself expensive —
  overrides it, walking the per-expert quantizer `ModuleList` directly. It keeps the same skip
  condition as the weight iterator, since fetching an attribute is free and only indexing
  collectives.

`promote_static_block_weight_quantizers` then iterates quantizers instead of `(weight, quantizer)`
pairs. No other caller changes: the other four call sites genuinely use the weight.

Why not just wrap the promote loop in `enable_weight_access_and_writeback`, the way
`weight_only_quantize` does?  It would still gather per module for weights the
loop never reads. `weight_only_quantize` needs the window because it actually computes amax from the
weight; promote only needs the quantizer.

Also included: a warn-once check if `_amax` is ever a `DTensor`. It should not be — `_amax` is a
registered buffer, and `fully_shard` shards parameters, not buffers — which is why the
`reduce_amax` in this loop stays local. If that assumption ever breaks, the reduction becomes a
per-quantizer collective too, and the warning says so rather than letting it degrade silently.

### Results

Measured on Qwen-3.8 2.4T at world 64 (8 nodes, B300), NVFP4:

| | pre-export |
|---|---|
| before | 79.3 min |
| after | **19.0 min** |

60.3 min saved, 4.2x. The block is gone rather than shortened -- the run logs 13 silent minutes
in total, all of it model load. Calibration itself is unchanged at 2:23, so the saving comes from
the promote loop rather than from work moving elsewhere. End-to-end projects to 41.7 min.

### Usage

No API change. `mtq.quantize` picks this up automatically.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ Additive; `iter_weights_for_calibration` and all its
  callers that use the weight are untouched.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ Under 0.47 Bug Fixes — the call site dates to 0.46.
- Did you get Claude approval on this PR?: ❌ Not yet.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced calibration overhead for FSDP2-sharded fused-MoE quantization by avoiding unnecessary expert-weight gathering when only quantizer state is needed.
  - Preserved quantizer ordering and projection filtering during calibration.

- **Bug Fixes**
  - Added a warning when global amax reduction requires collective processing for individual quantizers.

- **Tests**
  - Added coverage for gated and non-gated fused-expert calibration, including verification that fused weights are not unnecessarily indexed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->