### PR TITLE
Audit missing labels before release cherry-picks

### DIFF
--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -73,6 +73,12 @@ Present the complete audit before changing GitHub labels:
 | PR | Title | Author | NVBug(s) | Bug fix? | `cherry-pick-<VERSION>` present? | Recommendation |
 |---|---|---|---|---|---|---|
 
+Use these recommendation values and sort the table in this order:
+
+1. **Needs label** — confirmed release-relevant bug fix.
+2. **Unknown** — requires user judgment.
+3. **No action needed** — not a release-relevant bug fix.
+
 Use `—` when no NVBug is known. Also list NVBugs with no linked PR. Ask the user to confirm which recommended PRs should receive the missing label. After confirmation, apply it:
 
 ```bash

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -31,21 +31,32 @@ Audit PRs merged into `main` since the latest release candidate. Exclude PRs tha
 git fetch origin main "release/$VERSION" --tags
 RC_TAG=$(git tag --merged "origin/release/$VERSION" \
   --list "${VERSION}rc*" --sort=-version:refname | head -1)
-test -n "$RC_TAG"
+test -n "$RC_TAG" || {
+  echo "No ${VERSION}rc* tag found on origin/release/$VERSION" >&2
+  exit 1
+}
 SINCE=$(git for-each-ref --format='%(creatordate:iso-strict)' \
   "refs/tags/$RC_TAG")
 
 PATCH_STATUS=$(git cherry "origin/release/$VERSION" origin/main)
 
-gh search prs \
-  --repo NVIDIA/Model-Optimizer \
-  --merged \
-  --base main \
-  --merged-at ">=$SINCE" \
-  --limit 1000 \
-  --json number,title,author,labels,url \
-  -- "-label:cherry-pick-$VERSION" \
-  | jq -r '.[].number' \
+SEARCH_RESULTS=$(
+  gh search prs \
+    --repo NVIDIA/Model-Optimizer \
+    --merged \
+    --base main \
+    --merged-at ">=$SINCE" \
+    --limit 1000 \
+    --json number,title,author,labels,url \
+    -- "-label:cherry-pick-$VERSION"
+)
+
+if test "$(jq 'length' <<<"$SEARCH_RESULTS")" -ge 1000; then
+  echo "Recent-PR audit reached the 1,000-result limit" >&2
+  exit 1
+fi
+
+jq -r '.[].number' <<<"$SEARCH_RESULTS" \
   | while read -r pr; do
       sha=$(gh pr view "$pr" --repo NVIDIA/Model-Optimizer \
         --json mergeCommit --jq '.mergeCommit.oid')
@@ -56,7 +67,7 @@ gh search prs \
     done
 ```
 
-Assert that the GitHub result has no next-page token before continuing; abort the audit if it does. A release is not normally expected to exceed 1,000 merged PRs.
+A release is not normally expected to reach the 1,000-PR limit.
 
 Review each PR's title, body, labels, changed files, and linked issue context. Classify it as:
 
