### PR TITLE
Fix protobuf size-check failures in ONNX deployment

### DIFF
--- a/modelopt/torch/_deploy/utils/onnx_optimizer.py
+++ b/modelopt/torch/_deploy/utils/onnx_optimizer.py
@@ -21,6 +21,8 @@ import tempfile
 import onnx
 import onnx_graphsurgeon as gs
 
+from modelopt.onnx.utils import is_model_too_large_for_protobuf
+
 
 class Optimizer:
     """Optimizer for onnx graphs."""
@@ -62,7 +64,7 @@ class Optimizer:
     def infer_shapes(self, return_onnx=False):
         """Infers shapes of the onnx graph."""
         onnx_graph = gs.export_onnx(self.graph)
-        if onnx_graph.ByteSize() > (2 * (1024**3)):  # 2GB limit
+        if is_model_too_large_for_protobuf(onnx_graph):  # 2GB limit
             temp_dir = tempfile.TemporaryDirectory().name
             os.makedirs(temp_dir, exist_ok=True)
             onnx_orig_path = os.path.join(temp_dir, "model.onnx")

--- a/modelopt/torch/_deploy/utils/torch_onnx.py
+++ b/modelopt/torch/_deploy/utils/torch_onnx.py
@@ -56,6 +56,7 @@ from modelopt.onnx.utils import (
     get_output_names,
     get_output_shapes,
     infer_shapes,
+    is_model_too_large_for_protobuf,
     remove_node_training_mode,
     remove_redundant_casts,
 )
@@ -96,7 +97,6 @@ ValueInfoType = Any
 # a few constants...
 DEFAULT_ONNX_OPSET = 20
 ONNX_EXPORT_OUT_PREFIX = "out"
-TWO_GB = 2 * 1024 * 1024 * 1024
 
 
 class OnnxBytes:
@@ -765,6 +765,6 @@ def create_model_metadata(
         "output_onnx_names": get_output_names(onnx_graph),
         "signature": inspect.signature(model.forward),
         "onnx_node_names": get_node_names(onnx_graph),
-        "is_bytes_pickled": onnx_graph.ByteSize() > TWO_GB,
+        "is_bytes_pickled": is_model_too_large_for_protobuf(onnx_graph),
         "config": model.config if hasattr(model, "config") else None,
     }


### PR DESCRIPTION
### What does this PR do?

Type of change:  Bug fix：6701737

The ONNX deployment path assumed that ModelProto.ByteSize() would always return a valid size. With newer protobuf versions, querying the size of a model exceeding the protobuf serialization limit can itself raise EncodeError: Failed to serialize proto.

Replaced both direct size checks with the existing is_model_too_large_for_protobuf() helper. This helper handles size-query failures conservatively and checks the protobuf size limit:

Shape inference now selects the external-data/file-based path when ByteSize() fails or the model is too large.
Metadata creation uses the same safe check instead of raising another serialization error.
The unused TWO_GB constant was also removed.

### Usage

```
python examples/diffusers/quantization/diffusion_trt.py --model flux-dev --benchmark --skip-image
```

### Testing
the above test case pass on B100

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?:  N/A 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A 
- Did you write any new necessary tests?: N/A 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?:  N/A 
- Did you get Claude approval on this PR?: N/A 

### Additional Information
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ONNX model size detection during shape inference and export processing.
  * Ensured large models consistently use the appropriate external-data handling path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->