### PR TITLE
Exclude exact casts from DASC bounds

### DIFF
--- a/docs/source/guides/6_sparsity.rst
+++ b/docs/source/guides/6_sparsity.rst
@@ -197,10 +197,9 @@ calibration. Derive the evaluated head masks and reported ``retained_heads``/``t
 :func:`~modelopt.torch.sparsity.state_sparsity.analyze_gdn_decay` using the same ``epsilon``,
 ``static_gate_input``, and storage dtype passed to calibration. Policy validation allows only the
 rounding introduced by the declared storage dtype and the live tensor dtype. When they differ,
-their inverse rounding bounds are composed in sequence; when they match, the duplicate cast is
-counted once. Decay tensors that are live in BF16 or FP16 are still validated against that live
-dtype's rounding, so the default ``float32`` storage dtype contributes only a negligible float32
-step beyond it.
+distinct lossy inverse rounding bounds are composed in sequence; a duplicate dtype or an exact
+widening cast contributes no additional slack. Decay tensors that are live in BF16 or FP16 are
+still validated against that live dtype's rounding.
 
 .. _sparsity-concepts:
 

--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -69,17 +69,6 @@ def _validate_gdn_decay_tensors(a_log: torch.Tensor, dt_bias: torch.Tensor) -> N
         raise ValueError("GDN decay parameters must be finite")
 
 
-def _validated_gdn_decay_tensors(
-    a_log: torch.Tensor, dt_bias: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Validate decay tensors and return deterministic CPU float64 values."""
-    _validate_gdn_decay_tensors(a_log, dt_bias)
-    return (
-        a_log.detach().to(device="cpu", dtype=torch.float64),
-        dt_bias.detach().to(device="cpu", dtype=torch.float64),
-    )
-
-
 @lru_cache(maxsize=1)
 def _supported_gdn_classes() -> tuple[type[nn.Module], ...]:
     """Resolve installed GDN implementations without making either framework mandatory."""
@@ -121,7 +110,9 @@ def compute_gdn_decay_horizons(
     if not 0.0 < epsilon < 1.0:
         raise ValueError("epsilon must be in (0, 1)")
 
-    a_log_cpu, dt_bias_cpu = _validated_gdn_decay_tensors(a_log, dt_bias)
+    _validate_gdn_decay_tensors(a_log, dt_bias)
+    a_log_cpu = a_log.detach().to(device="cpu", dtype=torch.float64)
+    dt_bias_cpu = dt_bias.detach().to(device="cpu", dtype=torch.float64)
 
     decay = -torch.exp(a_log_cpu) * F.softplus(dt_bias_cpu + static_gate_input)
     horizons = torch.log(torch.tensor(epsilon, dtype=torch.float64)) / decay
@@ -291,11 +282,29 @@ def _decay_parameters(
     ]
 
 
+def _dtype_exactly_contains(source: torch.dtype, target: torch.dtype) -> bool:
+    """Return whether every finite source value is exactly representable in the target dtype."""
+    source_info = torch.finfo(source)
+    target_info = torch.finfo(target)
+    return (
+        target_info.max >= source_info.max
+        and target_info.eps <= source_info.eps
+        and target_info.tiny * target_info.eps <= source_info.tiny * source_info.eps
+    )
+
+
 def _storage_rounding_radius(tensor: torch.Tensor, storage_dtype: torch.dtype) -> torch.Tensor:
     """Compose inverse error bounds for storage and live-dtype materialization casts."""
     values = tensor.detach().to(device="cpu", dtype=torch.float64).abs()
     upper = values
     cast_dtypes = tuple(dict.fromkeys((storage_dtype, tensor.dtype)))
+    cast_dtypes = tuple(
+        dtype
+        for dtype in cast_dtypes
+        if not any(
+            dtype != other and _dtype_exactly_contains(other, dtype) for other in cast_dtypes
+        )
+    )
     for dtype in reversed(cast_dtypes):
         dtype_info = torch.finfo(dtype)
         unit_roundoff = dtype_info.eps / 2.0

--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -297,14 +297,13 @@ def _storage_rounding_radius(tensor: torch.Tensor, storage_dtype: torch.dtype) -
     """Compose inverse error bounds for storage and live-dtype materialization casts."""
     values = tensor.detach().to(device="cpu", dtype=torch.float64).abs()
     upper = values
-    cast_dtypes = tuple(dict.fromkeys((storage_dtype, tensor.dtype)))
-    cast_dtypes = tuple(
-        dtype
-        for dtype in cast_dtypes
-        if not any(
-            dtype != other and _dtype_exactly_contains(other, dtype) for other in cast_dtypes
-        )
-    )
+    live_dtype = tensor.dtype
+    if _dtype_exactly_contains(live_dtype, storage_dtype):
+        cast_dtypes = (live_dtype,)
+    elif _dtype_exactly_contains(storage_dtype, live_dtype):
+        cast_dtypes = (storage_dtype,)
+    else:
+        cast_dtypes = (storage_dtype, live_dtype)
     for dtype in reversed(cast_dtypes):
         dtype_info = torch.finfo(dtype)
         unit_roundoff = dtype_info.eps / 2.0

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -498,6 +498,17 @@ def test_cross_dtype_reload_accumulates_both_rounding_bounds(
     assert mtss.export_policy(model) == policy
 
 
+@pytest.mark.parametrize("live_dtype", [torch.float16, torch.bfloat16])
+def test_storage_rounding_excludes_exact_fp32_widening(live_dtype):
+    """Do not add FP32 slack when only the low-precision cast can round values."""
+    tensor = torch.tensor([1.25], dtype=live_dtype)
+
+    assert torch.equal(
+        dasc_policy._storage_rounding_radius(tensor, torch.float32),
+        dasc_policy._storage_rounding_radius(tensor, live_dtype),
+    )
+
+
 def test_non_finite_decay_parameters_are_rejected_on_export():
     """Reject NaNs before interval comparisons can silently accept them."""
     model = mtss.calibrate(


### PR DESCRIPTION
Addresses the final numerical-bound and cleanup review findings.

Changes:
- exclude exact widening dtypes from composed inverse rounding bounds
- retain both bounds only when neither dtype exactly contains the other, such as FP16 versus BF16
- add direct FP16/BF16-with-FP32 widening regressions
- remove the ambiguous single-use validated/converting helper and cast inline after validation
- align the guide with the tightened exact-widening contract

Validation:
- focused DASC tests: 27 passed, 1 skipped (optional Megatron dependency)
- pre-commit on all touched files: passed

Commit is ED25519-signed and carries a matching Signed-off-by trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved decay-policy validation for sequential rounding operations.
  - Prevented redundant precision conversions from adding incorrect rounding allowances.
  - Preserved accurate validation for BF16 and FP16 decay tensors.

- **Tests**
  - Added coverage confirming consistent rounding-radius calculations across FP16, BF16, and FP32 comparisons.

- **Documentation**
  - Updated sparsity guidance to clarify decay-policy rounding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->