@@ -83,7 +94,7 @@ Use `—` when no NVBug is known. Also list NVBugs with no linked PR. Ask the us
 
 ```bash
 for pr in <APPROVED_NUMBERS>; do
-  gh pr edit "$pr" --repo NVIDIA/Model-Optimizer --add-label "cherry-pick-<VERSION>"
+  gh pr edit "$pr" --repo NVIDIA/Model-Optimizer --add-label "cherry-pick-$VERSION"
 done
 ```
 

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -56,7 +56,7 @@ gh search prs \
     done
 ```
 
-`git cherry` marks patches absent from the release branch with `+`. It omits directly inherited commits and marks patch-equivalent cherry-picks with `-`, so only `+` candidates proceed. Assert that the GitHub result has no next-page token before continuing; abort the audit if it does. A release is not normally expected to exceed 1,000 merged PRs.
+Assert that the GitHub result has no next-page token before continuing; abort the audit if it does. A release is not normally expected to exceed 1,000 merged PRs.
 
 Review each PR's title, body, labels, changed files, and linked issue context. Classify it as:
 

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-cherry-pick
-description: Cherry-pick merged PRs labeled for a release branch into that branch, then open a PR and apply the cherry-pick-done label. Use when asked to "cherry-pick PRs for release/X.Y.Z", "pick PRs to release branch", or "cherry-pick labeled PRs".
+description: Audit merged bug-fix PRs and release NVBugs for missing cherry-pick labels, then cherry-pick labeled PRs into a release branch and open a PR. Use when asked to "cherry-pick PRs for release/X.Y.Z", "pick PRs to release branch", "verify cherry-pick labels", or "cherry-pick labeled PRs".
 ---
 
 # Cherry-pick PRs to a Release Branch
@@ -13,7 +13,68 @@ Ask the user for the release version (e.g. `0.44.0`) if not already provided.
 
 Set `VERSION=<version>` for use in subsequent steps.
 
-## Step 2 — Fetch pending PRs
+## Step 2 — Audit candidates for missing labels
+
+Before fetching the labeled queue, audit release NVBugs and recent merged PRs so bug fixes are not omitted.
+
+### Audit release NVBugs
+
+Use NVBug IDs supplied by the user or found in their release source (for example, a test-plan document or release message). If none were supplied, ask the user for the NVBug list; do not assume the GitHub queue is complete.
+
+For each NVBug:
+
+1. Open `https://nvbugspro.nvidia.com/bug/<NVBUG>`.
+2. Verify it has the exact release label `Committed_ModelOpt_<VERSION>`.
+3. Inspect its comments for `github.com/NVIDIA/Model-Optimizer/pull/<PR>` links. Record every linked PR, not only the latest comment.
+4. Verify each linked PR is merged into `main` and is a bug fix. A release-labeled NVBug is evidence for review, not by itself proof that every linked PR should be picked.
+
+If an NVBug lacks the expected NVBug label, report it but do not edit NVBug. If browser access is unavailable, report that the NVBug portion of the audit could not be completed and ask the user for the relevant PR links or exported comments.
+
+### Audit recent merged PRs
+
+Treat PRs merged into `main` since the release branch diverged as "recent":
+
+```bash
+git fetch origin main release/<VERSION>
+BASE=$(git merge-base origin/main origin/release/<VERSION>)
+SINCE=$(git show -s --format=%cs "$BASE")
+
+gh pr list \
+  --repo NVIDIA/Model-Optimizer \
+  --state merged \
+  --base main \
+  --limit 1000 \
+  --json number,title,author,mergedAt,labels,url \
+  | jq --arg since "${SINCE}T00:00:00Z" \
+      '[.[] | select(.mergedAt >= $since)]'
+```
+
+Review each PR's title, body, labels, changed files, and linked issue context. Classify it as:
+
+- **Yes** — repairs incorrect behavior, a regression, crash, compatibility problem, or documentation defect relevant to the release.
+- **No** — feature, refactor, cleanup, dependency refresh, or other change not needed to correct the release.
+- **Unclear** — insufficient evidence or meaningful backport risk; ask the user.
+
+Do not classify a PR as a bug fix from the word `fix` alone. Deduplicate PRs found through both audits.
+
+### Report and label
+
+Present the complete audit before changing GitHub labels:
+
+| PR | Title | Author | NVBug(s) | Bug fix? | `cherry-pick-<VERSION>` present? | Recommendation |
+|---|---|---|---|---|---|---|
+
+Use `—` when no NVBug is known. Also list NVBugs with no linked PR or a missing `Committed_ModelOpt_<VERSION>` label. Ask the user to confirm which recommended PRs should receive the missing label. After confirmation, apply it:
+
+```bash
+for pr in <APPROVED_NUMBERS>; do
+  gh pr edit "$pr" --repo NVIDIA/Model-Optimizer --add-label "cherry-pick-<VERSION>"
+done
+```
+
+Do not label unmerged PRs, PRs not based on `main`, or candidates classified **Unclear** without explicit approval. Re-run the audit table after edits so it reflects the final label state.
+
+## Step 3 — Fetch pending PRs
 
 Use the GitHub search API to list PRs that have the cherry-pick label but not cherry-pick-done, sorted by merge date ascending:
 
