### PR TITLE
Clarify DASC rounding dtype selection

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -297,14 +297,13 @@ def _storage_rounding_radius(tensor: torch.Tensor, storage_dtype: torch.dtype) -
     """Compose inverse error bounds for storage and live-dtype materialization casts."""
     values = tensor.detach().to(device="cpu", dtype=torch.float64).abs()
     upper = values
-    cast_dtypes = tuple(dict.fromkeys((storage_dtype, tensor.dtype)))
-    cast_dtypes = tuple(
-        dtype
-        for dtype in cast_dtypes
-        if not any(
-            dtype != other and _dtype_exactly_contains(other, dtype) for other in cast_dtypes
-        )
-    )
+    live_dtype = tensor.dtype
+    if _dtype_exactly_contains(live_dtype, storage_dtype):
+        cast_dtypes = (live_dtype,)
+    elif _dtype_exactly_contains(storage_dtype, live_dtype):
+        cast_dtypes = (storage_dtype,)
+    else:
+        cast_dtypes = (storage_dtype, live_dtype)
     for dtype in reversed(cast_dtypes):
         dtype_info = torch.finfo(dtype)
         unit_roundoff = dtype_info.eps / 2.0


### PR DESCRIPTION
Addresses the final non-blocking review suggestion on #2392.

Changes:
- replace the generic containment filter with an explicit three-way dtype selection
- guarantee a non-empty bound tuple
- make the exact outcomes obvious: keep live, keep storage, or compose both

Validation:
- focused DASC tests: 27 passed, 1 skipped (optional Megatron dependency)
- pre-commit on the touched file: passed

Commit is ED25519-signed and carries a matching Signed-off-by trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved numerical handling when determining storage rounding behavior across different data types.
  - Ensured cast sequences are selected according to exact representability between live and storage formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->