### PR TITLE
Invalidate sharded sparsity masks after updating the source mask

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Changelog
 
 **Bug Fixes**
 
+- Fix updated sparsity masks being ignored when reading or exporting sharded FSDP2 weights after calling ``set_mask()``.
+
 - Fix ``--use_fsdp2`` HuggingFace checkpoint export gathering the whole model onto rank 0, which made export the dominant phase of a PTQ run and could exhaust host memory on large models. The model is now split into per-decoder-layer units dealt round-robin across ranks; each rank gathers every unit but keeps, packs, and writes only the ones it owns, so a rank buffers roughly ``model / world_size`` instead of the whole checkpoint, and rank 0 writes the combined index. Export configurations that cannot be split this way now raise instead of producing a mismatched checkpoint: FSDP2 combined with another DTensor parallelism (for example FSDP2 + tensor parallel on a 2-D mesh; HSDP is supported), models whose decoder layers cannot be discovered, a decoder layer object reused across layers, and a module that holds the decoder layers while owning parameters of its own.
 - Speed up ``mtq.quantize`` on FSDP2-sharded fused-MoE models. Promoting static-block weight quantizers gathered each expert's slice of the fused weight across ranks even though only quantizer state is read, adding a collective per expert to calibration.
 - Add FP8 and INT8 recipes that quantize timm ResNet shortcut inputs immediately before residual adds. The torch ONNX example now accepts PTQ and AutoQuantize recipes through ``--recipe`` and uses ``--qformat`` when no recipe is provided. ResNet supports only FP8 and INT8 because TensorRT has limited convolution kernel support; AutoQuantize and other quantization formats are no longer supported for ResNet.

--- a/modelopt/torch/sparsity/weight_sparsity/module.py
+++ b/modelopt/torch/sparsity/weight_sparsity/module.py
@@ -87,11 +87,9 @@ class SparseModule(DynamicModule):
 
     def set_mask(self, value: torch.BoolTensor | None):
         """Set the active sparse mask of the module weights."""
-        # invalidate the cached DTensor mask since the underlying mask is changing
-        self._weight_mask_dtensor = None
-
         if value is None:
             self._weight_mask = None
+            self._weight_mask_dtensor = None
             return
 
         # sanity checks on the mask
@@ -108,3 +106,7 @@ class SparseModule(DynamicModule):
                 self._weight_mask = value.detach().clone().to(self.weight.device)
             else:
                 self._weight_mask.copy_(value.to(self._weight_mask.device))
+
+        # Reading self.weight above can populate the cache with the old mask.
+        # Invalidate it only after the underlying mask has been updated.
+        self._weight_mask_dtensor = None

--- a/tests/gpu/torch/sparsity/weight_sparsity/test_sparse_fsdp.py
+++ b/tests/gpu/torch/sparsity/weight_sparsity/test_sparse_fsdp.py
@@ -19,9 +19,11 @@ import pytest
 import torch
 import torch.nn as nn
 from _test_utils.torch.distributed.fsdp_test import run_fsdp_test
+from torch.distributed.fsdp import fully_shard
 
 from modelopt.torch.nas.search_space import SearchSpace
 from modelopt.torch.opt.conversion import apply_mode
+from modelopt.torch.sparsity import export
 
 
 def _get_test_case():
@@ -48,3 +50,33 @@ def test_fsdp(dist_workers, use_orig_params):
             fsdp_kwargs={"use_orig_params": use_orig_params},
         ),
     )
+
+
+def _run_fsdp2_mask_updates(dtype, initial_mask, rank, world_size):
+    model, _ = _get_test_case()
+    model.to(dtype=dtype)
+    raw_weight = model[0]._parameters["weight"].detach().clone()
+    mask = torch.ones_like(raw_weight, dtype=torch.bool)
+    mask[:, ::2] = False
+    if initial_mask:
+        model[0].set_mask(mask)
+    model = fully_shard(model)
+
+    for new_mask in [~mask, mask, None, torch.ones_like(mask), ~mask]:
+        model[0].set_mask(new_mask)
+        expected = raw_weight if new_mask is None else raw_weight * new_mask
+        # Reading a sharded dynamic weight must reflect the most recent mask.
+        torch.testing.assert_close(model[0].weight.full_tensor(), expected, atol=0, rtol=0)
+
+    # Export materializes the dynamic weight, so a stale cache would bake the
+    # previous mask into the checkpoint even though the mask buffer was updated.
+    exported = export(model)
+    torch.testing.assert_close(
+        exported.state_dict()["0.weight"].full_tensor(), expected, atol=0, rtol=0
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("initial_mask", [False, True])
+def test_fsdp2_mask_updates(dist_workers, dtype, initial_mask):
+    dist_workers.run(partial(_run_fsdp2_mask_updates, dtype, initial_mask))


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Calling `set_mask()` after FSDP2 sharding can leave the previous sparsity mask active when reading or exporting the sharded weight. The method invalidates its DTensor cache first, but then reads `self.weight.shape` for validation. That dynamic weight access rebuilds the cache from the old mask before the mask buffer is updated.

Invalidate the cache after updating the source mask instead, including the `None` path. Subsequent weight reads and sparse export then use the newly requested mask.

### Usage

No API change. `SparseModule.set_mask()` updates the mask used by sharded weights and their exported state.

### Testing

- Four new FSDP2 cases fail on the original implementation with incorrect masked weights.
- Six tests in `tests/gpu/torch/sparsity/weight_sparsity/test_sparse_fsdp.py` pass on two H800 GPUs, including the existing FSDP tests and new FP32/BF16 cases with and without a prior sparse mask.
- The new cases replace masks repeatedly, remove the mask, use an all-ones mask, and compare the exported state dict with the raw weights multiplied by the final requested mask.
- All 109 CPU tests in `tests/unit/torch/sparsity/weight_sparsity/test_sparsify.py` pass.
- Changed-file pre-commit checks pass, including Ruff, mypy, licenses and Bandit.

Multi-node execution, CPU offload and performance were not tested. The change addresses `set_mask()`; direct in-place mutation or checkpoint loading into an already populated cache is outside this regression.

### Before your PR is "*Ready for review*"

- Backward compatible: yes; no configuration or checkpoint schema changes.
- Copied code or new PIP dependencies: none.
- Necessary tests: added to the existing FSDP sparsity test module.
- Changelog: updated.
- Upstream review: pending.

### Additional Information

The DTensor mask cache was introduced in #1818. This corrects its invalidation ordering without changing the sharding strategy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated sparsity masks are now correctly respected when reading or exporting sharded FSDP2 weights after mask changes.
  - Removing or replacing a sparsity mask now reliably refreshes the affected weight data, including after repeated updates.

- **Tests**
  - Added coverage for dynamic mask updates across data types and initial-mask configurations, including sharded and exported weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->