### PR TITLE
Preserve zero batches in histogram calibration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
 
 **Bug Fixes**
 
+- Fix histogram calibration failing on a nonzero batch after initial all-zero batches, while preserving the zero-valued samples in the calibrated distribution.
+
 - Fix ``--use_fsdp2`` HuggingFace checkpoint export gathering the whole model onto rank 0, which made export the dominant phase of a PTQ run and could exhaust host memory on large models. The model is now split into per-decoder-layer units dealt round-robin across ranks; each rank gathers every unit but keeps, packs, and writes only the ones it owns, so a rank buffers roughly ``model / world_size`` instead of the whole checkpoint, and rank 0 writes the combined index. Export configurations that cannot be split this way now raise instead of producing a mismatched checkpoint: FSDP2 combined with another DTensor parallelism (for example FSDP2 + tensor parallel on a 2-D mesh; HSDP is supported), models whose decoder layers cannot be discovered, a decoder layer object reused across layers, and a module that holds the decoder layers while owning parameters of its own.
 - Speed up ``mtq.quantize`` on FSDP2-sharded fused-MoE models. Promoting static-block weight quantizers gathered each expert's slice of the fused weight across ranks even though only quantizer state is read, adding a collective per expert to calibration.
 - Add FP8 and INT8 recipes that quantize timm ResNet shortcut inputs immediately before residual adds. The torch ONNX example now accepts PTQ and AutoQuantize recipes through ``--recipe`` and uses ``--qformat`` when no recipe is provided. ResNet supports only FP8 and INT8 because TensorRT has limited convolution kernel support; AutoQuantize and other quantization formats are no longer supported for ResNet.

--- a/modelopt/torch/quantization/calib/histogram.py
+++ b/modelopt/torch/quantization/calib/histogram.py
@@ -114,18 +114,24 @@ class HistogramCalibrator(_Calibrator):
                 # Because we collect histogram on absolute value, setting min=0 simplifying the rare case where
                 # minimum value is not exactly 0 and first batch collected has larger min value than later batches
                 x_max = x.max()
-                if self._calib_bin_edges is None and self._calib_hist is None:
-                    self._calib_hist = torch.histc(x, bins=self._num_bins, min=0, max=x_max)
+                if self._calib_bin_edges is None or self._calib_bin_edges[-1] == 0:
+                    # A zero-only prefix has no bin width yet. Preserve its counts
+                    # in the first bin when the first nonzero batch defines the range.
+                    zero_count = 0 if self._calib_hist is None else self._calib_hist.sum()
+                    self._calib_hist = torch.histc(
+                        x, bins=self._num_bins, min=0, max=x_max if x_max > 0 else 1
+                    )
+                    self._calib_hist[0] += zero_count
                     self._calib_bin_edges = torch.linspace(0, x_max, self._num_bins + 1)
                 else:
-                    if x_max > self._calib_bin_edges[-1]:  # type: ignore[index]
-                        width = self._calib_bin_edges[1] - self._calib_bin_edges[0]  # type: ignore[index]
+                    if x_max > self._calib_bin_edges[-1]:
+                        width = self._calib_bin_edges[1] - self._calib_bin_edges[0]
                         self._num_bins = int((x_max / width).ceil().item())
                         self._calib_bin_edges = torch.arange(
                             0, x_max + width, width, device=x.device
                         )
 
-                    hist = torch.histc(x, bins=self._num_bins, min=0, max=self._calib_bin_edges[-1])  # type: ignore[index]
+                    hist = torch.histc(x, bins=self._num_bins, min=0, max=self._calib_bin_edges[-1])
                     hist[: self._calib_hist.numel()] += self._calib_hist  # type: ignore[union-attr]
                     self._calib_hist = hist
 

--- a/tests/unit/torch/quantization/test_calibrator.py
+++ b/tests/unit/torch/quantization/test_calibrator.py
@@ -23,6 +23,7 @@ from _test_utils.torch.quantization.models import QuantConvLinear
 from modelopt.torch.quantization import calib
 from modelopt.torch.quantization import nn as qnn
 from modelopt.torch.quantization import utils as quant_utils
+from modelopt.torch.quantization.config import QuantizerAttributeConfig
 
 
 class TestMaxCalibrator:
@@ -89,6 +90,49 @@ class TestMaxCalibrator:
 
 
 class TestHistogramCalibrator:
