### PR TITLE
Strengthen DASC device lifecycle regression

### DIFF
--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -514,7 +514,9 @@ def test_policy_lifecycle_ignores_the_default_device():
     with torch.device("meta"):
         calibrated = mtss.calibrate(model, _config(wmax_candidates=[7]), [_candidate(7)])
         state = mto.modelopt_state(calibrated)
+        policy = mtss.export_policy(calibrated)
     assert state["modelopt_state_dict"][0][0] == "dasc"
+    assert policy["layers"]["linear_attn"]["static_horizons"]
 
 
 def test_bf16_storage_round_trip_loaded_in_fp32_preserves_policy():


### PR DESCRIPTION
## Summary

Addresses the sole non-blocking suggestion on approved PR #2399:

- call `export_policy()` under the non-CPU ambient default-device context
- assert validated static horizons are present
- make the regression fail even if a future checkpoint-save path downgrades validation failures to warnings

## Validation

- targeted lifecycle regression passed
- pre-commit hooks passed
- signed commit with DCO sign-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended device lifecycle coverage to verify policy export while operating on the `meta` device.
  * Added validation that static horizon metadata is included in exported policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->