### PR TITLE
Sort DASC modules by explicit name

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -170,7 +170,7 @@ def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
             f"{module_name}.{class_name}" for module_name, class_name in _SUPPORTED_GDN_CLASS_PATHS
         )
         raise ApplyModeError(f"DASC found no supported GDN modules; expected one of: {supported}")
-    return dict(sorted(identity_modules))
+    return dict(sorted(identity_modules, key=lambda item: item[0]))
 
 
 def _analyze_gdn_modules(


### PR DESCRIPTION
## Summary

Follow-up to #2385 addressing its sole defensive Claude suggestion:

- sort discovered GDN modules with an explicit qualified-name key
- prevent any hypothetical duplicate-name fallback from comparing nn.Module objects

This PR is intentionally stacked on #2385 because repository rules protect a PR head branch after creation.

## Validation

- focused DASC suite: 23 passed, 1 absent optional Megatron skip
- DASC plus weight sparsity plus attention sparsity compatibility suite: 134 passed, 1 optional skip
- full pre-commit on the touched file: passed
- prior full-package coverage remains 408/408 statements; this change adds no statements and the line is exercised by the focused suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GDN modules are now returned in a consistent, predictable order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->