@@ -25,7 +86,7 @@ gh api "search/issues?q=repo:NVIDIA/Model-Optimizer+is:pr+is:merged+base:main+la
 
 Present the list to the user before proceeding.
 
-## Step 3 — Set up the release branch
+## Step 4 — Set up the release branch
 
 Check out `release/<VERSION>`, creating it from the remote if it doesn't exist locally:
 
@@ -34,7 +95,7 @@ git fetch origin release/<VERSION>
 git checkout release/<VERSION>
 ```
 
-## Step 4 — Get merge commit SHAs
+## Step 5 — Get merge commit SHAs
 
 All PRs are squash-merged, so each has a single-parent commit. Retrieve the SHA for each PR:
 
@@ -42,7 +103,7 @@ All PRs are squash-merged, so each has a single-parent commit. Retrieve the SHA 
 gh pr view <NUM> --repo NVIDIA/Model-Optimizer --json mergeCommit --jq '.mergeCommit.oid'
 ```
 
-## Step 5 — Cherry-pick in merge order
+## Step 6 — Cherry-pick in merge order
 
 Cherry-pick each commit with `-s` (DCO sign-off). GPG signing is handled automatically by the repo's git config.
 
@@ -56,7 +117,7 @@ git cherry-pick -s <SHA>
 git cherry-pick --continue
 ```
 
-## Step 6 — Create a PR to the release branch
+## Step 7 — Create a PR to the release branch
 
 Push the cherry-picks to a new branch and open a PR targeting `release/<VERSION>`. The PR title lists every cherry-picked PR number. The body uses `## Cherry-picked PRs` as the only heading with one `- #<NUM>` bullet per PR — no titles, no links, no extra text.
 
@@ -78,7 +139,7 @@ EOF
 )"
 ```
 
-## Step 7 — Apply cherry-pick-done label
+## Step 8 — Apply cherry-pick-done label
 
 Add the `cherry-pick-done` label to every PR that was successfully cherry-picked:
 

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -19,35 +19,32 @@ Before fetching the labeled queue, audit release NVBugs and recent merged PRs so
 
 ### Audit release NVBugs
 
-Use NVBug IDs supplied by the user or found in their release source (for example, a test-plan document or release message). If none were supplied, ask the user for the NVBug list; do not assume the GitHub queue is complete.
+Use the NVBugs MCP to search for every NVBug whose **Keywords** field contains the exact keyword `Committed_ModelOpt_<VERSION>`. Follow pagination until no next token is returned; do not ask the user for a list.
 
-For each NVBug:
-
-1. Open `https://nvbugspro.nvidia.com/bug/<NVBUG>`.
-2. Verify it has the exact release label `Committed_ModelOpt_<VERSION>`.
-3. Inspect its comments for `github.com/NVIDIA/Model-Optimizer/pull/<PR>` links. Record every linked PR, not only the latest comment.
-4. Verify each linked PR is merged into `main` and is a bug fix. A release-labeled NVBug is evidence for review, not by itself proof that every linked PR should be picked.
-
-If an NVBug lacks the expected NVBug label, report it but do not edit NVBug. If browser access is unavailable, report that the NVBug portion of the audit could not be completed and ask the user for the relevant PR links or exported comments.
+Fetch each matching NVBug with its comments. Extract every Model-Optimizer PR link or unambiguous `PR #<NUM>` reference from the comments, not only the latest comment. Verify each linked PR is merged into `main` and is a bug fix. The NVBug keyword is evidence for review, not by itself proof that every linked PR should be picked.
 
 ### Audit recent merged PRs
 