+    @pytest.mark.parametrize("scale", [1e-6, 1.0, 100.0])
+    @pytest.mark.parametrize("zero_batches", [1, 3])
+    def test_initial_zero_batches(self, scale, zero_batches):
+        calibrator = calib.HistogramCalibrator(num_bins=256)
+        batches = [torch.zeros(17)] * zero_batches
+        batches += [torch.linspace(-scale, scale, 101), torch.zeros(13)]
+        for batch in batches:
+            calibrator.collect(batch)
+
+        expected_hist, expected_edges = np.histogram(
+            torch.cat(batches).abs().numpy(), bins=256, range=(0, scale)
+        )
+        np.testing.assert_array_equal(calibrator._calib_hist.numpy(), expected_hist)
+        np.testing.assert_allclose(calibrator._calib_bin_edges.numpy(), expected_edges)
+        assert calibrator.compute_amax("percentile", percentile=99.9) == expected_edges[-2]
+
+    def test_only_zero_batches(self):
+        calibrator = calib.HistogramCalibrator(num_bins=256)
+        for count in [17, 23]:
+            calibrator.collect(torch.zeros(count))
+        assert calibrator._calib_hist[0] == 40
+        assert calibrator._calib_hist.sum() == 40
+        assert calibrator.compute_amax("percentile") == 0
+        calibrator.reset()
+        calibrator.collect(torch.tensor([0.0, 2.0]))
+        assert calibrator._calib_hist.sum() == 2
+        assert calibrator._calib_bin_edges[-1] == 2
+
+    def test_quantizer_calibration_after_zero_batch(self):
+        quantizer = qnn.TensorQuantizer(
+            QuantizerAttributeConfig(calibrator="histogram", axis=None),
+            if_quant=False,
+            if_calib=True,
+        )
+        quantizer(torch.zeros(16))
+        quantizer(torch.linspace(0, 1, 256))
+        quantizer.load_calib_amax(method="percentile")
+        quantizer.disable_calib()
+        quantizer.enable_quant()
+        output = quantizer(torch.linspace(0, 1, 256))
+        assert torch.isfinite(output).all()
+        torch.testing.assert_close(output, torch.linspace(0, 1, 256), atol=0.01, rtol=0)
+
     @pytest.mark.skip(reason="TODO: Fix assertions in test_grow")
     def test_grow(self, verbose):
         x_1 = torch.tensor([0, 255, 255, 255, 255, 255])


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Histogram calibration can fail when its first batch is all zeros and a later batch contains nonzero values. The initial bin edges are all zero, so growing the range divides by a zero bin width and raises `OverflowError`. `torch.histc` also places zeros in the middle of its automatic range when both bounds are zero.

Keep zero-only batches in the first bin, then rebuild the range when the first nonzero batch arrives and carry the previous zero counts into that bin. This preserves the calibrated distribution without imposing a minimum range that would lose resolution for small activations. Ordinary range growth and the NumPy collector are unchanged.

### Usage

No API change. Existing histogram-calibrated `TensorQuantizer` calls accept initial zero batches.

### Testing

- All eight new cases fail on unmodified production code. The complete calibrator module passes 36 tests, with one pre-existing skipped test.
- Tests compare every bin count with a NumPy histogram over the complete data, including repeated zero batches, negative values, small/large ranges, reset, and calibration followed by quantized inference through `TensorQuantizer`.
- On an H800, FP32/FP16/BF16 × percentile/MSE/entropy: incremental calibration after zero batches matches one-shot calibration in histogram counts, amax and quantized output in all nine cases.
- Changed-file pre-commit checks pass, including Ruff, mypy and Bandit.

This covers the default `torch_hist=True, skip_zeros=False` collector. Empty input after filtering with `skip_zeros=True`, nonfinite inputs, distributed calibration and full-model accuracy/performance were not tested or changed.

### Before your PR is "*Ready for review*"

- Backward compatible: yes; no API or serialized configuration changes.
- Copied code or new PIP dependencies: none.
- Necessary tests: added to the existing calibrator module.
- Changelog: updated.
- Upstream review: pending.

### Additional Information

The histogram collector is separate from the NVFP4 activation headroom algorithm in #2028.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed histogram calibration when initial batches contain only zero values and later batches become nonzero.
  * Preserved zero-valued samples in calibrated distributions.
  * Improved calibration reliability for all-zero inputs, reset workflows, percentile calculations, and quantizer outputs.

* **Tests**
  * Added coverage for zero-value batches, histogram ranges, calibration recovery, percentile results, and finite quantizer outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->