### PR TITLE
Release cached activations when exporting distillation models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
 
 **Bug Fixes**
 
+- Release cached student and teacher activations when exporting a distillation model, including teacher inputs captured by layerwise distillation.
+
 - Fix ``--use_fsdp2`` HuggingFace checkpoint export gathering the whole model onto rank 0, which made export the dominant phase of a PTQ run and could exhaust host memory on large models. The model is now split into per-decoder-layer units dealt round-robin across ranks; each rank gathers every unit but keeps, packs, and writes only the ones it owns, so a rank buffers roughly ``model / world_size`` instead of the whole checkpoint, and rank 0 writes the combined index. Export configurations that cannot be split this way now raise instead of producing a mismatched checkpoint: FSDP2 combined with another DTensor parallelism (for example FSDP2 + tensor parallel on a 2-D mesh; HSDP is supported), models whose decoder layers cannot be discovered, a decoder layer object reused across layers, and a module that holds the decoder layers while owning parameters of its own.
 - Speed up ``mtq.quantize`` on FSDP2-sharded fused-MoE models. Promoting static-block weight quantizers gathered each expert's slice of the fused weight across ranks even though only quantizer state is read, adding a collective per expert to calibration.
 - Add FP8 and INT8 recipes that quantize timm ResNet shortcut inputs immediately before residual adds. The torch ONNX example now accepts PTQ and AutoQuantize recipes through ``--recipe`` and uses ``--qformat`` when no recipe is provided. ResNet supports only FP8 and INT8 because TensorRT has limited convolution kernel support; AutoQuantize and other quantization formats are no longer supported for ResNet.

--- a/modelopt/torch/distill/distillation_model.py
+++ b/modelopt/torch/distill/distillation_model.py
@@ -124,6 +124,8 @@ class DistillationModel(DynamicModule):
         for handle in self._hook_handles:
             handle.remove()
         self._hook_handles.clear()
+        for layer in {layer for pair in self._layers_to_loss for layer in pair}:
+            delattr(layer, "_intermediate_output")
         return super().export()
 
     @property

--- a/modelopt/torch/distill/layerwise_distillation_model.py
+++ b/modelopt/torch/distill/layerwise_distillation_model.py
@@ -67,8 +67,10 @@ class LayerwiseDistillationModel(DistillationModel):
 
     def export(self):
         """Export the distillation model."""
-        for student_layer, _ in self._layers_to_loss:
+        for student_layer in {student for student, _ in self._layers_to_loss}:
             delattr(student_layer, "_teacher_layer")
+        for teacher_layer in {teacher for _, teacher in self._layers_to_loss}:
+            delattr(teacher_layer, "_intermediate_input")
 
         if hasattr(self, "_lm_head"):
             self.lm_head = self._lm_head

--- a/tests/unit/torch/distill/test_distill.py
+++ b/tests/unit/torch/distill/test_distill.py
@@ -13,17 +13,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import gc
 import inspect
 import warnings
+import weakref
 
 import pytest
 import torch
 import torch.nn as nn
+from _test_utils.torch.quantization.models import SimpleLinear
 from _test_utils.torch.vision_models import get_tiny_mobilenet_and_input
 from torchvision.models import alexnet
 
 import modelopt.torch.distill as mtd
 import modelopt.torch.opt as mto