-Treat PRs merged into `main` since the release branch diverged as "recent":
+Treat PRs merged into `main` since the latest release candidate as "recent":
 
 ```bash
-git fetch origin main release/<VERSION>
-BASE=$(git merge-base origin/main origin/release/<VERSION>)
-SINCE=$(git show -s --format=%cs "$BASE")
+git fetch origin main release/<VERSION> --tags
+RC_TAG=$(git tag --merged origin/release/<VERSION> \
+  --list '<VERSION>rc*' --sort=-version:refname | head -1)
+test -n "$RC_TAG"
+SINCE=$(git for-each-ref --format='%(creatordate:iso-strict)' \
+  "refs/tags/$RC_TAG")
 
-gh pr list \
+gh search prs \
   --repo NVIDIA/Model-Optimizer \
-  --state merged \
+  --merged \
   --base main \
+  --merged-at ">=$SINCE" \
   --limit 1000 \
-  --json number,title,author,mergedAt,labels,url \
-  | jq --arg since "${SINCE}T00:00:00Z" \
-      '[.[] | select(.mergedAt >= $since)]'
+  --json number,title,author,labels,url
 ```
+
+Assert that the GitHub result has no next-page token before continuing; abort the audit if it does.
 
 Review each PR's title, body, labels, changed files, and linked issue context. Classify it as:
 
@@ -55,7 +52,7 @@ Review each PR's title, body, labels, changed files, and linked issue context. C
 - **No** — feature, refactor, cleanup, dependency refresh, or other change not needed to correct the release.
 - **Unclear** — insufficient evidence or meaningful backport risk; ask the user.
 
-Do not classify a PR as a bug fix from the word `fix` alone. Deduplicate PRs found through both audits.
+Deduplicate PRs found through both audits.
 
 ### Report and label
 
@@ -64,7 +61,7 @@ Present the complete audit before changing GitHub labels:
 | PR | Title | Author | NVBug(s) | Bug fix? | `cherry-pick-<VERSION>` present? | Recommendation |
 |---|---|---|---|---|---|---|
 
-Use `—` when no NVBug is known. Also list NVBugs with no linked PR or a missing `Committed_ModelOpt_<VERSION>` label. Ask the user to confirm which recommended PRs should receive the missing label. After confirmation, apply it:
+Use `—` when no NVBug is known. Also list NVBugs with no linked PR. Ask the user to confirm which recommended PRs should receive the missing label. After confirmation, apply it:
 
 ```bash
 for pr in <APPROVED_NUMBERS>; do

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -25,7 +25,7 @@ Fetch each matching NVBug with its comments. Extract every Model-Optimizer PR li
 
 ### Audit recent merged PRs
 
-Treat PRs merged into `main` since the latest release candidate as "recent":
+Audit PRs merged into `main` since the latest release candidate. Exclude PRs that already have `cherry-pick-<VERSION>` and changes already present on the release branch:
 
 ```bash
 git fetch origin main "release/$VERSION" --tags

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -21,19 +21,21 @@ Before fetching the labeled queue, audit release NVBugs and recent merged PRs so
 
 Use the NVBugs MCP to search for every NVBug whose **Keywords** field contains the exact keyword `Committed_ModelOpt_<VERSION>`. Follow pagination until no next token is returned.
 
