### PR TITLE
Allow DASC quality gates above parity

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/config.py
+++ b/modelopt/torch/sparsity/state_sparsity/config.py
@@ -142,9 +142,9 @@ class DASCConfig(ModeloptBaseConfig):
     @field_validator("min_perplexity_retention")
     @classmethod
     def validate_perplexity_gate(cls, value: float) -> float:
-        """Require a finite retention gate in (0, 1]."""
-        if not math.isfinite(value) or not 0.0 < value <= 1.0:
-            raise ValueError("min_perplexity_retention must be finite and in (0, 1]")
+        """Require a finite positive retention gate."""
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError("min_perplexity_retention must be finite and positive")
         return value
 
     @field_validator("min_top1_agreement")

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -160,11 +160,19 @@ def test_config_fails_closed(override):
 
 
 def test_perplexity_retention_accepts_parity_improvements():
-    """Allow an observed DASC perplexity improvement instead of requiring clamping."""
-    measurement = mtss.DASCCalibrationMeasurement(**_candidate(7))
-    measurement.quality[0].perplexity_retention = 1.0004
+    """Allow improvement measurements and thresholds instead of requiring clamping."""
+    candidate = _candidate(7)
+    candidate["quality"][0]["perplexity_retention"] = 1.0004
+    measurement = mtss.DASCCalibrationMeasurement(**candidate)
 
     assert measurement.quality[0].perplexity_retention == 1.0004
+
+    model = mtss.calibrate(
+        TinyGatedDeltaNetForCausalLM(),
+        _config(wmax_candidates=[7], min_perplexity_retention=1.0002),
+        [candidate],
+    )
+    assert mtss.export_policy(model)["selected_wmax"] == 7
 
 
 def test_calibration_fails_closed_on_measurements_and_model_mismatch():


### PR DESCRIPTION
Follow-up to #2377 for its CodeRabbit consistency finding.

The DASC perplexity ratio allows values above 1.0, so the configurable minimum gate now accepts any finite positive value as well. The test exercises a 1.0002 minimum against a 1.0004 measurement through full calibration and policy export.

Validation:
- 15 focused DASC tests pass
- pre-commit passes for both changed files

Signed-off-by: Kai Xu <kaix@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Perplexity-retention thresholds now accept any finite positive value, including values above 1.0.
  * Calibration succeeds when measured perplexity retention exceeds 1.0 and meets the configured threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->