### PR TITLE
Unify DASC public analysis validation

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/config.py
+++ b/modelopt/torch/sparsity/state_sparsity/config.py
@@ -16,6 +16,7 @@
 """Configuration and result schemas for DASC state sparsity."""
 
 import math
+from numbers import Real
 from typing import Literal
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
@@ -31,6 +32,37 @@ __all__ = [
 ]
 
 _DecayParameterStorageDtype = Literal["float16", "bfloat16", "float32"]
+_DEFAULT_EPSILON = 1e-3
+_DEFAULT_STATIC_GATE_INPUT = -0.3
+
+
+def _validate_analysis_arguments(
+    epsilon: object = _DEFAULT_EPSILON,
+    static_gate_input: object = _DEFAULT_STATIC_GATE_INPUT,
+) -> None:
+    """Reject decay-analysis arguments that cannot produce well-defined horizons."""
+    try:
+        epsilon_is_valid = (
+            isinstance(epsilon, Real)
+            and not isinstance(epsilon, bool)
+            and math.isfinite(epsilon)
+            and 0.0 < epsilon < 1.0
+        )
+    except OverflowError:
+        epsilon_is_valid = False
+    if not epsilon_is_valid:
+        raise ValueError("epsilon must be finite and in (0, 1)")
+
+    try:
+        static_gate_input_is_valid = (
+            isinstance(static_gate_input, Real)
+            and not isinstance(static_gate_input, bool)
+            and math.isfinite(static_gate_input)
+        )
+    except OverflowError:
+        static_gate_input_is_valid = False
+    if not static_gate_input_is_valid:
+        raise ValueError("static_gate_input must be finite")
 
 
 class DASCQualityMeasurement(ModeloptBaseConfig):