-Fetch each matching NVBug with its comments. Extract every Model-Optimizer PR link or unambiguous `PR #<NUM>` reference from the comments, not only the latest comment. Verify each linked PR is merged into `main` and is a bug fix. The NVBug keyword is evidence for review, not by itself proof that every linked PR should be picked.
+Fetch each matching NVBug with its comments. Extract every Model-Optimizer PR link or unambiguous `PR #<NUM>` reference from the comments, not only the latest comment. Keep only PRs that are merged into `main`, lack `cherry-pick-<VERSION>`, and are not already included in the release branch. Verify each remaining PR is a bug fix. The NVBug keyword is evidence for review, not by itself proof that every linked PR should be picked.
 
 ### Audit recent merged PRs
 
 Treat PRs merged into `main` since the latest release candidate as "recent":
 
 ```bash
-git fetch origin main release/<VERSION> --tags
-RC_TAG=$(git tag --merged origin/release/<VERSION> \
-  --list '<VERSION>rc*' --sort=-version:refname | head -1)
+git fetch origin main "release/$VERSION" --tags
+RC_TAG=$(git tag --merged "origin/release/$VERSION" \
+  --list "${VERSION}rc*" --sort=-version:refname | head -1)
 test -n "$RC_TAG"
 SINCE=$(git for-each-ref --format='%(creatordate:iso-strict)' \
   "refs/tags/$RC_TAG")
+
+PATCH_STATUS=$(git cherry "origin/release/$VERSION" origin/main)
 
 gh search prs \
   --repo NVIDIA/Model-Optimizer \
@@ -41,10 +43,20 @@ gh search prs \
   --base main \
   --merged-at ">=$SINCE" \
   --limit 1000 \
-  --json number,title,author,labels,url
+  --json number,title,author,labels,url \
+  -- "-label:cherry-pick-$VERSION" \
+  | jq -r '.[].number' \
+  | while read -r pr; do
+      sha=$(gh pr view "$pr" --repo NVIDIA/Model-Optimizer \
+        --json mergeCommit --jq '.mergeCommit.oid')
+      if grep -q "^+ $sha$" <<<"$PATCH_STATUS"; then
+        gh pr view "$pr" --repo NVIDIA/Model-Optimizer \
+          --json number,title,author,labels,url
+      fi
+    done
 ```
 
-Assert that the GitHub result has no next-page token before continuing; abort the audit if it does. A release is not normally expected to exceed 1,000 merged PRs.
+`git cherry` marks patches absent from the release branch with `+`. It omits directly inherited commits and marks patch-equivalent cherry-picks with `-`, so only `+` candidates proceed. Assert that the GitHub result has no next-page token before continuing; abort the audit if it does. A release is not normally expected to exceed 1,000 merged PRs.
 
 Review each PR's title, body, labels, changed files, and linked issue context. Classify it as:
 

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -44,7 +44,7 @@ gh search prs \
   --json number,title,author,labels,url
 ```
 
-Assert that the GitHub result has no next-page token before continuing; abort the audit if it does.
+Assert that the GitHub result has no next-page token before continuing; abort the audit if it does. A release is not normally expected to exceed 1,000 merged PRs.
 
 Review each PR's title, body, labels, changed files, and linked issue context. Classify it as:
 

--- a/plugins/modelopt/skills/release-cherry-pick/SKILL.md
+++ b/plugins/modelopt/skills/release-cherry-pick/SKILL.md
@@ -19,7 +19,7 @@ Before fetching the labeled queue, audit release NVBugs and recent merged PRs so
 
 ### Audit release NVBugs
 
-Use the NVBugs MCP to search for every NVBug whose **Keywords** field contains the exact keyword `Committed_ModelOpt_<VERSION>`. Follow pagination until no next token is returned; do not ask the user for a list.
+Use the NVBugs MCP to search for every NVBug whose **Keywords** field contains the exact keyword `Committed_ModelOpt_<VERSION>`. Follow pagination until no next token is returned.
 
 Fetch each matching NVBug with its comments. Extract every Model-Optimizer PR link or unambiguous `PR #<NUM>` reference from the comments, not only the latest comment. Verify each linked PR is merged into `main` and is a bug fix. The NVBug keyword is evidence for review, not by itself proof that every linked PR should be picked.
 


### PR DESCRIPTION
Chad's Agent

## Summary

- query NVBugs MCP for the exact `Committed_ModelOpt_<VERSION>` keyword and inspect linked PRs
- audit PRs merged after the latest RC tag for missing cherry-pick labels
- verify audit result pagination, report findings, and require confirmation before adding labels

## Testing

- `npx --yes markdownlint-cli2@0.18.1 plugins/modelopt/skills/release-cherry-pick/SKILL.md`
- exercised the 0.47.0 audit using `0.47.0rc1`; GitHub returned 13 complete results
- verified the exact NVBug keyword query returned 33 bugs and inspected their comments
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the release cherry-pick workflow to exclude pull requests whose merge commits are already included in the target release branch.
  - Applied this audit to both NVBug-linked and recently merged pull request candidates.
  - Updated recent pull request queries to reference the selected version and release branch.
  - Renumbered the remaining workflow steps for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->