### PR TITLE
Reject incomplete DASC layer sets

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -105,13 +105,6 @@ def compute_gdn_decay_horizons(
     return horizons
 
 
-def _is_gdn_module(module: nn.Module, supported_classes: tuple[type[nn.Module], ...]) -> bool:
-    """Accept supported GDN implementations and their ModelOpt dynamic subclasses."""
-    return _has_supported_gdn_identity(module, supported_classes) and all(
-        isinstance(getattr(module, name, None), torch.Tensor) for name in ("A_log", "dt_bias")
-    )
-
-
 def _has_supported_gdn_identity(
     module: nn.Module, supported_classes: tuple[type[nn.Module], ...]
 ) -> bool:
@@ -128,37 +121,39 @@ def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
     model = unwrap_model(model, force_unwrap=True)
     supported_classes = _supported_gdn_classes()
     named_modules = list(model.named_modules())
-    modules = {
-        name: module for name, module in named_modules if _is_gdn_module(module, supported_classes)
-    }
+    identity_modules = [
+        (name, module)
+        for name, module in named_modules
+        if _has_supported_gdn_identity(module, supported_classes)
+    ]
+    missing_decay_parameters = [
+        name or "<root>"
+        for name, module in identity_modules
+        if not all(
+            isinstance(getattr(module, parameter, None), torch.Tensor)
+            for parameter in ("A_log", "dt_bias")
+        )
+    ]
+    if missing_decay_parameters:
+        raise ApplyModeError(
+            "DASC found supported GDN modules without A_log and dt_bias tensors at: "
+            f"{', '.join(missing_decay_parameters)}"
+        )
+    unsupported_subclasses = [
+        name or "<root>"
+        for name, module in named_modules
+        if not isinstance(module, DynamicModule)
+        and type(module) not in supported_classes
+        and any(base in supported_classes for base in type(module).__mro__[1:])
+    ]
+    if unsupported_subclasses:
+        raise ApplyModeError(
+            "DASC found GDN subclasses that are not ModelOpt dynamic modules at: "
+            f"{', '.join(unsupported_subclasses)}; convert the module with ModelOpt or use a "
+            "supported class directly"
+        )
+    modules = dict(identity_modules)
     if not modules:
-        missing_decay_parameters = [
-            name or "<root>"
-            for name, module in named_modules
-            if _has_supported_gdn_identity(module, supported_classes)
-            and not all(
-                isinstance(getattr(module, parameter, None), torch.Tensor)
-                for parameter in ("A_log", "dt_bias")
-            )
-        ]
-        if missing_decay_parameters:
-            raise ApplyModeError(
-                "DASC found supported GDN modules without A_log and dt_bias tensors at: "
-                f"{', '.join(missing_decay_parameters)}"
-            )
-        unsupported_subclasses = [
-            name or "<root>"
-            for name, module in named_modules
-            if not isinstance(module, DynamicModule)
-            and type(module) not in supported_classes
-            and any(base in supported_classes for base in type(module).__mro__[1:])
-        ]
-        if unsupported_subclasses:
-            raise ApplyModeError(
-                "DASC found GDN subclasses that are not ModelOpt dynamic modules at: "
-                f"{', '.join(unsupported_subclasses)}; convert the module with ModelOpt or use a "
-                "supported class directly"
-            )
         supported = ", ".join(
             f"{module_name}.{class_name}" for module_name, class_name in _SUPPORTED_GDN_CLASS_PATHS
         )

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -265,6 +265,13 @@ def test_calibration_fails_closed_on_measurements_and_model_mismatch():
     with pytest.raises(ApplyModeError, match="without A_log and dt_bias tensors"):
         mtss.calibrate(missing_decay, _config(wmax_candidates=[7]), [_candidate(7)])
 
+    partially_valid = nn.Module()
+    partially_valid.good = GatedDeltaNet()
+    partially_valid.bad = GatedDeltaNet()
+    del partially_valid.bad.dt_bias
+    with pytest.raises(ApplyModeError, match="bad"):
+        mtss.analyze_gdn_decay(partially_valid)
+
     invalid_decay = TinyGatedDeltaNetForCausalLM()
     invalid_decay.linear_attn.dt_bias = nn.Parameter(torch.zeros(3))
     with pytest.raises(ApplyModeError, match="Invalid GDN decay parameters"):


### PR DESCRIPTION
## Summary

Follow-up to #2383 addressing its final Claude suggestion:

- resolve supported GDN identities once
- reject every supported identity missing A_log or dt_bias before accepting any layer
- remove the dead duplicated tensor predicate
- add a mixed valid-plus-malformed layer regression so malformed GDN layers cannot be silently omitted

This PR is intentionally stacked on #2383 because repository rules protect a PR head branch after creation.

## Validation

- focused DASC suite: 23 passed, 1 absent optional Megatron skip
- DASC plus weight sparsity plus attention sparsity compatibility suite: 134 passed, 1 optional skip
- DASC package coverage: 405/405 statements, 100%
- full pre-commit on touched files: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when analyzing GDN modules for sparsity.
  * Detects missing or invalid decay parameters and reports the affected module.
  * Rejects unsupported GDN subclasses unless they are compatible dynamic modules.
  * Ensures partially valid module trees are correctly rejected instead of being processed inconsistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The fail-closed coverage applies symmetrically to mixed models containing a valid GDN layer plus either a malformed supported identity or an unconverted ordinary GDN subclass; neither layer may be silently omitted.