@@ -81,11 +113,11 @@ class DASCConfig(ModeloptBaseConfig):
         description="Use zero recovery (DASC-NR) or suffix replay recovery (DASC-WR).",
     )
     epsilon: float = ModeloptField(
-        default=1e-3,
+        default=_DEFAULT_EPSILON,
         description="Retained contribution threshold used to derive static decay horizons.",
     )
     static_gate_input: float = ModeloptField(
-        default=-0.3,
+        default=_DEFAULT_STATIC_GATE_INPUT,
         description="Static gate input added to each GDN head's dt_bias.",
     )
     decay_parameter_storage_dtype: _DecayParameterStorageDtype = ModeloptField(
@@ -118,16 +150,14 @@ class DASCConfig(ModeloptBaseConfig):
     @classmethod
     def validate_epsilon(cls, epsilon: float) -> float:
         """Require a finite decay threshold strictly between zero and one."""
-        if not math.isfinite(epsilon) or not 0.0 < epsilon < 1.0:
-            raise ValueError("epsilon must be finite and in (0, 1)")
+        _validate_analysis_arguments(epsilon=epsilon)
         return epsilon
 
     @field_validator("static_gate_input")
     @classmethod
     def validate_static_gate_input(cls, value: float) -> float:
         """Require a finite representative gate input."""
-        if not math.isfinite(value):
-            raise ValueError("static_gate_input must be finite")
+        _validate_analysis_arguments(static_gate_input=value)
         return value
 
     @field_validator("wmax_candidates", mode="before")

--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -65,6 +65,14 @@ class _DASCDecayParametersUnavailableError(_DASCRecoverableStalenessError):
     """Identify supported GDN modules whose decay tensors are temporarily unavailable."""
 
 
+def _validate_analysis_arguments(epsilon: float, static_gate_input: float) -> None:
+    """Normalize invalid public analysis arguments to the ValueError contract."""
+    if not isinstance(epsilon, float | int) or not (math.isfinite(epsilon) and 0.0 < epsilon < 1.0):
+        raise ValueError("epsilon must be finite and in (0, 1)")
+    if not isinstance(static_gate_input, float | int) or not math.isfinite(static_gate_input):
+        raise ValueError("static_gate_input must be finite")
+
+
 def _validate_gdn_decay_tensors(a_log: torch.Tensor, dt_bias: torch.Tensor) -> None:
     """Reject decay tensors that cannot produce well-defined horizons."""
     if a_log.ndim != 1 or dt_bias.ndim != 1 or a_log.shape != dt_bias.shape or not a_log.numel():
@@ -115,9 +123,7 @@ def compute_gdn_decay_horizons(
     static_gate_input: float = -0.3,
 ) -> torch.Tensor:
     """Compute one static retention horizon per GDN head in CPU float64."""
-    if not 0.0 < epsilon < 1.0:
-        raise ValueError("epsilon must be in (0, 1)")
-
+    _validate_analysis_arguments(epsilon, static_gate_input)
     _validate_gdn_decay_tensors(a_log, dt_bias)
     a_log_cpu = a_log.detach().to(device="cpu", dtype=torch.float64)
     dt_bias_cpu = dt_bias.detach().to(device="cpu", dtype=torch.float64)
@@ -210,9 +216,8 @@ def _analyze_gdn_modules(
         a_log = module.A_log
         dt_bias = module.dt_bias
         try:
-            # Check the original tensors before a storage cast can hide an invalid integer dtype.
-            _validate_gdn_decay_tensors(a_log, dt_bias)
             if storage_dtype is not None:
+                _validate_gdn_decay_tensors(a_log, dt_bias)
                 a_log = a_log.detach().to(device="cpu", dtype=storage_dtype)
                 dt_bias = dt_bias.detach().to(device="cpu", dtype=storage_dtype)
             layer_horizons = compute_gdn_decay_horizons(
@@ -237,18 +242,7 @@ def analyze_gdn_decay(
     decay_parameter_storage_dtype: _DecayParameterStorageDtype | None = None,
 ) -> dict[str, list[float]]:
     """Return per-head horizons, optionally canonicalized to a checkpoint storage dtype."""
-    try:
-        epsilon_is_valid = math.isfinite(epsilon) and 0.0 < epsilon < 1.0
-    except TypeError:
-        epsilon_is_valid = False
-    if not epsilon_is_valid:
-        raise ValueError("epsilon must be finite and in (0, 1)")
-    try:
-        static_gate_input_is_valid = math.isfinite(static_gate_input)
-    except TypeError:
-        static_gate_input_is_valid = False
-    if not static_gate_input_is_valid:
-        raise ValueError("static_gate_input must be finite")
+    _validate_analysis_arguments(epsilon, static_gate_input)
     storage_dtype = None
     if decay_parameter_storage_dtype is not None:
         if (

--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -38,6 +38,7 @@ from .config import (
     DASCLayerPolicy,
     DASCPolicy,
     _DecayParameterStorageDtype,
+    _validate_analysis_arguments,
 )
 
 __all__ = ["analyze_gdn_decay", "compute_gdn_decay_horizons"]
@@ -63,14 +64,6 @@ class _DASCModelStructureMismatchError(_DASCRecoverableStalenessError):
 
 class _DASCDecayParametersUnavailableError(_DASCRecoverableStalenessError):
     """Identify supported GDN modules whose decay tensors are temporarily unavailable."""
-
-
-def _validate_analysis_arguments(epsilon: float, static_gate_input: float) -> None:
-    """Normalize invalid public analysis arguments to the ValueError contract."""
-    if not isinstance(epsilon, float | int) or not (math.isfinite(epsilon) and 0.0 < epsilon < 1.0):
-        raise ValueError("epsilon must be finite and in (0, 1)")
-    if not isinstance(static_gate_input, float | int) or not math.isfinite(static_gate_input):
-        raise ValueError("static_gate_input must be finite")
 
 
 def _validate_gdn_decay_tensors(a_log: torch.Tensor, dt_bias: torch.Tensor) -> None:
@@ -129,7 +122,7 @@ def compute_gdn_decay_horizons(
     dt_bias_cpu = dt_bias.detach().to(device="cpu", dtype=torch.float64)
 
     decay = -torch.exp(a_log_cpu) * F.softplus(dt_bias_cpu + static_gate_input)
-    horizons = torch.log(torch.tensor(epsilon, dtype=torch.float64)) / decay
+    horizons = math.log(epsilon) / decay
     if not torch.isfinite(horizons).all() or not torch.all(horizons > 0):
         raise ValueError("GDN decay parameters produced non-finite or non-positive horizons")
     return horizons
@@ -527,7 +520,7 @@ def validate_dasc_decay_parameters(model: nn.Module, policy: DASCPolicy) -> None
                     "DASC policy head mask does not match current decay parameters in layer "
                     f"{name!r}"
                 )
-        stored = torch.tensor(layer.static_horizons, dtype=torch.float64)
+        stored = torch.tensor(layer.static_horizons, device="cpu", dtype=torch.float64)
         numerical_slack = 32.0 * torch.finfo(torch.float64).eps
         if torch.any(stored < lower * (1.0 - numerical_slack)) or torch.any(
             stored > upper * (1.0 + numerical_slack)

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -454,14 +454,16 @@ def test_analysis_arguments_fail_at_the_public_boundary(invalid_storage_dtype):
         )
 
 
-@pytest.mark.parametrize("epsilon", [1.0, []])
+@pytest.mark.parametrize("epsilon", [1.0, True, [], 10**1000, torch.tensor([1e-3, 2e-3])])
 def test_analysis_rejects_invalid_epsilon_at_the_public_boundary(epsilon):
     """Normalize invalid epsilon values to the public ValueError contract."""
     with pytest.raises(ValueError, match=r"epsilon must be finite and in \(0, 1\)"):
         mtss.analyze_gdn_decay(TinyGatedDeltaNetForCausalLM(), epsilon=epsilon)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("static_gate_input", [torch.nan, []])
+@pytest.mark.parametrize(
+    "static_gate_input", [torch.nan, True, [], 10**1000, torch.tensor([-0.3, -0.2])]
+)
 def test_analysis_rejects_invalid_static_gate_input_at_the_public_boundary(static_gate_input):
     """Normalize invalid static gate values to the public ValueError contract."""
     with pytest.raises(ValueError, match="static_gate_input must be finite"):
@@ -475,7 +477,15 @@ def test_analysis_rejects_invalid_static_gate_input_at_the_public_boundary(stati
     ("argument", "value", "message"),
     [
         ("epsilon", [], r"epsilon must be finite and in \(0, 1\)"),
+        ("epsilon", True, r"epsilon must be finite and in \(0, 1\)"),
+        ("epsilon", torch.nan, r"epsilon must be finite and in \(0, 1\)"),
+        ("epsilon", 10**1000, r"epsilon must be finite and in \(0, 1\)"),
+        ("epsilon", torch.tensor([1e-3, 2e-3]), r"epsilon must be finite and in \(0, 1\)"),
         ("static_gate_input", [], "static_gate_input must be finite"),
+        ("static_gate_input", True, "static_gate_input must be finite"),
+        ("static_gate_input", torch.nan, "static_gate_input must be finite"),
+        ("static_gate_input", 10**1000, "static_gate_input must be finite"),
+        ("static_gate_input", torch.tensor([-0.3, -0.2]), "static_gate_input must be finite"),
     ],
 )
 def test_horizon_computation_rejects_invalid_public_arguments(argument, value, message):
@@ -487,6 +497,26 @@ def test_horizon_computation_rejects_invalid_public_arguments(argument, value, m
             torch.tensor([0.0]),
             **kwargs,  # type: ignore[arg-type]
         )
+
+
+def test_horizon_computation_ignores_the_default_device():
+    """Keep CPU horizon analysis independent of PyTorch's ambient allocation device."""
+    a_log = torch.tensor([0.0])
+    dt_bias = torch.tensor([0.0])
+    with torch.device("meta"):
+        horizons = mtss.compute_gdn_decay_horizons(a_log, dt_bias)
+    assert horizons.device.type == "cpu"
+
+
+def test_policy_lifecycle_ignores_the_default_device():
+    """Keep calibration and checkpoint metadata validation on their declared CPU path."""
+    model = TinyGatedDeltaNetForCausalLM()
+    with torch.device("meta"):
+        calibrated = mtss.calibrate(model, _config(wmax_candidates=[7]), [_candidate(7)])
+        state = mto.modelopt_state(calibrated)
+        policy = mtss.export_policy(calibrated)
+    assert state["modelopt_state_dict"][0][0] == "dasc"
+    assert policy["layers"]["linear_attn"]["static_horizons"]
 
 
 def test_bf16_storage_round_trip_loaded_in_fp32_preserves_policy():

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -471,6 +471,24 @@ def test_analysis_rejects_invalid_static_gate_input_at_the_public_boundary(stati
         )
 
 
+@pytest.mark.parametrize(
+    ("argument", "value", "message"),
+    [
+        ("epsilon", [], r"epsilon must be finite and in \(0, 1\)"),
+        ("static_gate_input", [], "static_gate_input must be finite"),
+    ],
+)
+def test_horizon_computation_rejects_invalid_public_arguments(argument, value, message):
+    """Use the same public argument contract for direct horizon computation."""
+    kwargs = {argument: value}
+    with pytest.raises(ValueError, match=message):
+        mtss.compute_gdn_decay_horizons(
+            torch.tensor([0.0]),
+            torch.tensor([0.0]),
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+
 def test_bf16_storage_round_trip_loaded_in_fp32_preserves_policy():
     """Accept BF16-rounded values after a checkpoint loader materializes FP32 tensors."""
     model = mtss.calibrate(


### PR DESCRIPTION
## Summary

Addresses the two follow-up findings on #2394:

- use one argument validator for both exported analysis entry points
- normalize invalid epsilon and static gate inputs to ValueError before tensor/model work
- remove the redundant validation hoist and retain the existing pre-cast check only where a storage cast occurs
- add direct public-API regressions for `compute_gdn_decay_horizons`

## Validation

- `python -m pytest -q tests/unit/torch/sparsity/state_sparsity/test_dasc.py` (36 passed, 1 optional Megatron skip)
- pre-commit hooks on both changed files
- signed commit with DCO sign-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for sparsity analysis inputs, including finite numeric values and supported epsilon ranges.
  - Ensured invalid decay-tensor values are detected consistently across analysis workflows.
  - Standardized error handling for direct decay-horizon calculations.

- **Tests**
  - Added coverage for invalid epsilon and static gate input values, including verification of consistent error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->