### PR TITLE
Clarify DASC layer validation

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -170,7 +170,7 @@ def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
             f"{module_name}.{class_name}" for module_name, class_name in _SUPPORTED_GDN_CLASS_PATHS
         )
         raise ApplyModeError(f"DASC found no supported GDN modules; expected one of: {supported}")
-    return dict(sorted(identity_modules))
+    return dict(sorted(identity_modules, key=lambda item: item[0]))
 
 
 def _analyze_gdn_modules(

--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -116,16 +116,8 @@ def _has_supported_gdn_identity(
     )
 
 
-def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
-    """Find supported GDN layers after removing a recognized model wrapper."""
-    model = unwrap_model(model, force_unwrap=True)
-    supported_classes = _supported_gdn_classes()
-    named_modules = list(model.named_modules())
-    identity_modules = [
-        (name, module)
-        for name, module in named_modules
-        if _has_supported_gdn_identity(module, supported_classes)
-    ]
+def _reject_incomplete_gdn_modules(identity_modules: list[tuple[str, nn.Module]]) -> None:
+    """Reject supported identities that do not expose both required decay tensors."""
     missing_decay_parameters = [
         name or "<root>"
         for name, module in identity_modules
@@ -139,6 +131,13 @@ def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
             "DASC found supported GDN modules without A_log and dt_bias tensors at: "
             f"{', '.join(missing_decay_parameters)}"
         )
+
+
+def _reject_unconverted_gdn_subclasses(
+    named_modules: list[tuple[str, nn.Module]],
+    supported_classes: tuple[type[nn.Module], ...],
+) -> None:
+    """Reject ordinary subclasses that would otherwise be silently omitted from the policy."""
     unsupported_subclasses = [
         name or "<root>"
         for name, module in named_modules
@@ -152,13 +151,26 @@ def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
             f"{', '.join(unsupported_subclasses)}; convert the module with ModelOpt or use a "
             "supported class directly"
         )
-    modules = dict(identity_modules)
-    if not modules:
+
+
+def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
+    """Find supported GDN layers after removing a recognized model wrapper."""
+    model = unwrap_model(model, force_unwrap=True)
+    supported_classes = _supported_gdn_classes()
+    named_modules = list(model.named_modules())
+    identity_modules = [
+        (name, module)
+        for name, module in named_modules
+        if _has_supported_gdn_identity(module, supported_classes)
+    ]
+    _reject_incomplete_gdn_modules(identity_modules)
+    _reject_unconverted_gdn_subclasses(named_modules, supported_classes)
+    if not identity_modules:
         supported = ", ".join(
             f"{module_name}.{class_name}" for module_name, class_name in _SUPPORTED_GDN_CLASS_PATHS
         )
         raise ApplyModeError(f"DASC found no supported GDN modules; expected one of: {supported}")
-    return dict(sorted(modules.items()))
+    return dict(sorted(identity_modules))
 
 
 def _analyze_gdn_modules(

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -269,8 +269,20 @@ def test_calibration_fails_closed_on_measurements_and_model_mismatch():
     partially_valid.good = GatedDeltaNet()
     partially_valid.bad = GatedDeltaNet()
     del partially_valid.bad.dt_bias
-    with pytest.raises(ApplyModeError, match="bad"):
+    with pytest.raises(ApplyModeError, match=r"without A_log and dt_bias tensors at: bad$"):
         mtss.analyze_gdn_decay(partially_valid)
+
+    mixed_subclass = nn.Module()
+    mixed_subclass.good = GatedDeltaNet()
+    mixed_subclass.stale = UnsupportedSubclass()
+    with pytest.raises(
+        ApplyModeError,
+        match=(
+            r"not ModelOpt dynamic modules at: stale; convert the module with ModelOpt or use a "
+            r"supported class directly$"
+        ),
+    ):
+        mtss.analyze_gdn_decay(mixed_subclass)
 
     invalid_decay = TinyGatedDeltaNetForCausalLM()
     invalid_decay.linear_attn.dt_bias = nn.Parameter(torch.zeros(3))


### PR DESCRIPTION
## Summary

Follow-up to #2384 addressing its complete Claude review:

- move incomplete-layer and unconverted-subclass checks into named fail-closed helpers
- remove the redundant identity-module dict alias
- anchor malformed-layer diagnostics to the exact offending path
- add a mixed valid-plus-unconverted-subclass regression
- document that both mixed malformed cases are intentionally rejected

This PR is intentionally stacked on #2384 because repository rules protect a PR head branch after creation.

## Validation

- focused DASC suite: 23 passed, 1 absent optional Megatron skip
- DASC plus weight sparsity plus attention sparsity compatibility suite: 134 passed, 1 optional skip
- DASC package coverage: 408/408 statements, 100%
- full pre-commit on touched files: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for GDN modules during sparsity policy processing.
  - Clear errors now identify missing tensor values and unsupported subclasses that require conversion.
  - Diagnostics include affected module paths and remediation guidance.
  - Module processing order is now deterministic.

- **Tests**
  - Expanded coverage for missing tensors, unsupported subclasses, and mixed valid and stale modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->