### PR TITLE
Add bounded FP8 scale search for NVFP4 calibration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 
 *Quantization*
 
+- Add bounded FP8 scale search for NVFP4 MSE and local-Hessian calibration. Set ``fp8_scale_sweep`` to an inclusive E4M3 code-offset range such as ``[-8, 8]``; ``False`` retains multiplier search and ``True`` retains exhaustive search.
 - Add ``layerwise.export_dir``: layerwise calibration writes each decoder layer to its own quantized checkpoint shard as it finishes, so no separate ``export_hf_checkpoint()`` pass is needed and, with ``layerwise.checkpoint_dir``, an interrupted run resumes without redoing finished layers. Calibration writes the layer shards; ``finalize()`` on the exporter left on the model adds the tail shard, the index and the config artifacts, and the checkpoint does not load until it runs. ``examples/hf_ptq`` does this for you. Supports FP8 and NVFP4 on single-process models, resident or offloaded, including multimodal models and models with MTP layers; other formats and placements raise ``NotImplementedError`` before calibration starts.
 
 *Misc*

--- a/modelopt/torch/kernels/quantization/gemm/_fp8_scale_candidates.py
+++ b/modelopt/torch/kernels/quantization/gemm/_fp8_scale_candidates.py
@@ -22,10 +22,48 @@ wrapper (which is triton-gated) and the reference Python sweep in the
 
 import torch
 
+_E4M3_MIN_POSITIVE_CODE = 1
+_E4M3_MAX_FINITE_CODE = 126
 
-def fp8_scale_candidates(device: torch.device | str = "cpu") -> torch.Tensor:
-    """Return the 126 valid finite positive FP8 E4M3 scale candidates / 448."""
+
+def fp8_scale_candidates(
+    device: torch.device | str = "cpu", fp8_max_for_normalization: float = 448.0
+) -> torch.Tensor:
+    """Return finite positive E4M3 values divided by the configured normalization max."""
     uint8_values = torch.arange(0, 128, dtype=torch.uint8, device=device)
     fp8_values = uint8_values.view(torch.float8_e4m3fn).float()
     valid_mask = torch.isfinite(fp8_values) & (fp8_values > 0)
-    return fp8_values[valid_mask] / 448.0
+    return fp8_values[valid_mask] / fp8_max_for_normalization
+
+
+def fp8_scale_codes(
+    amax: torch.Tensor,
+    global_amax: torch.Tensor,
+    fp8_max_for_normalization: float = 448.0,
+) -> torch.Tensor:
+    """Return each block's max-derived finite positive E4M3 scale code."""
+    global_amax = global_amax.detach().to(device=amax.device, dtype=torch.float32)
+    safe_global_amax = torch.where(global_amax > 0, global_amax, torch.ones_like(global_amax))
+    normalized_scale = (
+        amax.detach().to(dtype=torch.float32) * fp8_max_for_normalization / safe_global_amax
+    )
+    codes = normalized_scale.to(torch.float8_e4m3fn).view(torch.uint8).to(torch.int16)
+    return codes.clamp(_E4M3_MIN_POSITIVE_CODE, _E4M3_MAX_FINITE_CODE).to(torch.uint8)
+
+
+def fp8_scale_offset_candidates(
+    amax: torch.Tensor,
+    global_amax: torch.Tensor,
+    offset_range: tuple[int, int],
+    fp8_max_for_normalization: float = 448.0,
+) -> torch.Tensor:
+    """Return normalized per-block candidates for an inclusive E4M3 code-offset range."""
+    min_offset, max_offset = offset_range
+    base_codes = fp8_scale_codes(amax, global_amax, fp8_max_for_normalization).to(torch.int16)
+    offsets = torch.arange(
+        min_offset, max_offset + 1, device=amax.device, dtype=torch.int16
+    ).reshape((-1,) + (1,) * amax.ndim)
+    codes = (base_codes.unsqueeze(0) + offsets).clamp(
+        _E4M3_MIN_POSITIVE_CODE, _E4M3_MAX_FINITE_CODE
+    )
+    return fp8_scale_candidates(amax.device, fp8_max_for_normalization)[codes.to(torch.long) - 1]

--- a/modelopt/torch/kernels/quantization/gemm/nvfp4_fp8_sweep.py
+++ b/modelopt/torch/kernels/quantization/gemm/nvfp4_fp8_sweep.py
@@ -15,13 +15,14 @@
 
 """Fused Triton kernel for the NVFP4 weight-MSE FP8 scale sweep.
 
-Replaces the 126-iteration Python sweep in :class:`NVFP4MSECalibrator` with a single
-kernel that, for each NVFP4 block, evaluates all 126 valid FP8 E4M3 scale candidates
-and emits the per-block ``best_amax`` directly.
+Replaces the Python sweep in :class:`NVFP4MSECalibrator` with a single kernel that,
+for each NVFP4 block, evaluates either all 126 valid FP8 E4M3 scale candidates or a
+bounded range of code offsets and emits the per-block ``best_amax`` directly.
 
-The 126 candidates are constructed as ``valid_fp8_e4m3_value / 448`` (see
-:func:`fp8_scale_candidates`). For these specific candidates, the FP8 round-trip on
-the per-block scale is the identity, so the kernel can use
+Exhaustive candidates retain ``valid_fp8_e4m3_value / 448``; bounded candidates use
+``valid_fp8_e4m3_value / normalization_max`` (see :func:`fp8_scale_candidates`),
+where the normalization max is 448 normally and 256 in 4/6 mode. Their FP8 round-trip
+is the identity, so the kernel can use
 ``scale = candidate * global_amax / 6.0`` without an explicit FP8 cast — making it
 runnable on any CUDA GPU with Triton (no ``tl.float8e4nv`` requirement).
 
@@ -33,7 +34,7 @@ import triton
 import triton.language as tl
 
 from ..common.nvfp4_quant import fp4_round_magnitude
-from ._fp8_scale_candidates import fp8_scale_candidates
+from ._fp8_scale_candidates import fp8_scale_candidates, fp8_scale_codes
 from .fp4_kernel import compute_fp4_scales
 
 __all__ = [
@@ -59,11 +60,14 @@ _FP8_SWEEP_AUTOTUNE_CONFIGS = [
 def _fp8_scale_sweep_kernel(
     x_ptr,  # [N_BLOCKS * BLOCK_SIZE], any float dtype (loaded as fp32)
     candidates_ptr,  # [NUM_CANDIDATES] fp32
+    base_codes_ptr,  # [N_BLOCKS] uint8; used only for bounded search
     global_amax_ptr,  # scalar fp32
     best_amax_ptr,  # [N_BLOCKS] fp32 output
     N_BLOCKS,
     BLOCK_SIZE: tl.constexpr,
     NUM_CANDIDATES: tl.constexpr,
+    MIN_OFFSET: tl.constexpr,
+    BOUNDED: tl.constexpr,
     BLOCKS_PER_PROGRAM: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
@@ -84,13 +88,19 @@ def _fp8_scale_sweep_kernel(
     best_loss = tl.full([BLOCKS_PER_PROGRAM], float("inf"), dtype=tl.float32)
     best_idx = tl.zeros([BLOCKS_PER_PROGRAM], dtype=tl.int32)
 
-    # Loop over the 126 FP8 candidates (compile-time unrolled).
+    # Loop over the exhaustive or bounded FP8 candidates (compile-time unrolled).
     # Scales are guaranteed positive and finite (constructed from a positive candidate
     # times nonneg global_amax), so the degenerate-scale guard from nvfp4_scalar_quant is
     # unnecessary apart from the global_amax == 0 case handled below.
     for k in tl.static_range(NUM_CANDIDATES):
-        c = tl.load(candidates_ptr + k).to(tl.float32)
-        scale = c * global_amax / 6.0
+        if BOUNDED:
+            code = tl.load(base_codes_ptr + block_idx, mask=block_mask, other=1).to(tl.int32)
+            code = tl.maximum(1, tl.minimum(126, code + MIN_OFFSET + k))
+            c = tl.load(candidates_ptr + code - 1).to(tl.float32)
+            scale = (c * global_amax / 6.0)[:, None]
+        else:
+            c = tl.load(candidates_ptr + k).to(tl.float32)
+            scale = c * global_amax / 6.0
         # Avoid divide-by-zero when global_amax == 0; in that case w_abs is also zero
         # (global_amax = max|w|), so the loss is zero for every candidate either way.
         scale_safe = tl.where(scale == 0.0, 1.0, scale)
@@ -102,7 +112,12 @@ def _fp8_scale_sweep_kernel(
         best_idx = tl.where(is_better, k, best_idx)
 
     # Map each block's winning candidate index back to its amax = global_amax * c[best].
-    best_c = tl.load(candidates_ptr + best_idx, mask=block_mask, other=0.0).to(tl.float32)
+    if BOUNDED:
+        code = tl.load(base_codes_ptr + block_idx, mask=block_mask, other=1).to(tl.int32)
+        code = tl.maximum(1, tl.minimum(126, code + MIN_OFFSET + best_idx))
+        best_c = tl.load(candidates_ptr + code - 1, mask=block_mask, other=0.0).to(tl.float32)
+    else:
+        best_c = tl.load(candidates_ptr + best_idx, mask=block_mask, other=0.0).to(tl.float32)
     best_amax = global_amax * best_c
     tl.store(best_amax_ptr + block_idx, best_amax, mask=block_mask)
 
@@ -128,11 +143,14 @@ def nvfp4_fp8_scale_sweep(
     x: torch.Tensor,
     global_amax: torch.Tensor,
     block_size: int = 16,
+    offset_range: tuple[int, int] | None = None,
+    initial_amax: torch.Tensor | None = None,
+    fp8_max_for_normalization: float = 448.0,
 ) -> torch.Tensor:
     """Find the per-block FP8 scale that minimizes NVFP4 quantization MSE.
 