+
+
+@pytest.mark.parametrize(
+    "pairs",
+    [
+        [("", ""), ("net", "net"), ("net", "linear1")],
+        [("", ""), ("net", "net"), ("linear1", "net")],
+    ],
+)
+def test_export_releases_captured_activations(pairs):
+    student = SimpleLinear(add_linear=True)
+    reference = copy.deepcopy(student)
+    teacher = SimpleLinear(add_linear=True)
+    hook_calls = []
+    handle = student.net.register_forward_hook(lambda *_: hook_calls.append(True))
+    model = mtd.convert(
+        student,
+        mode=[
+            (
+                "kd_loss",
+                {
+                    "teacher_model": teacher,
+                    "criterion": {pair: nn.MSELoss() for pair in pairs},
+                    "loss_balancer": mtd.StaticLossBalancer([1 / len(pairs)] * len(pairs)),
+                },
+            )
+        ],
+    )
+    inputs = student.get_input()
+    model(inputs)
+    layers = {layer for pair in model._layers_to_loss for layer in pair}
+    captures = [weakref.ref(layer._intermediate_output) for layer in layers]
+    assert all(capture() is not None for capture in captures)
+    assert model._intermediate_output.grad_fn is not None
+
+    exported = mtd.export(model)
+    gc.collect()
+
+    assert exported is student
+    assert type(exported) is SimpleLinear
+    assert all(capture() is None for capture in captures)
+    assert all(not hasattr(layer, "_intermediate_output") for layer in layers)
+    torch.testing.assert_close(exported(inputs), reference(inputs))
+    assert len(hook_calls) == 2
+    handle.remove()
 
 
 def get_input_tensor():

--- a/tests/unit/torch/distill/test_layerwise.py
+++ b/tests/unit/torch/distill/test_layerwise.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import warnings
+import weakref
 
 import pytest
 import torch
@@ -45,6 +47,20 @@ def layerwise_distillation_model():
     layerwise_model = mtd.convert(student, mode=[("layerwise_kd", config)])
 
     return layerwise_model
+
+
+def test_layerwise_export_releases_teacher_inputs(layerwise_distillation_model):
+    model = layerwise_distillation_model
+    with model.only_teacher_forward():
+        model(get_input_tensor())
+    teacher_layers = {teacher for _, teacher in model._layers_to_loss}
+    captures = [weakref.ref(layer._intermediate_input[0]) for layer in teacher_layers]
+
+    mtd.export(model)
+    gc.collect()
+
+    assert all(capture() is None for capture in captures)
+    assert all(not hasattr(layer, "_intermediate_input") for layer in teacher_layers)
 
 
 def test_layerwise_hooks_registration(layerwise_distillation_model):


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

After a distillation forward pass, `mtd.export()` removes the capture hooks but leaves their last outputs attached to the student and teacher layers. Student outputs can retain an autograd graph even though distillation has finished. Layerwise distillation can also retain teacher inputs after a teacher-only forward.

Remove these caches when exporting, deduplicating shared layers so a layer used by multiple loss pairs is cleaned up once. Existing unrelated user hooks remain installed.

### Usage

The existing `mtd.export(model)` call releases the distillation caches; no API change is required.

### Testing

- Three new cases fail on unmodified production code because captured tensors remain reachable after export.
- All 32 tests in `tests/unit/torch/distill/test_distill.py` and `test_layerwise.py` pass.
- Tests check weak references, repeated student/teacher layers, root-layer capture, restored model class and forward behavior, user-hook preservation, and a layerwise teacher-only forward.
- A small GPT-2 CUDA reproduction on an H800 retains both captured tensors before the fix and neither after it. With the teacher model retained separately in both runs, live allocated memory drops by 32,539,648 bytes on export after the fix, versus zero before it. This measures that specific reproduction, not a general memory reduction estimate.
- Changed-file pre-commit checks pass, including Ruff, mypy, licenses, and Bandit.

Distributed execution, checkpoint serialization, and full-model training performance were not tested.

### Before your PR is "*Ready for review*"

- Backward compatible: yes; only distillation-owned caches are removed after export.
- Copied code or new PIP dependencies: none.
- Necessary tests: added to the existing distillation modules.
- Changelog: updated.
- Upstream review: pending.

### Additional Information

Related to the activation-retention report in item 6 of #1926 and #1923. Other reports in #1926 are outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added layerwise quantization for operators outside transformer layers.
  * Added NVFP4 quantization recipes and tutorials.
  * Added filesystem-first recipe resolution.
  * Prior-layer QDQ activations are now enabled by default.

* **Changes**
  * Renamed recipe tiers and added compatibility warnings.
  * Single-format quantization flags are deprecated.

* **Bug Fixes**
  * Fixed distillation exports releasing cached activations and temporary layer data.
  * Fixed additional calibration, export, router dtype, and duplicate embedding issues.

* **Tests**
  * Added regression coverage for activation cleanup during export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->