### PR TITLE
Pin DASC policy validation to CPU

### DIFF
--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -520,7 +520,7 @@ def validate_dasc_decay_parameters(model: nn.Module, policy: DASCPolicy) -> None
                     "DASC policy head mask does not match current decay parameters in layer "
                     f"{name!r}"
                 )
-        stored = torch.tensor(layer.static_horizons, dtype=torch.float64)
+        stored = torch.tensor(layer.static_horizons, device="cpu", dtype=torch.float64)
         numerical_slack = 32.0 * torch.finfo(torch.float64).eps
         if torch.any(stored < lower * (1.0 - numerical_slack)) or torch.any(
             stored > upper * (1.0 + numerical_slack)

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -514,7 +514,9 @@ def test_policy_lifecycle_ignores_the_default_device():
     with torch.device("meta"):
         calibrated = mtss.calibrate(model, _config(wmax_candidates=[7]), [_candidate(7)])
         state = mto.modelopt_state(calibrated)
+        policy = mtss.export_policy(calibrated)
     assert state["modelopt_state_dict"][0][0] == "dasc"
+    assert policy["layers"]["linear_attn"]["static_horizons"]
 
 
 def test_bf16_storage_round_trip_loaded_in_fp32_preserves_policy():

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -508,6 +508,15 @@ def test_horizon_computation_ignores_the_default_device():
     assert horizons.device.type == "cpu"
 
 
+def test_policy_lifecycle_ignores_the_default_device():
+    """Keep calibration and checkpoint metadata validation on their declared CPU path."""
+    model = TinyGatedDeltaNetForCausalLM()
+    with torch.device("meta"):
+        calibrated = mtss.calibrate(model, _config(wmax_candidates=[7]), [_candidate(7)])
+        state = mto.modelopt_state(calibrated)
+    assert state["modelopt_state_dict"][0][0] == "dasc"
+
+
 def test_bf16_storage_round_trip_loaded_in_fp32_preserves_policy():
     """Accept BF16-rounded values after a checkpoint loader materializes FP32 tensors."""
     model = mtss.calibrate(


### PR DESCRIPTION
## Summary

Closes the remaining full-package device-independence finding on #2398:

- explicitly allocate stored policy horizons on CPU before comparing with CPU bounds
- exercise calibration and `modelopt_state()` under a non-CPU ambient default-device context
- retain the existing low-level horizon default-device regression

A full factory-call scan confirms this was the only remaining ambient-device tensor allocation in `state_sparsity`.

## Validation

- focused DASC suite: 52 passed, 1 optional Megatron skip
- pre-commit hooks on both changed files
- signed commit with DCO sign-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DASC calibration and checkpoint metadata generation when PyTorch’s default device is set to `meta`.
  * Ensured decay-parameter validation remains CPU-backed for reliable processing.

* **Tests**
  * Added regression coverage for CPU-backed DASC calibration and checkpoint metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->