-    Equivalent to the 126-step sweep in :class:`NVFP4MSECalibrator`, but fused into
-    a single Triton kernel: every block's weight elements are loaded once, all 126
+    Equivalent to :class:`NVFP4MSECalibrator`'s exhaustive or bounded sweep, but fused
+    into a single Triton kernel: every block's weight elements are loaded once, all
     candidates are evaluated in registers, and the running argmin is kept inline.
 
     Args:
@@ -140,24 +158,49 @@ def nvfp4_fp8_scale_sweep(
             ``block_size``; layout is treated as a flat ``[N_BLOCKS, BLOCK_SIZE]``.
         global_amax: Scalar FP32 global amax (``= reduce_amax(per_block_amax)``).
         block_size: NVFP4 block size (typically 16).
+        offset_range: Inclusive E4M3 code-offset range, or None for exhaustive search.
+        initial_amax: Max-calibrated per-block amax used to derive the starting codes.
+            Computed from ``x`` when omitted in bounded mode.
+        fp8_max_for_normalization: FP8 normalization max (448, or 256 for 4/6 mode).
 
     Returns:
         ``best_amax`` of shape ``[N_BLOCKS]``, fp32, on the same device as ``x``.
     """
     n_blocks, x_flat, best_amax = _prepare_block_sweep(x, block_size)
-    candidates = fp8_scale_candidates(x.device).to(dtype=torch.float32)
+    candidates = fp8_scale_candidates(
+        x.device, fp8_max_for_normalization if offset_range is not None else 448.0
+    ).to(dtype=torch.float32)
     global_amax_f32 = global_amax.detach().to(device=x.device, dtype=torch.float32).reshape(1)
+    if offset_range is None:
+        base_codes = torch.empty(1, dtype=torch.uint8, device=x.device)
+        min_offset = 0
+        num_candidates = int(candidates.numel())
+    else:
+        if initial_amax is None:
+            initial_amax = x_flat.view(n_blocks, block_size).float().abs().amax(dim=-1)
+        if initial_amax.numel() != n_blocks:
+            raise ValueError(
+                f"initial_amax.numel() ({initial_amax.numel()}) must equal n_blocks ({n_blocks})."
+            )
+        base_codes = fp8_scale_codes(
+            initial_amax.reshape(-1), global_amax_f32, fp8_max_for_normalization
+        )
+        min_offset, max_offset = offset_range
+        num_candidates = max_offset - min_offset + 1
 
     grid = lambda meta: (triton.cdiv(n_blocks, meta["BLOCKS_PER_PROGRAM"]),)
     with torch.cuda.device(x.device):
         _fp8_scale_sweep_kernel[grid](
             x_flat,
             candidates,
+            base_codes,
             global_amax_f32,
             best_amax,
             n_blocks,
             BLOCK_SIZE=block_size,
-            NUM_CANDIDATES=int(candidates.numel()),
+            NUM_CANDIDATES=num_candidates,
+            MIN_OFFSET=min_offset,
+            BOUNDED=offset_range is not None,
         )
     return best_amax
 
@@ -176,11 +219,16 @@ def _fp8_scale_sweep_hessian_kernel(
     hessian_ptr,  # [N_CIN_BLOCKS * BLOCK_SIZE * BLOCK_SIZE] fp32
     candidate_scales_ptr,  # [NUM_CANDIDATES] fp32: per-candidate FP8-quantized block scale
     candidate_amaxes_ptr,  # [NUM_CANDIDATES] fp32: per-candidate block amax (kernel output value)
+    candidates_ptr,  # [126] normalized finite positive E4M3 values; bounded search only
+    base_codes_ptr,  # [COUT * N_CIN_BLOCKS] uint8; bounded search only
+    global_amax_ptr,  # scalar fp32; bounded search only
     best_amax_ptr,  # [COUT * N_CIN_BLOCKS] fp32 output
     COUT,
     N_CIN_BLOCKS,
     BLOCK_SIZE: tl.constexpr,
     NUM_CANDIDATES: tl.constexpr,
+    MIN_OFFSET: tl.constexpr,
+    BOUNDED: tl.constexpr,
     ROWS_PER_PROGRAM: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
@@ -208,10 +256,17 @@ def _fp8_scale_sweep_hessian_kernel(
 
     best_loss = tl.full([ROWS_PER_PROGRAM], float("inf"), dtype=tl.float32)
     best_idx = tl.zeros([ROWS_PER_PROGRAM], dtype=tl.int32)
+    global_amax = tl.load(global_amax_ptr).to(tl.float32)
 
     # Non-unrolled loop: unrolling 126 tl.dot bodies explodes compile time for no runtime gain.
     for k in tl.range(NUM_CANDIDATES):
-        scale = tl.load(candidate_scales_ptr + k).to(tl.float32)
+        if BOUNDED:
+            code = tl.load(base_codes_ptr + block_idx, mask=row_mask, other=1).to(tl.int32)
+            code = tl.maximum(1, tl.minimum(126, code + MIN_OFFSET + k))
+            candidate = tl.load(candidates_ptr + code - 1).to(tl.float32)
+            scale = (candidate * global_amax / 6.0)[:, None]
+        else:
+            scale = tl.load(candidate_scales_ptr + k).to(tl.float32)
         scale_safe = tl.where(scale == 0.0, 1.0, scale)  # scale == 0 only if global_amax == 0
         q_mag = fp4_round_magnitude(w_abs / scale_safe)
         dw = w_sign * (w_abs - q_mag * scale_safe)  # = w - quant(w), [ROWS, BS]
@@ -222,7 +277,17 @@ def _fp8_scale_sweep_hessian_kernel(
         best_loss = tl.where(is_better, loss, best_loss)
         best_idx = tl.where(is_better, k, best_idx)
 
-    best_amax = tl.load(candidate_amaxes_ptr + best_idx, mask=row_mask, other=0.0).to(tl.float32)
+    if BOUNDED:
+        code = tl.load(base_codes_ptr + block_idx, mask=row_mask, other=1).to(tl.int32)
+        code = tl.maximum(1, tl.minimum(126, code + MIN_OFFSET + best_idx))
+        best_amax = (
+            tl.load(candidates_ptr + code - 1, mask=row_mask, other=0.0).to(tl.float32)
+            * global_amax
+        )
+    else:
+        best_amax = tl.load(candidate_amaxes_ptr + best_idx, mask=row_mask, other=0.0).to(
+            tl.float32
+        )
     tl.store(best_amax_ptr + block_idx, best_amax, mask=row_mask)
 
 
@@ -231,13 +296,16 @@ def nvfp4_fp8_scale_sweep_hessian(
     global_amax: torch.Tensor,
     hessian: torch.Tensor,
     block_size: int = 16,
+    offset_range: tuple[int, int] | None = None,
+    initial_amax: torch.Tensor | None = None,
+    fp8_max_for_normalization: float = 448.0,
 ) -> torch.Tensor:
     """Find the per-block FP8 scale minimizing the Hessian-weighted NVFP4 quant error.
 
     Hessian-weighted counterpart of :func:`nvfp4_fp8_scale_sweep`: for each NVFP4 block
-    it minimizes ``dwᵀ H dw`` (``dw = w - quant(w)``) over the 126 FP8 E4M3 candidates,
-    where ``H`` is the per-cin-block local Hessian shared across all output rows. Used by
-    :class:`NVFP4MSECalibrator` for ``local_hessian`` calibration.
+    it minimizes ``dwᵀ H dw`` (``dw = w - quant(w)``) over the exhaustive or bounded
+    FP8 E4M3 candidates, where ``H`` is the per-cin-block local Hessian shared across all
+    output rows. Used by :class:`NVFP4MSECalibrator` for ``local_hessian`` calibration.
 
     Args:
         x: Weight tensor on CUDA in the blocked ``[N_BLOCKS, block_size]`` layout, row-major
@@ -247,6 +315,10 @@ def nvfp4_fp8_scale_sweep_hessian(
         hessian: Per-cin-block Hessian of shape ``[cin // block_size, block_size, block_size]``,
             fp32 (typically normalized by sample count).
         block_size: NVFP4 block size (typically 16).
+        offset_range: Inclusive E4M3 code-offset range, or None for exhaustive search.
+        initial_amax: Max-calibrated per-block amax used to derive the starting codes.
+            Computed from ``x`` when omitted in bounded mode.
+        fp8_max_for_normalization: FP8 normalization max (448, or 256 for 4/6 mode).
 
     Returns:
         ``best_amax`` of shape ``[N_BLOCKS]``, fp32, on the same device as ``x``.
@@ -273,17 +345,41 @@ def nvfp4_fp8_scale_sweep_hessian(
         candidate_scales = compute_fp4_scales(
             candidate_amaxes, global_amax_f32, quantize_block_scales=True
         ).to(dtype=torch.float32)
+        if offset_range is None:
+            base_codes = torch.empty(1, dtype=torch.uint8, device=x.device)
+            min_offset = 0
+            num_candidates = int(candidate_amaxes.numel())
+        else:
+            if initial_amax is None:
+                initial_amax = x_flat.view(n_blocks, block_size).float().abs().amax(dim=-1)
+            if initial_amax.numel() != n_blocks:
+                raise ValueError(
+                    f"initial_amax.numel() ({initial_amax.numel()}) must equal "
+                    f"n_blocks ({n_blocks})."
+                )
+            base_codes = fp8_scale_codes(
+                initial_amax.reshape(-1), global_amax_f32, fp8_max_for_normalization
+            )
+            min_offset, max_offset = offset_range
+            num_candidates = max_offset - min_offset + 1
         hessian_flat = hessian.contiguous().to(device=x.device, dtype=torch.float32).view(-1)
         _fp8_scale_sweep_hessian_kernel[grid](
             x_flat,
             hessian_flat,
             candidate_scales,
             candidate_amaxes,
+            fp8_scale_candidates(
+                x.device, fp8_max_for_normalization if offset_range is not None else 448.0
+            ).to(dtype=torch.float32),
+            base_codes,
+            global_amax_f32,
             best_amax,
             cout,
             n_cin_blocks,
             BLOCK_SIZE=block_size,
-            NUM_CANDIDATES=int(candidate_amaxes.numel()),
+            NUM_CANDIDATES=num_candidates,
+            MIN_OFFSET=min_offset,
+            BOUNDED=offset_range is not None,
             ROWS_PER_PROGRAM=_HESSIAN_ROWS_PER_PROGRAM,
             num_warps=_HESSIAN_NUM_WARPS,
         )

--- a/modelopt/torch/quantization/calib/mse.py
+++ b/modelopt/torch/quantization/calib/mse.py
@@ -154,7 +154,14 @@ class MseCalibrator(_Calibrator):
         losses = torch.stack(losses)
         best_indices = torch.argmin(losses, dim=0)
         assert self._candidates is not None
-        best_candidates = self._candidates[best_indices]
+        if self._candidates.ndim == 1:
+            best_candidates = self._candidates[best_indices]
+        else:
+            best_candidates = torch.gather(
+                self._candidates.reshape(self._num_steps, -1),
+                0,
+                best_indices.reshape(1, -1),
+            ).reshape(best_indices.shape)
         self._amax = self._compute_candidate_amax(best_candidates)
 
         if verbose:
@@ -175,8 +182,8 @@ class MseCalibrator(_Calibrator):
 class NVFP4MSECalibrator(MseCalibrator):
     """Per-block FP8 scale sweep calibrator for NVFP4 static quantization.
 
-    ``collect`` dispatches to one of two fused Triton fast paths, else the reference 126-step
-    Python sweep. Both fast paths require the input on CUDA in the blocked
+    ``collect`` dispatches to one of two fused Triton fast paths, else the reference exhaustive
+    or bounded Python sweep. Both fast paths require the input on CUDA in the blocked
     ``[n_blocks, block_size]`` layout with Triton + the kernel package importable:
 
     - **Hessian-weighted** (local_hessian): taken when ``hessian is not None`` — minimizes
@@ -196,16 +203,23 @@ class NVFP4MSECalibrator(MseCalibrator):
         quant_func: Callable | None = None,
         error_func: Callable | None = None,
         hessian: torch.Tensor | None = None,
+        fp8_scale_sweep: bool | tuple[int, int] = True,
+        fp8_max_for_normalization: float = 448.0,
     ):
         """Initialize NVFP4 MSE calibrator with per-block and global amax.
 
         ``hessian`` (per-cin-block ``[cin // block_size, block_size, block_size]``) enables
         the Hessian-weighted Triton fast path (local_hessian); ``error_func`` carries the
         same metric for the reference fallback when the fast path is unavailable.
+        ``fp8_scale_sweep`` is True for the exhaustive search or an inclusive E4M3
+        code-offset tuple for a bounded per-block search.
+        ``fp8_max_for_normalization`` is 256 for 4/6 mode and 448 otherwise.
         """
         super().__init__(amax=amax, axis=axis, quant_func=quant_func, error_func=error_func)
         self._global_amax = global_amax.to(dtype=torch.float32)
         self._hessian = hessian
+        self._fp8_scale_sweep = fp8_scale_sweep
+        self._fp8_max_for_normalization = fp8_max_for_normalization
         # Set by collect() after either sweep path; consumed by compute_amax.
         self._best_amax: torch.Tensor | None = None
 
@@ -217,11 +231,19 @@ class NVFP4MSECalibrator(MseCalibrator):
         )
 
     def _generate_candidates(self, device: torch.device) -> torch.Tensor:
-        """Generate the 126 valid FP8 E4M3 scale candidates."""
+        """Generate exhaustive or bounded per-block FP8 E4M3 scale candidates."""
         from modelopt.torch.kernels.quantization.gemm._fp8_scale_candidates import (
             fp8_scale_candidates,
+            fp8_scale_offset_candidates,
         )
 
+        if isinstance(self._fp8_scale_sweep, tuple):
+            return fp8_scale_offset_candidates(
+                self._initial_amax,
+                self._global_amax,
+                self._fp8_scale_sweep,
+                self._fp8_max_for_normalization,
+            )
         return fp8_scale_candidates(device)
 
     def _triton_sweep_eligible(self, x: torch.Tensor) -> bool:
@@ -265,14 +287,31 @@ class NVFP4MSECalibrator(MseCalibrator):
             from modelopt.torch.kernels.quantization.gemm import nvfp4_fp8_scale_sweep_hessian
 
             best_flat = nvfp4_fp8_scale_sweep_hessian(
-                x.detach(), self._global_amax, self._hessian, block_size=x.shape[-1]
+                x.detach(),
+                self._global_amax,
+                self._hessian,
+                block_size=x.shape[-1],
+                offset_range=(
+                    self._fp8_scale_sweep if isinstance(self._fp8_scale_sweep, tuple) else None
+                ),
+                initial_amax=self._initial_amax,
+                fp8_max_for_normalization=self._fp8_max_for_normalization,
             )
             self._best_amax = best_flat.reshape(self._initial_amax.shape).to(dtype=torch.float32)
             return
         if self._can_use_triton_fast_path(x):
             from modelopt.torch.kernels.quantization.gemm import nvfp4_fp8_scale_sweep
 
-            best_flat = nvfp4_fp8_scale_sweep(x.detach(), self._global_amax, block_size=x.shape[-1])
+            best_flat = nvfp4_fp8_scale_sweep(
+                x.detach(),
+                self._global_amax,
+                block_size=x.shape[-1],
+                offset_range=(
+                    self._fp8_scale_sweep if isinstance(self._fp8_scale_sweep, tuple) else None
+                ),
+                initial_amax=self._initial_amax,
+                fp8_max_for_normalization=self._fp8_max_for_normalization,
+            )
             # Store the selected amax in fp32; the fake-quant kernel still returns
             # tensors in the requested output dtype.
             self._best_amax = best_flat.reshape(self._initial_amax.shape).to(dtype=torch.float32)

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -946,6 +946,29 @@ class MaxCalibConfig(_SharedStatesConfig, QuantizeAlgorithmConfig):
     )
 
 
+def _validate_fp8_scale_sweep(value):
+    """Normalize and validate an optional bounded E4M3 code-offset search."""
+    if value is None or isinstance(value, bool):
+        return value
+    if not isinstance(value, (tuple, list)) or len(value) != 2:
+        raise ValueError("fp8_scale_sweep must be a bool or a two-integer tuple/list")
+    if any(isinstance(offset, bool) or not isinstance(offset, int) for offset in value):
+        raise ValueError("fp8_scale_sweep offsets must be integers, not booleans or floats")
+
+    min_offset, max_offset = value
+    if min_offset > max_offset:
+        raise ValueError("fp8_scale_sweep minimum offset must not exceed the maximum offset")
+    if not min_offset <= 0 <= max_offset:
+        raise ValueError("fp8_scale_sweep offset range must include 0")
+    if min_offset < -125 or max_offset > 125:
+        raise ValueError("fp8_scale_sweep offsets must each be between -125 and 125")
+    if max_offset - min_offset + 1 > 126:
+        raise ValueError(
+            "fp8_scale_sweep range may contain at most 126 offsets; use True for exhaustive search"
+        )
+    return (min_offset, max_offset)
+
+
 class MseCalibConfig(_SharedStatesConfig, QuantizeAlgorithmConfig):
     """Configuration for per-tensor MSE calibration.
 
@@ -983,13 +1006,20 @@ class MseCalibConfig(_SharedStatesConfig, QuantizeAlgorithmConfig):
         description="Ending multiplier for amax search range (multiplies initial amax).",
     )
 
-    fp8_scale_sweep: bool | None = ModeloptField(
+    fp8_scale_sweep: bool | tuple[int, int] | None = ModeloptField(
         default=False,
         title="Enable FP8 scale sweep for NVFP4 per-block quantization.",
-        description="If True, sweep all 128 FP8 E4M3 scale values instead of using multipliers. "
-        "Applies to ModelOpt static NVFP4 weight quantizers and registered custom backends with "
-        "FP8 sweep support. Other weight quantizers use the multiplier search.",
+        description="If True, sweep all 126 finite positive FP8 E4M3 scale values instead of "
+        "using multipliers. A two-integer tuple selects an inclusive range of E4M3 code offsets "
+        "around each block's max-derived scale for ModelOpt static NVFP4 weights. Registered "
+        "custom backends retain support for True only.",
     )
+
+    @field_validator("fp8_scale_sweep", mode="before")
+    @classmethod
+    def validate_fp8_scale_sweep(cls, value):
+        """Normalize and validate a bounded FP8 scale sweep."""
+        return _validate_fp8_scale_sweep(value)
 
     distributed_sync: bool | None = ModeloptField(
         default=True,
@@ -1037,13 +1067,19 @@ class LocalHessianCalibConfig(_SharedStatesConfig, QuantizeAlgorithmConfig):
         description="Ending multiplier for amax search range (multiplies initial amax).",
     )
 
-    fp8_scale_sweep: bool | None = ModeloptField(
+    fp8_scale_sweep: bool | tuple[int, int] | None = ModeloptField(
         default=True,
         title="Enable FP8 scale sweep for NVFP4 per-block quantization.",
-        description="If True, sweep over all 128 possible FP8 E4M3 scale values "
-        "for NVFP4 per-block quantization instead of using multipliers. "
-        "This is the recommended setting for NVFP4 quantization.",
+        description="If True, sweep all 126 finite positive FP8 E4M3 scale values. A two-integer "
+        "tuple selects an inclusive range of E4M3 code offsets around each block's max-derived "
+        "scale. If False, use the multiplier search.",
     )
+
+    @field_validator("fp8_scale_sweep", mode="before")
+    @classmethod
+    def validate_fp8_scale_sweep(cls, value):
+        """Normalize and validate a bounded FP8 scale sweep."""
+        return _validate_fp8_scale_sweep(value)
 
     block_size: int | None = ModeloptField(
         default=16,

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -43,6 +43,7 @@ from modelopt.torch.utils.distributed import size as dist_size
 from modelopt.torch.utils.network import bind_forward_method, unpatch_forward_method
 
 from .calib import MseCalibrator, NVFP4ActHeadroomCalibrator, NVFP4MSECalibrator, _Calibrator
+from .config import _validate_fp8_scale_sweep
 from .conversion import create_and_replace_svdquant_linear_on_the_fly, set_quantizer_by_cfg_context
 from .nn import (
     AnyQuantizer,
@@ -68,6 +69,7 @@ from .utils import (
     promote_static_block_weight_quantizers,
 )
 from .utils.calib_utils import _GPTQ_HELPER_REGISTRY, GPTQHelper
+from .utils.numeric_utils import fp8_max_for_normalization
 
 __all__ = [
     "CalibratorFactory",
@@ -670,7 +672,7 @@ def _make_weight_mse_calibrator(
     step_size: float,
     start_multiplier: float,
     stop_multiplier: float,
-    fp8_scale_sweep: bool,
+    fp8_scale_sweep: bool | tuple[int, int] | None,
     error_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
     hessian: torch.Tensor | None = None,
 ) -> _Calibrator | None:
@@ -699,7 +701,7 @@ def _make_weight_mse_calibrator(
         backend_factory = (
             _FP8_SWEEP_CALIBRATOR_REGISTRY.get(backend) if backend is not None else None
         )
-        if backend is not None and backend_factory is not None:
+        if fp8_scale_sweep is True and backend is not None and backend_factory is not None:
             if error_func is not None:
                 # Registered backend factories don't accept a custom error_func.
                 warnings.warn(
@@ -716,6 +718,8 @@ def _make_weight_mse_calibrator(
                 quant_func=quant_func,
                 error_func=error_func,
                 hessian=hessian,
+                fp8_scale_sweep=fp8_scale_sweep,
+                fp8_max_for_normalization=fp8_max_for_normalization(weight_quantizer),
             )
         # fp8_scale_sweep applies only to registered backends and static NVFP4; skip others.
         return None
@@ -740,7 +744,7 @@ def mse_calibrate(
     step_size: float = 0.1,
     start_multiplier: float = 0.25,
     stop_multiplier: float = 4.0,
-    fp8_scale_sweep: bool = False,
+    fp8_scale_sweep: bool | tuple[int, int] | list[int] | None = False,
     shared_states: Mapping[str, Mapping[str, Sequence[str]]] | None = None,
 ):
     """Calibrate weight quantizers using MSE-based amax search.
@@ -760,12 +764,14 @@ def mse_calibrate(
         fp8_scale_sweep: If True, only ModelOpt static NVFP4 weights and registered
             custom backends are MSE-calibrated (via FP8 E4M3 scale-value sweep); all
             other weight quantizers (INT8, plain FP8, unregistered backends, etc.) are
-            skipped and left at their max-calibrated amax. If False, all weight
-            quantizers use the multiplier search.
+            skipped and left at their max-calibrated amax. A two-integer tuple selects
+            an inclusive per-block E4M3 code-offset range for ModelOpt static NVFP4
+            weights only. If False, all weight quantizers use the multiplier search.
 
     See :class:`MseCalibConfig <modelopt.torch.quantization.config.MseCalibConfig>` for
     details on the remaining arguments.
     """
+    fp8_scale_sweep = _validate_fp8_scale_sweep(fp8_scale_sweep)
     # max_calibrate initializes activations and weights; MSE only refines weights below.
     max_calibrate(model, forward_loop, distributed_sync, shared_states=shared_states)
     names = module_name_maps(model)
@@ -786,7 +792,7 @@ def _mse_calibrate_weights(
     step_size: float,
     start_multiplier: float,
     stop_multiplier: float,
-    fp8_scale_sweep: bool,
+    fp8_scale_sweep: bool | tuple[int, int] | None,
     error_func_for: Callable[[TensorQuantizer], Callable | None] | None = None,
     hessian_for: Callable[[TensorQuantizer], torch.Tensor | None] | None = None,
 ):
@@ -1012,7 +1018,7 @@ def local_hessian_calibrate(
     step_size: float = 0.1,
     start_multiplier: float = 0.25,
     stop_multiplier: float = 4.0,
-    fp8_scale_sweep: bool = True,
+    fp8_scale_sweep: bool | tuple[int, int] | list[int] | None = True,
     block_size: int = 16,
     debug: bool = False,
     shared_states: Mapping[str, Mapping[str, Sequence[str]]] | None = None,
@@ -1036,8 +1042,9 @@ def local_hessian_calibrate(
         step_size: Step size for amax search (default: 0.1).
         start_multiplier: Starting multiplier for amax search (default: 0.25).
         stop_multiplier: Ending multiplier for amax search (default: 4.0).
-        fp8_scale_sweep: If True, sweep over all 128 possible FP8 E4M3 scale values
-            for NVFP4 per-block quantization (default: True).
+        fp8_scale_sweep: If True, sweep all 126 finite positive FP8 E4M3 scale values.
+            A two-integer tuple selects an inclusive per-block E4M3 code-offset range.
+            If False, use the multiplier search (default: True).
         block_size: Block size for local Hessian computation (default: 16).
         debug: If True, retain the per-quantizer Hessian accumulators on the model
             (``model._local_hessian_accumulators``) for inspection.
@@ -1045,6 +1052,7 @@ def local_hessian_calibrate(
     See :class:`LocalHessianCalibConfig <modelopt.torch.quantization.config.LocalHessianCalibConfig>`
     for details on the configuration options.
     """
+    fp8_scale_sweep = _validate_fp8_scale_sweep(fp8_scale_sweep)
     if forward_loop is None:
         warnings.warn("forward_loop must be provided for local_hessian; skipping local_hessian")
         return

--- a/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
@@ -45,7 +45,7 @@ from modelopt.torch.quantization.calib import NVFP4MSECalibrator
 from modelopt.torch.quantization.extensions import get_cuda_ext_mx
 from modelopt.torch.quantization.model_calib import _LocalHessianAccumulator
 from modelopt.torch.quantization.tensor_quant import static_blockwise_fp4_fake_quant
-from modelopt.torch.quantization.utils.numeric_utils import E4M3_MAX
+from modelopt.torch.quantization.utils.numeric_utils import E4M3_MAX, E4M3_MAX_46
 
 BLOCK_SIZE = 16
 
@@ -66,34 +66,59 @@ def _force_sweep_path(triton_enabled: bool):
             os.environ[key] = prev
 
 
-def _reference_quant_func(global_amax):
+def _reference_quant_func(global_amax, fp8_max_for_normalization=E4M3_MAX):
     """Reference NVFP4 fake-quant matching what ``mse_calibrate`` plumbs in."""
 
     def quant_func(x, amax):
-        return static_blockwise_fp4_fake_quant(x, amax, global_amax)
+        return static_blockwise_fp4_fake_quant(
+            x, amax, global_amax, True, fp8_max_for_normalization
+        )
 
     return quant_func
 
 
-def _make_calibrator(per_block_amax, global_amax):
+def _make_calibrator(
+    per_block_amax,
+    global_amax,
+    fp8_scale_sweep=True,
+    fp8_max_for_normalization=E4M3_MAX,
+):
     return NVFP4MSECalibrator(
         amax=per_block_amax,
         axis=0,
         global_amax=global_amax,
-        quant_func=_reference_quant_func(global_amax),
+        quant_func=_reference_quant_func(global_amax, fp8_max_for_normalization),
+        fp8_scale_sweep=fp8_scale_sweep,
+        fp8_max_for_normalization=fp8_max_for_normalization,
     )
 
 
-def _run_reference(x, per_block_amax, global_amax):
+def _run_reference(
+    x,
+    per_block_amax,
+    global_amax,
+    fp8_scale_sweep=True,
+    fp8_max_for_normalization=E4M3_MAX,
+):
     with _force_sweep_path(triton_enabled=False):
-        cal = _make_calibrator(per_block_amax, global_amax)
+        cal = _make_calibrator(
+            per_block_amax, global_amax, fp8_scale_sweep, fp8_max_for_normalization
+        )
         cal.collect(x)
         return cal.compute_amax()
 
 
-def _run_triton(x, per_block_amax, global_amax):
+def _run_triton(
+    x,
+    per_block_amax,
+    global_amax,
+    fp8_scale_sweep=True,
+    fp8_max_for_normalization=E4M3_MAX,
+):
     with _force_sweep_path(triton_enabled=True):
-        cal = _make_calibrator(per_block_amax, global_amax)
+        cal = _make_calibrator(
+            per_block_amax, global_amax, fp8_scale_sweep, fp8_max_for_normalization
+        )
         cal.collect(x)
         return cal.compute_amax()
 
@@ -123,6 +148,24 @@ def test_parity_random_weights(seed, num_blocks, dtype):
         f"{(ref - tri).abs().max().item():.3e}, "
         f"differing blocks = {(ref != tri).sum().item()} / {num_blocks}"
     )
+
+
+@requires_triton
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("offset_range", [(0, 0), (-2, 6), (-8, 8)])
+def test_bounded_parity_including_code_boundaries_and_zero_blocks(dtype, offset_range):
+    torch.manual_seed(2)
+    x = torch.randn(64, BLOCK_SIZE, device="cuda", dtype=dtype)
+    x[0].zero_()
+    x[1].mul_(2**-16)
+    x[2].mul_(2**8)
+    per_block_amax = x.float().abs().amax(dim=-1)
+    global_amax = per_block_amax.max()
+
+    ref = _run_reference(x, per_block_amax, global_amax, offset_range)
+    tri = _run_triton(x, per_block_amax, global_amax, offset_range)
+
+    assert torch.equal(ref, tri)
 
 
 @requires_triton
@@ -282,8 +325,9 @@ def test_dispatch_cpu_path_excluded():
 
 @requires_triton
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-def test_mse_calibrate_end_to_end(monkeypatch, tmp_path, dtype):
-    """End-to-end: the ``mse``/``fp8_scale_sweep=True`` path produces the same quantized
+@pytest.mark.parametrize("fp8_scale_sweep", [True, (-2, 6)])
+def test_mse_calibrate_end_to_end(monkeypatch, tmp_path, dtype, fp8_scale_sweep):
+    """End-to-end: exhaustive and bounded ``mse`` paths produce the same quantized
     weights with the fast path on (default) and off (``MODELOPT_NVFP4_TRITON_SWEEP=0``),
     and stores/restores NVFP4 static amax in fp32 for fp32 and bf16 model forwards."""
     if get_cuda_ext_mx() is None:
@@ -302,7 +346,7 @@ def test_mse_calibrate_end_to_end(monkeypatch, tmp_path, dtype):
             },
             {"quantizer_name": "*input_quantizer", "enable": False},
         ],
-        "algorithm": {"method": "mse", "fp8_scale_sweep": True},
+        "algorithm": {"method": "mse", "fp8_scale_sweep": fp8_scale_sweep},
     }
 
     def _run_calibrated(env_value, label):
@@ -324,7 +368,8 @@ def test_mse_calibrate_end_to_end(monkeypatch, tmp_path, dtype):
         amax_dtypes = nvfp4_static_amax_dtypes(model)
         assert_nvfp4_static_amaxes_fp32(amax_dtypes, dtype, label)
 
-        ckpt_path = tmp_path / f"mse_calibrate_{label}_{str(dtype).rpartition('.')[-1]}.pt"
+        mode = "full" if fp8_scale_sweep is True else "bounded"
+        ckpt_path = tmp_path / f"mse_calibrate_{label}_{mode}_{str(dtype).rpartition('.')[-1]}.pt"
         mto.save(model, ckpt_path)
         restored_model = mto.restore(SimpleLinear(dtype=dtype).cuda(), ckpt_path)
         restored_amax_dtypes = nvfp4_static_amax_dtypes(restored_model)
@@ -371,29 +416,47 @@ def _build_hessian_accumulator(cout, cin, hessian_input, block_size=BLOCK_SIZE):
     return acc
 
 
-def _run_hessian_reference(x_blocks, per_block_amax, global_amax, acc):
+def _run_hessian_reference(
+    x_blocks,
+    per_block_amax,
+    global_amax,
+    acc,
+    fp8_scale_sweep=True,
+    fp8_max_for_normalization=E4M3_MAX,
+):
     """Reference 126-step sweep using the Hessian-weighted ``error_func`` (Triton off)."""
     with _force_sweep_path(triton_enabled=False):
         cal = NVFP4MSECalibrator(
             amax=per_block_amax,
             axis=0,
             global_amax=global_amax,
-            quant_func=_reference_quant_func(global_amax),
+            quant_func=_reference_quant_func(global_amax, fp8_max_for_normalization),
             error_func=acc.build_error_func(keep_buffer=True),
+            fp8_scale_sweep=fp8_scale_sweep,
+            fp8_max_for_normalization=fp8_max_for_normalization,
         )
         cal.collect(x_blocks)
         return cal.compute_amax()
 
 
-def _run_hessian_triton(x_blocks, per_block_amax, global_amax, acc):
+def _run_hessian_triton(
+    x_blocks,
+    per_block_amax,
+    global_amax,
+    acc,
+    fp8_scale_sweep=True,
+    fp8_max_for_normalization=E4M3_MAX,
+):
     """Hessian-weighted Triton fast path (same metric as a raw per-cin-block tensor)."""
     with _force_sweep_path(triton_enabled=True):
         cal = NVFP4MSECalibrator(
             amax=per_block_amax,
             axis=0,
             global_amax=global_amax,
-            quant_func=_reference_quant_func(global_amax),
+            quant_func=_reference_quant_func(global_amax, fp8_max_for_normalization),
             hessian=acc.normalized_hessian(),
+            fp8_scale_sweep=fp8_scale_sweep,
+            fp8_max_for_normalization=fp8_max_for_normalization,
         )
         cal.collect(x_blocks)
         return cal.compute_amax()
@@ -466,6 +529,71 @@ def test_hessian_parity_random_weights(seed, cout, cin, dtype):
         f"aggregate Hessian-loss gap {rel_gap:.3e} too large "
         f"({n_diff}/{n_blocks} boundary blocks flipped, dtype={dtype})"
     )
+
+
+@requires_triton
+@pytest.mark.parametrize("offset_range", [(0, 0), (-2, 6), (-8, 8)])
+def test_hessian_bounded_parity(offset_range):
+    torch.manual_seed(3)
+    cout, cin = 8, 64
+    weight = torch.randn(cout, cin, device="cuda", dtype=torch.float32)
+    weight[0].zero_()
+    acc = _build_hessian_accumulator(
+        cout, cin, torch.randn(128, cin, device="cuda", dtype=torch.float32)
+    )
+    x_blocks = weight.reshape(-1, BLOCK_SIZE)
+    per_block_amax = x_blocks.abs().amax(dim=-1)
+    global_amax = per_block_amax.max()
+
+    ref = _run_hessian_reference(x_blocks, per_block_amax, global_amax, acc, offset_range)
+    tri = _run_hessian_triton(x_blocks, per_block_amax, global_amax, acc, offset_range)
+
+    assert torch.equal(ref, tri)
+
+
+@requires_triton
+def test_bounded_four_over_six_parity_for_both_losses():
+    torch.manual_seed(4)
+    cout, cin = 8, 64
+    x_blocks = torch.randn(cout * cin // BLOCK_SIZE, BLOCK_SIZE, device="cuda")
+    per_block_amax = x_blocks.abs().amax(dim=-1)
+    global_amax = per_block_amax.max()
+    offset_range = (-2, 6)
+
+    ref = _run_reference(x_blocks, per_block_amax, global_amax, offset_range, E4M3_MAX_46)
+    tri = _run_triton(x_blocks, per_block_amax, global_amax, offset_range, E4M3_MAX_46)
+    assert torch.equal(ref, tri)
+
+    acc = _build_hessian_accumulator(
+        cout, cin, torch.randn(128, cin, device="cuda", dtype=torch.float32)
+    )
+    ref = _run_hessian_reference(
+        x_blocks, per_block_amax, global_amax, acc, offset_range, E4M3_MAX_46
+    )
+    tri = _run_hessian_triton(x_blocks, per_block_amax, global_amax, acc, offset_range, E4M3_MAX_46)
+    assert torch.equal(ref, tri)
+
+
+@requires_triton
+def test_bounded_all_zero_tensor_is_deterministic_for_both_losses():
+    cout, cin = 4, 64
+    x_blocks = torch.zeros(cout * cin // BLOCK_SIZE, BLOCK_SIZE, device="cuda")
+    per_block_amax = x_blocks.abs().amax(dim=-1)
+    global_amax = per_block_amax.max()
+    offset_range = (-8, 8)
+
+    ref = _run_reference(x_blocks, per_block_amax, global_amax, offset_range)
+    tri = _run_triton(x_blocks, per_block_amax, global_amax, offset_range)
+    assert torch.equal(ref, tri)
+    assert torch.count_nonzero(tri) == 0
+
+    acc = _build_hessian_accumulator(
+        cout, cin, torch.randn(64, cin, device="cuda", dtype=torch.float32)
+    )
+    ref = _run_hessian_reference(x_blocks, per_block_amax, global_amax, acc, offset_range)
+    tri = _run_hessian_triton(x_blocks, per_block_amax, global_amax, acc, offset_range)
+    assert torch.equal(ref, tri)
+    assert torch.count_nonzero(tri) == 0
 
 
 @requires_triton

--- a/tests/unit/torch/quantization/test_config_validation.py
+++ b/tests/unit/torch/quantization/test_config_validation.py
@@ -675,6 +675,23 @@ class TestLayerwiseNestedConfig:
         assert cfg.layerwise.calib_mutates_weights is False
 
 
+class TestFP8ScaleSweepRange:
+    @pytest.mark.parametrize("cfg_cls", [MseCalibConfig, LocalHessianCalibConfig])
+    def test_list_is_normalized_and_json_serializable(self, cfg_cls):
+        cfg = cfg_cls(fp8_scale_sweep=[-8, 8])
+        assert cfg.fp8_scale_sweep == (-8, 8)
+        assert '"fp8_scale_sweep":[-8,8]' in cfg.model_dump_json(exclude_unset=True)
+
+    @pytest.mark.parametrize("cfg_cls", [MseCalibConfig, LocalHessianCalibConfig])
+    @pytest.mark.parametrize(
+        "value",
+        [(-126, 0), (0, 126), (-63, 63), (1, 2), (-2, -1), (2, 1), (False, 1), (-1.0, 1)],
+    )
+    def test_invalid_ranges_are_rejected(self, cfg_cls, value):
+        with pytest.raises(ValidationError, match="fp8_scale_sweep"):
+            cfg_cls(fp8_scale_sweep=value)
+
+
 class TestFourOverSixBlockSizes:
     """`four_over_six` is an accepted block_sizes key for NVFP4 4/6 adaptive weight scaling.
 

--- a/tests/unit/torch/quantization/test_local_hessian.py
+++ b/tests/unit/torch/quantization/test_local_hessian.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 from _test_utils.torch.quantization.models import SimpleConv, SimpleLinear
 
 import modelopt.torch.quantization as mtq
+import modelopt.torch.quantization.model_calib as model_calib_module
 from modelopt.torch.quantization import calib
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
 from modelopt.torch.quantization.model_calib import (
@@ -69,6 +70,13 @@ def _make_forward_loop(seed=0):
     return forward_loop
 
 
+@pytest.mark.parametrize("calibrate_fn", [mse_calibrate, local_hessian_calibrate])
+@pytest.mark.parametrize("value", [[-2], (2, 1), (False, 1), (-126, 0)])
+def test_direct_calibration_rejects_invalid_fp8_scale_sweep(calibrate_fn, value):
+    with pytest.raises(ValueError, match="fp8_scale_sweep"):
+        calibrate_fn(nn.Linear(2, 2), lambda model: model(torch.ones(1, 2)), fp8_scale_sweep=value)
+
+
 class TestLocalHessianAccumulator:
     def test_accumulate_shape_samples_fp32_buffer(self):
         torch.manual_seed(0)
@@ -112,6 +120,21 @@ class TestLocalHessianAccumulator:
 
 
 class TestLocalHessianCalibrateDense:
+    def test_bounded_sweep_is_forwarded_to_weight_search(self, monkeypatch):
+        model = SimpleLinear()
+        forward_loop = _make_forward_loop()
+        mtq.quantize(model, INT8_WEIGHT_CFG, forward_loop=forward_loop)
+        calls = []
+        monkeypatch.setattr(
+            model_calib_module,
+            "_mse_calibrate_weights",
+            lambda *args, **kwargs: calls.append(kwargs),
+        )
+
+        local_hessian_calibrate(model, forward_loop, fp8_scale_sweep=[-2, 6])
+
+        assert calls[0]["fp8_scale_sweep"] == (-2, 6)
+
     def test_refines_amax_beyond_max_and_plain_mse(self):
         forward_loop = _make_forward_loop()
         torch.manual_seed(0)

--- a/tests/unit/torch/quantization/test_lsq.py
+++ b/tests/unit/torch/quantization/test_lsq.py
@@ -121,17 +121,17 @@ class TestLSQConfig:
             LSQConfig(scale_algorithm={"method": "smoothquant"})
 
     def test_scale_algorithm_preserves_sparse_dict(self, monkeypatch):
-        cfg = LSQConfig(scale_algorithm={"method": "mse", "fp8_scale_sweep": True})
+        cfg = LSQConfig(scale_algorithm={"method": "mse", "fp8_scale_sweep": [-8, 8]})
         assert cfg.model_dump()["scale_algorithm"] == {
             "method": "mse",
-            "fp8_scale_sweep": True,
+            "fp8_scale_sweep": (-8, 8),
         }
 
         calibrate = create_autospec(model_calib_module.mse_calibrate)
         monkeypatch.setattr(model_calib_module, "mse_calibrate", calibrate)
         model = Mock()
         model_calib_module._run_weight_scale_calibration(model, None, cfg.scale_algorithm)
-        calibrate.assert_called_once_with(model, forward_loop=None, fp8_scale_sweep=True)
+        calibrate.assert_called_once_with(model, forward_loop=None, fp8_scale_sweep=(-8, 8))
 
     @pytest.mark.parametrize(
         ("learnable_amax", "tied_amax"),

--- a/tests/unit/torch/quantization/test_mse_calibrator.py
+++ b/tests/unit/torch/quantization/test_mse_calibrator.py
@@ -18,6 +18,10 @@
 import torch
 
 import modelopt.torch.quantization as mtq
+import modelopt.torch.quantization.model_calib as model_calib_module
+from modelopt.torch.kernels.quantization.gemm._fp8_scale_candidates import (
+    fp8_scale_offset_candidates,
+)
 from modelopt.torch.quantization import calib
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
 from modelopt.torch.quantization.model_calib import (
@@ -543,6 +547,45 @@ class TestMseCalibrator:
         assert torch.all(a_best > 0)
 
 
+def test_nvfp4_bounded_candidates_clip_codes_and_break_ties_by_ascending_offset():
+    global_amax = torch.tensor(448.0)
+    initial_amax = torch.tensor([0.0, 1.0, 448.0])
+    offset_range = (-2, 2)
+    candidates = fp8_scale_offset_candidates(initial_amax, global_amax, offset_range)
+
+    candidate_codes = (candidates * 448.0).to(torch.float8_e4m3fn).view(torch.uint8)
+    base_codes = candidate_codes[2]
+    expected_codes = (
+        base_codes.to(torch.int16).unsqueeze(0)
+        + torch.arange(-2, 3, dtype=torch.int16).unsqueeze(1)
+    ).clamp(1, 126)
+    assert torch.equal(candidate_codes, expected_codes.to(torch.uint8))
+
+    cal = calib.NVFP4MSECalibrator(
+        amax=initial_amax,
+        axis=0,
+        global_amax=global_amax,
+        quant_func=lambda x, _amax: torch.zeros_like(x),
+        fp8_scale_sweep=offset_range,
+    )
+    cal.collect(torch.zeros(3, 1))
+    assert torch.equal(cal.compute_amax(), candidates[0] * global_amax)
+
+
+def test_mse_calibrate_normalizes_direct_list_input(monkeypatch):
+    calls = []
+    monkeypatch.setattr(model_calib_module, "max_calibrate", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        model_calib_module,
+        "_mse_calibrate_weights",
+        lambda *args, **kwargs: calls.append(kwargs),
+    )
+
+    mse_calibrate(torch.nn.Linear(2, 2), fp8_scale_sweep=[-2, 6])
+
+    assert calls[0]["fp8_scale_sweep"] == (-2, 6)
+
+
 class TestRegisterFP8SweepCalibrator:
     """Tests for _register_fp8_sweep_calibrator and its dispatch in mse_calibrate."""
 
@@ -627,6 +670,18 @@ class TestRegisterFP8SweepCalibrator:
 
         assert len(factory_calls) == 0
 
+    def test_bounded_sweep_does_not_change_custom_backend_dispatch(self):
+        factory_calls: list = []
+
+        def my_factory(amax, axis, quant_func):
+            factory_calls.append(amax)
+            return calib.MseCalibrator(amax=amax, axis=axis, quant_func=quant_func)
+
+        _register_fp8_sweep_calibrator("_test_bounded", my_factory)
+        self._quantize_and_calibrate("_test_bounded", fp8_scale_sweep=(-2, 6))
+
+        assert factory_calls == []
+
     def test_unregistered_backend_skipped_when_fp8_sweep_enabled(self):
         """An unregistered backend is skipped under fp8_scale_sweep, leaving the max calibrator."""
         model = self._quantize_and_calibrate("_test_unregistered", fp8_scale_sweep=True)
@@ -658,6 +713,39 @@ class TestRegisterFP8SweepCalibrator:
         )
 
         assert isinstance(cal, calib.NVFP4MSECalibrator)
+
+        bounded_cal = _make_weight_mse_calibrator(
+            q,
+            step_size=0.1,
+            start_multiplier=0.25,
+            stop_multiplier=4.0,
+            fp8_scale_sweep=(-2, 6),
+        )
+        assert bounded_cal._fp8_max_for_normalization == 448.0
+
+        q_4_over_6 = TensorQuantizer(
+            QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={
+                    -1: 16,
+                    "type": "static",
+                    "scale_bits": (4, 3),
+                    "four_over_six": True,
+                },
+                axis=None,
+            ),
+            amax=torch.tensor([1.0, 2.0]),
+        )
+        model.weight_quantizer = q_4_over_6
+        promote_nvfp4_static_quantizers(model)
+        bounded_cal = _make_weight_mse_calibrator(
+            q_4_over_6,
+            step_size=0.1,
+            start_multiplier=0.25,
+            stop_multiplier=4.0,
+            fp8_scale_sweep=(-2, 6),
+        )
+        assert bounded_cal._fp8_max_for_normalization == 256.0
 
     def test_internal_int8_skipped_when_fp8_sweep_enabled(self):
         """INT8 is skipped under fp8_scale_sweep but uses the multiplier search otherwise."""


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

Adds a configurable bounded FP8 scale search for static NVFP4 MSE and local-Hessian calibration. `fp8_scale_sweep=True` keeps the existing exhaustive search over all 126 finite positive E4M3 values, while a two-integer range such as `[-8, 8]` searches an inclusive set of E4M3 code offsets around each block's max-derived scale. `False` continues to use the multiplier search.

The bounded MSE and Hessian searches use the fused Triton paths, preserve the reference fallback, and account for both the standard 448 normalization and the 256 normalization used by four-over-six mode. Registered custom backends retain their existing exhaustive-`True` behavior.

### Usage

```python
quant_cfg = {
    "algorithm": {
        "method": "mse",
        "fp8_scale_sweep": [-8, 8],
    }
}

# The same bounded range is available for local Hessian calibration:
quant_cfg["algorithm"] = {
    "method": "local_hessian",
    "fp8_scale_sweep": [-8, 8],
}
```

### Testing

- `pre-commit run --files <11 changed files>` — all hooks passed.
- `/home/akuriparambi/.codex/tools/pytest_pwd tests/unit/torch/quantization/test_config_validation.py tests/unit/torch/quantization/test_local_hessian.py tests/unit/torch/quantization/test_lsq.py tests/unit/torch/quantization/test_mse_calibrator.py -q -x` — 190 passed.
- `CUDA_VISIBLE_DEVICES=5 /home/akuriparambi/.codex/tools/pytest_pwd tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py -q -x` — 61 passed on NVIDIA RTX PRO 6000 Blackwell Max-Q.

GPU coverage includes bounded and exhaustive MSE/Hessian paths, 448/256 normalization, reference–Triton parity, boundary codes, zeros, tie-breaking, dtypes, save/restore, and end-to-end calibration.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: ❌

### Additional Information

Design motivation: [Search Your Block Floating Point Scales!](https://arxiv.org/abs/2605.12464)
