### PR TITLE
Carry a checkpoint's ModelOpt PTQ run into its eval's MLflow run

### DIFF
--- a/plugins/modelopt/skills/accessing-mlflow/SKILL.md
+++ b/plugins/modelopt/skills/accessing-mlflow/SKILL.md
@@ -19,7 +19,7 @@ license: Apache-2.0
 
 When the user provides a hex ID (e.g. `71f3f3199ea5e1f0`) without specifying what it is, assume it is an **invocation_id** (not an MLflow run_id). An invocation_id identifies a launcher invocation and is stored as both a tag and a param on MLflow runs. One invocation can produce multiple MLflow runs (one per task). You may need to search across multiple experiments if you don't know which experiment the run belongs to.
 
-A **`modelopt_run_id`** tag is different again: it names the ModelOpt PTQ run that quantized the checkpoint being evaluated, not this run. The evaluation skill copies it (with `modelopt_run_name` / `modelopt_run_url`) out of the checkpoint's `.experiment.json`, and files the eval in the PTQ run's own experiment — so a quantization and its evals usually sit in one experiment.
+A **`modelopt_run_id`** tag is different again: it names the ModelOpt PTQ run that quantized the checkpoint being evaluated, not this run, and it belongs to a *different server* — the PTQ's. The evaluation skill copies it (with `modelopt_run_name` / `modelopt_run_url`) out of the checkpoint's `.experiment.json` and files the eval under the PTQ's experiment *name*, so evals of one checkpoint group together. The PTQ run itself is usually not there: reach it through `modelopt_run_url`, and use this server's own `experiment_id` for any query here.
 
 ## Querying Runs
 

--- a/plugins/modelopt/skills/accessing-mlflow/SKILL.md
+++ b/plugins/modelopt/skills/accessing-mlflow/SKILL.md
@@ -19,6 +19,8 @@ license: Apache-2.0
 
 When the user provides a hex ID (e.g. `71f3f3199ea5e1f0`) without specifying what it is, assume it is an **invocation_id** (not an MLflow run_id). An invocation_id identifies a launcher invocation and is stored as both a tag and a param on MLflow runs. One invocation can produce multiple MLflow runs (one per task). You may need to search across multiple experiments if you don't know which experiment the run belongs to.
 
+A **`modelopt_run_id`** tag is different again: it names the ModelOpt PTQ run that quantized the checkpoint being evaluated, not this run. The evaluation skill copies it (with `modelopt_run_name` / `modelopt_run_url`) out of the checkpoint's `.experiment.json`, and files the eval in the PTQ run's own experiment — so a quantization and its evals usually sit in one experiment.
+
 ## Querying Runs
 
 ```python
@@ -28,6 +30,9 @@ MLflow:search_runs_by_tags(experiment_id, {"invocation_id": "<invocation_id>"})
 # Query for example model/task runs
 MLflow:query_runs(experiment_id, "tags.model LIKE '%<model>%'")
 MLflow:query_runs(experiment_id, "tags.task_name LIKE '%<task_name>%'")
+
+# Every eval of the checkpoint a given ModelOpt PTQ run produced
+MLflow:query_runs(experiment_id, "tags.modelopt_run_id = '<ptq_run_id>'")
 
 # Get a config from run's artifacts
 MLflow:get_artifact_content(run_id, "config.yml")

--- a/plugins/modelopt/skills/accessing-mlflow/SKILL.md
+++ b/plugins/modelopt/skills/accessing-mlflow/SKILL.md
@@ -19,8 +19,6 @@ license: Apache-2.0
 
 When the user provides a hex ID (e.g. `71f3f3199ea5e1f0`) without specifying what it is, assume it is an **invocation_id** (not an MLflow run_id). An invocation_id identifies a launcher invocation and is stored as both a tag and a param on MLflow runs. One invocation can produce multiple MLflow runs (one per task). You may need to search across multiple experiments if you don't know which experiment the run belongs to.
 
-A **`modelopt_run_id`** tag is different again: it names the ModelOpt PTQ run that quantized the checkpoint being evaluated, not this run, and it belongs to a *different server* — the PTQ's. The evaluation skill copies it (with `modelopt_run_name` / `modelopt_run_url`) out of the checkpoint's `.experiment.json` and files the eval under the PTQ's experiment *name*, so evals of one checkpoint group together. The PTQ run itself is usually not there: reach it through `modelopt_run_url`, and use this server's own `experiment_id` for any query here.
-
 ## Querying Runs
 
 ```python
@@ -30,9 +28,6 @@ MLflow:search_runs_by_tags(experiment_id, {"invocation_id": "<invocation_id>"})
 # Query for example model/task runs
 MLflow:query_runs(experiment_id, "tags.model LIKE '%<model>%'")
 MLflow:query_runs(experiment_id, "tags.task_name LIKE '%<task_name>%'")
-
-# Every eval of the checkpoint a given ModelOpt PTQ run produced
-MLflow:query_runs(experiment_id, "tags.modelopt_run_id = '<ptq_run_id>'")
 
 # Get a config from run's artifacts
 MLflow:get_artifact_content(run_id, "config.yml")

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -144,7 +144,7 @@ Run `nel --version`; if missing, instruct `pip install nemo-evaluator-launcher`.
 1. Read the task reference file(s).
 2. Use `recipes/examples/example_eval.yaml` as the base.
 3. Copy the YAML fragment(s) into `evaluation.tasks`, applying any per-task notes.
-4. **MLflow auto-export is on by default** — it needs **two** pieces, both in `example_eval.yaml`: (a) the **trigger** `execution.auto_export.destinations: [mlflow]` (without it the run is *not* uploaded), and (b) the `export.mlflow` block that configures it. In the `export.mlflow` block use **literal** values for `experiment_name` / `description` / `tags` — substitute the actual `served_model_name` and sampling params. Do **not** use `${deployment.*}` / `${evaluation.*}` cross-references: with auto-export on, NEL resolves the export block at submit time in a scope without those nodes and fails with `Interpolation key '...' not found` (`${oc.env:USER}` and `${oc.env:MLFLOW_TRACKING_URI}` are fine — they're env vars). Because these literals can't interpolate, keep the `temperature` / `top_p` / `max_new_tokens` tags **equal to** the top-level `params` and update both in the same edit — they're the only queryable record of sampling in MLflow (NEL doesn't log them as run params), so a stale tag silently misreports the run. `tracking_uri` = `${oc.env:MLFLOW_TRACKING_URI}` from `modelopttools:eval-config` (not hand-filled), and auto-export needs `execution.cpu_partition` (e.g. gcp-nrt `cpu`) — it's a separate CPU-only sbatch that GPU-only partitions reject (`Cannot find GPU specification`), silently dropping the link.
+4. **MLflow auto-export is on by default** — it needs **two** pieces, both in `example_eval.yaml`: (a) the **trigger** `execution.auto_export.destinations: [mlflow]` (without it the run is *not* uploaded), and (b) the `export.mlflow` block that configures it. In the `export.mlflow` block use **literal** values for `experiment_name` / `description` / `tags` — substitute the actual `served_model_name` and sampling params. Do **not** use `${deployment.*}` / `${evaluation.*}` cross-references: with auto-export on, NEL resolves the export block at submit time in a scope without those nodes and fails with `Interpolation key '...' not found` (`${oc.env:USER}` and `${oc.env:MLFLOW_TRACKING_URI}` are fine — they're env vars). Because these literals can't interpolate, keep the `temperature` / `top_p` / `max_new_tokens` tags **equal to** the top-level `params` and update both in the same edit — they're the only queryable record of sampling in MLflow (NEL doesn't log them as run params), so a stale tag silently misreports the run. `tracking_uri` = `${oc.env:MLFLOW_TRACKING_URI}` from `modelopttools:eval-config` (not hand-filled), and auto-export needs `execution.cpu_partition` (e.g. gcp-nrt `cpu`) — it's a separate CPU-only sbatch that GPU-only partitions reject (`Cannot find GPU specification`), silently dropping the link. Before filling `experiment_name`/`tags`, read the checkpoint's `.experiment.json` (Step 3) and carry the PTQ run's experiment name plus its `modelopt_*` tags across (Step 4).
 5. Proceed to Step 3, then Step 4, then Step 7.5/8. Skip Step 2's 5-question flow.
 
 ---
@@ -172,6 +172,16 @@ nel skills build-config --execution <...> --deployment <...> --model_type <...> 
 ### Step 3 — Configure deployment
 
 **Model path.** Checkpoint path (`/`, `./`, `../`, `~`, or exists on disk) → set `deployment.checkpoint_path`, leave `hf_model_handle: null`. Else HF handle (one `/`, not on disk) → set `deployment.hf_model_handle`, leave `checkpoint_path: null`.
+
+**With the path in hand, read its ModelOpt provenance** — a PTQ run tracked with
+`hf_ptq.py --mlflow` leaves `.experiment.json` in the checkpoint it wrote. Do it now rather
+than at Step 4, so the values are already on hand when you name the experiment:
+
+```bash
+cat "$CHECKPOINT_PATH"/.experiment.json   # absent (or an HF handle) → nothing to carry, name the experiment as usual
+```
+
+Carry what it says into `export.mlflow` per **Step 4**.
 
 > **NEVER point `checkpoint_path` at a HuggingFace *cache snapshot* dir.** Entries under
 > `snapshots/<sha>/` are relative symlinks into `../../blobs/`. NEL mounts only the snapshot dir at
@@ -363,6 +373,37 @@ On SLURM, several deploy/eval failures are invisible to `--dry-run` and only sur
 - Find every `???` left. Ask the user only for what can't be inferred (SLURM hostname/account/output_dir, the `cpu_partition` for auto-export, etc.). Don't propose defaults; let them give plain text. (`tracking_uri` is **not** one of these — it's `${oc.env:MLFLOW_TRACKING_URI}` from `modelopttools:eval-config`.)
 - **`parallelism`** — size it yourself from the run shape (total requests = `dataset_size × repeats` vs GPU serving capacity), and set `--max-num-seqs` to match. Read `references/parallelism.md` for the decision rule and worked examples; only ask the user if a non-GPU cap (e.g. judge rate limit) is unknown.
 - Ask about other defaults they may want to change (partition, walltime, MLflow tags).
+- **ModelOpt provenance — carry the PTQ run forward.** When Step 3 found a
+  `.experiment.json`, group this eval under the quantization that produced the checkpoint:
+
+  | `.experiment.json` field | goes to |
+  | --- | --- |
+  | `experiment_name` | `export.mlflow.experiment_name`, verbatim — replaces `${oc.env:USER}/CHANGEME-served-model-name` |
+  | `run_name` | tag `modelopt_run_name` |
+  | `run_id` | tag `modelopt_run_id` |
+  | `run_url` | tag `modelopt_run_url` |
+  | `tracking_uri` | nothing — see below |
+  | `experiment_id` | nothing; an experiment ID is server-local and means nothing on the eval server |
+
+  **Quote all three tag values** like the neighbouring tags: an unquoted all-digit `run_id`
+  or a `run_name` such as `20260910` is coerced to an int or a date and reaches MLflow
+  wrong. Copy them literally — `${deployment.*}` does not resolve in the export block. The
+  `modelopt_` prefix is required: untagged `run_id` / `run_name` read as this eval's own run.
+  Leave `description` identifying the *eval* — once `experiment_name` is the PTQ's, the
+  description is the only run-level place the served model still appears.
+
+  **`tracking_uri` stays `${oc.env:MLFLOW_TRACKING_URI}`** — never the file's. What that
+  buys depends on whether the two match, so know which case you are in:
+
+  - **Same server** (file's `tracking_uri` == `$MLFLOW_TRACKING_URI`): the eval genuinely
+    lands in the PTQ run's experiment, next to it.
+  - **Different servers** (the usual case — `modelopttools:eval-config` points evals at
+    `mlflow.frontier-evals`, while `hf_ptq --mlflow` typically writes to
+    `mlflow-modelopt`): the export **creates a new, empty experiment of the same name** on
+    the eval server. Evals of one checkpoint still group together under a stable name, but
+    the PTQ run is *not* there — it is reachable only through `modelopt_run_url`. Say so
+    when you report the run, so nobody goes looking for the PTQ beside the eval.
+
 - **`execution.gres`** — auto-set if you used a predefined `internal/slurm/<cluster>` config (above). On the `slurm/default` fallback it's `gpu:8`, so set it to the node's GPU count (and match `--data-parallel-size`/`--tensor-parallel-size`) or `sbatch` rejects the job with *"Requested node configuration is not available"* (e.g. 4-GPU GB300 → `gres: gpu:4`; check with `sinfo -o '%P %G'`).
 
 **Walltime cap: 4 hours.** Always `execution.walltime: "04:00:00"`. The cluster does not schedule jobs longer than 4h — this is a hard limit, not a preference.

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -173,20 +173,17 @@ nel skills build-config --execution <...> --deployment <...> --model_type <...> 
 
 **Model path.** Checkpoint path (`/`, `./`, `../`, `~`, or exists on disk) → set `deployment.checkpoint_path`, leave `hf_model_handle: null`. Else HF handle (one `/`, not on disk) → set `deployment.hf_model_handle`, leave `checkpoint_path: null`.
 
-**With the path in hand, read its ModelOpt provenance** — a PTQ run tracked with
-`hf_ptq.py --mlflow` leaves `.experiment.json` in the checkpoint it wrote. Do it now rather
-than at Step 4, so the values are already on hand when you name the experiment:
+**Read its ModelOpt provenance now** — `hf_ptq.py --mlflow` leaves `.experiment.json` in the
+checkpoint it wrote, and having the values in hand saves revisiting this at Step 4:
 
 ```bash
-cat "$CHECKPOINT_PATH"/.experiment.json   # absent (or an HF handle) → nothing to carry, name the experiment as usual
+cat "$CHECKPOINT_PATH"/.experiment.json   # absent (or an HF handle) → nothing to carry
 ```
 
-Carry what it says into `export.mlflow` per **Step 4**.
-
-It is a tracking pointer, not a quantization signal — read it independently of the
-quantization detection below, and never infer deploy flags from it either way. A checkpoint
-can carry one and be quantized by something other than ModelOpt, and a ModelOpt checkpoint
-quantized without `--mlflow` carries none.
+It is a tracking pointer, not a quantization signal: read it independently of the quant
+detection below and never infer deploy flags from it either way. A checkpoint can carry one
+and be quantized by something other than ModelOpt; a ModelOpt checkpoint quantized without
+`--mlflow` carries none.
 
 > **NEVER point `checkpoint_path` at a HuggingFace *cache snapshot* dir.** Entries under
 > `snapshots/<sha>/` are relative symlinks into `../../blobs/`. NEL mounts only the snapshot dir at
@@ -378,36 +375,24 @@ On SLURM, several deploy/eval failures are invisible to `--dry-run` and only sur
 - Find every `???` left. Ask the user only for what can't be inferred (SLURM hostname/account/output_dir, the `cpu_partition` for auto-export, etc.). Don't propose defaults; let them give plain text. (`tracking_uri` is **not** one of these — it's `${oc.env:MLFLOW_TRACKING_URI}` from `modelopttools:eval-config`.)
 - **`parallelism`** — size it yourself from the run shape (total requests = `dataset_size × repeats` vs GPU serving capacity), and set `--max-num-seqs` to match. Read `references/parallelism.md` for the decision rule and worked examples; only ask the user if a non-GPU cap (e.g. judge rate limit) is unknown.
 - Ask about other defaults they may want to change (partition, walltime, MLflow tags).
-- **ModelOpt provenance — carry the PTQ run forward.** When Step 3 found a
-  `.experiment.json`, group this eval under the quantization that produced the checkpoint:
+- **ModelOpt provenance.** When Step 3 found a `.experiment.json`, carry it into
+  `export.mlflow` so evals group under the run that quantized the checkpoint:
 
   | `.experiment.json` field | goes to |
   | --- | --- |
-  | `experiment_name` | `export.mlflow.experiment_name`, verbatim — replaces `${oc.env:USER}/CHANGEME-served-model-name` |
-  | `run_name` | tag `modelopt_run_name` |
-  | `run_id` | tag `modelopt_run_id` |
-  | `run_url` | tag `modelopt_run_url` |
-  | `tracking_uri` | nothing — see below |
-  | `experiment_id` | nothing; an experiment ID is server-local and means nothing on the eval server |
+  | `experiment_name` | `experiment_name`, verbatim — replaces `${oc.env:USER}/CHANGEME-served-model-name` |
+  | `run_name` / `run_id` / `run_url` | tags `modelopt_run_name` / `modelopt_run_id` / `modelopt_run_url` |
+  | `tracking_uri`, `experiment_id` | nothing — both are local to the PTQ's server |
 
-  **Quote all three tag values** like the neighbouring tags: an unquoted all-digit `run_id`
-  or a `run_name` such as `20260910` is coerced to an int or a date and reaches MLflow
-  wrong. Copy them literally — `${deployment.*}` does not resolve in the export block. The
-  `modelopt_` prefix is required: untagged `run_id` / `run_name` read as this eval's own run.
-  Leave `description` identifying the *eval* — once `experiment_name` is the PTQ's, the
-  description is the only run-level place the served model still appears.
+  Quote the tag values (a bare `20260910` becomes a date), keep the `modelopt_` prefix
+  (untagged, they read as this eval's own run), and **skip any value containing `${`** —
+  quoting does not stop OmegaConf resolving it, so a crafted file could interpolate an env
+  var into a tag. Leave `description` identifying the eval.
 
-  **`tracking_uri` stays `${oc.env:MLFLOW_TRACKING_URI}`** — never the file's. What that
-  buys depends on whether the two match, so know which case you are in:
-
-  - **Same server** (file's `tracking_uri` == `$MLFLOW_TRACKING_URI`): the eval genuinely
-    lands in the PTQ run's experiment, next to it.
-  - **Different servers** (the usual case — `modelopttools:eval-config` points evals at
-    `mlflow.frontier-evals`, while `hf_ptq --mlflow` typically writes to
-    `mlflow-modelopt`): the export **creates a new, empty experiment of the same name** on
-    the eval server. Evals of one checkpoint still group together under a stable name, but
-    the PTQ run is *not* there — it is reachable only through `modelopt_run_url`. Say so
-    when you report the run, so nobody goes looking for the PTQ beside the eval.
+  `tracking_uri` stays `${oc.env:MLFLOW_TRACKING_URI}`. When it differs from the file's —
+  the usual case — the export creates a *same-named, empty* experiment on the eval server
+  under a new server-local `experiment_id`; the PTQ run is not in it, and only
+  `modelopt_run_url` reaches it. Say so when you report the run.
 
 - **`execution.gres`** — auto-set if you used a predefined `internal/slurm/<cluster>` config (above). On the `slurm/default` fallback it's `gpu:8`, so set it to the node's GPU count (and match `--data-parallel-size`/`--tensor-parallel-size`) or `sbatch` rejects the job with *"Requested node configuration is not available"* (e.g. 4-GPU GB300 → `gres: gpu:4`; check with `sinfo -o '%P %G'`).
 

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -385,11 +385,15 @@ On SLURM, several deploy/eval failures are invisible to `--dry-run` and only sur
   | `tracking_uri`, `experiment_id` | nothing — both are local to the PTQ's server |
 
   **Skip any imported value containing `${`, `experiment_name` included** — quoting does not
-  stop OmegaConf resolving it, and the same pass resolves the whole block, so a crafted file
-  could interpolate an env var into the config. `hf_ptq` only sanitizes the experiment name
-  it derives itself; an explicit `--mlflow_experiment` reaches the file as typed. Otherwise
-  quote the tag values (a bare `20260910` becomes a date), keep the `modelopt_` prefix
-  (untagged, they read as this eval's own run), and leave `description` identifying the eval.
+  stop OmegaConf resolving it, and one pass resolves the whole block, so a crafted file could
+  interpolate an env var into the config. (`hf_ptq` sanitizes only the experiment name it
+  derives itself; an explicit `--mlflow_experiment` reaches the file as typed.) Drop that tag
+  outright — for `experiment_name`, fall back to the usual default — and say which you
+  dropped when you report the run. Otherwise quote the tag values (a bare `20260910` becomes
+  a date), keep the `modelopt_` prefix (untagged, they read as this eval's own run), and
+  leave `description` naming the model and sampling params as the template does. Carry the
+  values verbatim, but flag any that look like placeholders rather than quietly publishing a
+  `run_url` with no run behind it.
 
   `tracking_uri` stays `${oc.env:MLFLOW_TRACKING_URI}`. When it differs from the file's —
   the usual case — the export creates a *same-named, empty* experiment on the eval server

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -384,15 +384,18 @@ On SLURM, several deploy/eval failures are invisible to `--dry-run` and only sur
   | `run_name` / `run_id` / `run_url` | tags `modelopt_run_name` / `modelopt_run_id` / `modelopt_run_url` |
   | `tracking_uri`, `experiment_id` | nothing — both are local to the PTQ's server |
 
-  Quote the tag values (a bare `20260910` becomes a date), keep the `modelopt_` prefix
-  (untagged, they read as this eval's own run), and **skip any value containing `${`** —
-  quoting does not stop OmegaConf resolving it, so a crafted file could interpolate an env
-  var into a tag. Leave `description` identifying the eval.
+  **Skip any imported value containing `${`, `experiment_name` included** — quoting does not
+  stop OmegaConf resolving it, and the same pass resolves the whole block, so a crafted file
+  could interpolate an env var into the config. `hf_ptq` only sanitizes the experiment name
+  it derives itself; an explicit `--mlflow_experiment` reaches the file as typed. Otherwise
+  quote the tag values (a bare `20260910` becomes a date), keep the `modelopt_` prefix
+  (untagged, they read as this eval's own run), and leave `description` identifying the eval.
 
   `tracking_uri` stays `${oc.env:MLFLOW_TRACKING_URI}`. When it differs from the file's —
   the usual case — the export creates a *same-named, empty* experiment on the eval server
   under a new server-local `experiment_id`; the PTQ run is not in it, and only
-  `modelopt_run_url` reaches it. Say so when you report the run.
+  `modelopt_run_url` reaches it. Say so when you report the run. To find these evals again
+  later, query this server for `tags.modelopt_run_id = '<ptq_run_id>'`.
 
 - **`execution.gres`** — auto-set if you used a predefined `internal/slurm/<cluster>` config (above). On the `slurm/default` fallback it's `gpu:8`, so set it to the node's GPU count (and match `--data-parallel-size`/`--tensor-parallel-size`) or `sbatch` rejects the job with *"Requested node configuration is not available"* (e.g. 4-GPU GB300 → `gres: gpu:4`; check with `sinfo -o '%P %G'`).
 

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -183,6 +183,11 @@ cat "$CHECKPOINT_PATH"/.experiment.json   # absent (or an HF handle) → nothing
 
 Carry what it says into `export.mlflow` per **Step 4**.
 
+It is a tracking pointer, not a quantization signal — read it independently of the
+quantization detection below, and never infer deploy flags from it either way. A checkpoint
+can carry one and be quantized by something other than ModelOpt, and a ModelOpt checkpoint
+quantized without `--mlflow` carries none.
+
 > **NEVER point `checkpoint_path` at a HuggingFace *cache snapshot* dir.** Entries under
 > `snapshots/<sha>/` are relative symlinks into `../../blobs/`. NEL mounts only the snapshot dir at
 > `/checkpoint`, so every link dangles in-container and vLLM dies with

--- a/plugins/modelopt/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/example_eval.yaml
@@ -192,10 +192,9 @@ export:
   # SAME edit, or MLflow will misreport the run.
   mlflow:
     tracking_uri: ${oc.env:MLFLOW_TRACKING_URI}   # from modelopttools:eval-config (canonical frontier-evals host; NOT the -nemo-evaluator alias)
-    # If the checkpoint holds a .experiment.json, use ITS experiment_name verbatim here
-    # instead, so evals of this checkpoint group under the run that quantized it. When the
-    # PTQ tracked to a different server this creates a same-named experiment here, and the
-    # PTQ run stays reachable only via modelopt_run_url (Step 4).
+    # If the checkpoint holds a .experiment.json, use ITS experiment_name verbatim here so
+    # evals group under the run that quantized it. Cross-server, that makes a same-named
+    # experiment here and only modelopt_run_url reaches the PTQ run (Step 4).
     experiment_name: ${oc.env:USER}/CHANGEME-served-model-name
     description: 'CHANGEME-served-model-name | T=1.0, top_p=0.95, max_new_tokens=65536'
     log_logs: true
@@ -208,10 +207,9 @@ export:
       temperature: '1.0'
       top_p: '0.95'
       max_new_tokens: '65536'
-      # From the checkpoint's .experiment.json when present — the ModelOpt PTQ run that
-      # produced it. Drop these three rows when the file is absent. The modelopt_ prefix
-      # keeps them from reading as this eval's own run; keep the quotes, or an all-digit
-      # run_id / a run_name like 20260910 is coerced to an int or a date.
+      # From the checkpoint's .experiment.json when present; drop when absent. Keep the
+      # quotes (a bare 20260910 becomes a date) and skip any value containing ${ — quoting
+      # does not stop OmegaConf resolving it.
       #modelopt_run_name: 'CHANGEME-from-.experiment.json'
       #modelopt_run_id: 'CHANGEME-from-.experiment.json'
       #modelopt_run_url: 'CHANGEME-from-.experiment.json'

--- a/plugins/modelopt/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/example_eval.yaml
@@ -193,8 +193,9 @@ export:
   mlflow:
     tracking_uri: ${oc.env:MLFLOW_TRACKING_URI}   # from modelopttools:eval-config (canonical frontier-evals host; NOT the -nemo-evaluator alias)
     # If the checkpoint holds a .experiment.json, use ITS experiment_name verbatim here so
-    # evals group under the run that quantized it. Cross-server, that makes a same-named
-    # experiment here and only modelopt_run_url reaches the PTQ run (Step 4).
+    # evals group under the run that quantized it -- unless it contains ${, which OmegaConf
+    # would resolve. Cross-server, that makes a same-named experiment here and only
+    # modelopt_run_url reaches the PTQ run (Step 4).
     experiment_name: ${oc.env:USER}/CHANGEME-served-model-name
     description: 'CHANGEME-served-model-name | T=1.0, top_p=0.95, max_new_tokens=65536'
     log_logs: true
@@ -208,7 +209,7 @@ export:
       top_p: '0.95'
       max_new_tokens: '65536'
       # From the checkpoint's .experiment.json when present; drop when absent. Keep the
-      # quotes (a bare 20260910 becomes a date) and skip any value containing ${ — quoting
+      # quotes (a bare 20260910 becomes a date) and skip any value containing ${ -- quoting
       # does not stop OmegaConf resolving it.
       #modelopt_run_name: 'CHANGEME-from-.experiment.json'
       #modelopt_run_id: 'CHANGEME-from-.experiment.json'

--- a/plugins/modelopt/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/example_eval.yaml
@@ -192,6 +192,10 @@ export:
   # SAME edit, or MLflow will misreport the run.
   mlflow:
     tracking_uri: ${oc.env:MLFLOW_TRACKING_URI}   # from modelopttools:eval-config (canonical frontier-evals host; NOT the -nemo-evaluator alias)
+    # If the checkpoint holds a .experiment.json, use ITS experiment_name verbatim here
+    # instead, so evals of this checkpoint group under the run that quantized it. When the
+    # PTQ tracked to a different server this creates a same-named experiment here, and the
+    # PTQ run stays reachable only via modelopt_run_url (Step 4).
     experiment_name: ${oc.env:USER}/CHANGEME-served-model-name
     description: 'CHANGEME-served-model-name | T=1.0, top_p=0.95, max_new_tokens=65536'
     log_logs: true
@@ -204,3 +208,10 @@ export:
       temperature: '1.0'
       top_p: '0.95'
       max_new_tokens: '65536'
+      # From the checkpoint's .experiment.json when present — the ModelOpt PTQ run that
+      # produced it. Drop these three rows when the file is absent. The modelopt_ prefix
+      # keeps them from reading as this eval's own run; keep the quotes, or an all-digit
+      # run_id / a run_name like 20260910 is coerced to an int or a date.
+      #modelopt_run_name: 'CHANGEME-from-.experiment.json'
+      #modelopt_run_id: 'CHANGEME-from-.experiment.json'
+      #modelopt_run_url: 'CHANGEME-from-.experiment.json'

--- a/plugins/modelopt/skills/evaluation/references/nel-next.md
+++ b/plugins/modelopt/skills/evaluation/references/nel-next.md
@@ -193,6 +193,13 @@ with its own `run_id`, copying the shared `services:` block.
   alias, whose 308 strips `/api/...` → 405). **SLURM does NOT auto-export** — push after
   the run with `nel-next.sh mlflow-push` (Run flow), which resolves the var and falls back
   to the canonical host.
+- **ModelOpt provenance.** Same rule as SKILL.md Step 4: if the served checkpoint holds a
+  `.experiment.json` (left by `hf_ptq.py --mlflow`), use its `experiment_name` verbatim
+  instead of `<user>/<model>` and add its quoted `run_name`/`run_id`/`run_url` as the
+  `modelopt_run_name`/`modelopt_run_id`/`modelopt_run_url` tags. Keep `tracking_uri` as
+  `${MLFLOW_TRACKING_URI}` — when the PTQ tracked elsewhere, the inherited name creates a
+  same-named experiment here and `modelopt_run_url` is the only route back. Absent → name
+  it as usual.
 
 ## Run (dry-run → canary → full) → push to MLflow
 

--- a/plugins/modelopt/skills/evaluation/references/nel-next.md
+++ b/plugins/modelopt/skills/evaluation/references/nel-next.md
@@ -194,12 +194,10 @@ with its own `run_id`, copying the shared `services:` block.
   the run with `nel-next.sh mlflow-push` (Run flow), which resolves the var and falls back
   to the canonical host.
 - **ModelOpt provenance.** Same rule as SKILL.md Step 4: if the served checkpoint holds a
-  `.experiment.json` (left by `hf_ptq.py --mlflow`), use its `experiment_name` verbatim
-  instead of `<user>/<model>` and add its quoted `run_name`/`run_id`/`run_url` as the
-  `modelopt_run_name`/`modelopt_run_id`/`modelopt_run_url` tags. Keep `tracking_uri` as
-  `${MLFLOW_TRACKING_URI}` — when the PTQ tracked elsewhere, the inherited name creates a
-  same-named experiment here and `modelopt_run_url` is the only route back. Absent → name
-  it as usual.
+  `.experiment.json`, use its `experiment_name` verbatim and add its quoted
+  `run_name`/`run_id`/`run_url` as `modelopt_run_*` tags, skipping any value containing
+  `${`. Keep `tracking_uri` as `${MLFLOW_TRACKING_URI}` — cross-server, the inherited name
+  makes a same-named experiment here and `modelopt_run_url` is the only route back.
 
 ## Run (dry-run → canary → full) → push to MLflow
 

--- a/plugins/modelopt/skills/evaluation/references/nel-next.md
+++ b/plugins/modelopt/skills/evaluation/references/nel-next.md
@@ -195,8 +195,8 @@ with its own `run_id`, copying the shared `services:` block.
   to the canonical host.
 - **ModelOpt provenance.** Same rule as SKILL.md Step 4: if the served checkpoint holds a
   `.experiment.json`, use its `experiment_name` verbatim and add its quoted
-  `run_name`/`run_id`/`run_url` as `modelopt_run_*` tags, skipping any value containing
-  `${`. Keep `tracking_uri` as `${MLFLOW_TRACKING_URI}` — cross-server, the inherited name
+  `run_name`/`run_id`/`run_url` as `modelopt_run_*` tags, skipping any imported value
+  containing `${` — `experiment_name` included, since the same pass resolves the block. Keep `tracking_uri` as `${MLFLOW_TRACKING_URI}` — cross-server, the inherited name
   makes a same-named experiment here and `modelopt_run_url` is the only route back.
 
 ## Run (dry-run → canary → full) → push to MLflow


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation (agent skill)

Follow-up to #2374, which made a tracked `hf_ptq.py --mlflow` run leave `.experiment.json` in the checkpoint it writes, naming the MLflow run that quantized it. Nothing on the eval side read that file, so an eval of a quantized checkpoint recorded no link back to the quantization that produced it.

The `evaluation` skill now reads it. **Step 3** `cat`s the file as soon as `checkpoint_path` is known; **Step 4** carries it into `export.mlflow`:

| `.experiment.json` field | goes to |
| --- | --- |
| `experiment_name` | `export.mlflow.experiment_name`, verbatim |
| `run_name` / `run_id` / `run_url` | tags `modelopt_run_name` / `modelopt_run_id` / `modelopt_run_url` |
| `tracking_uri`, `experiment_id` | deliberately unmapped |

The `modelopt_` prefix keeps them from reading as the eval's own run. Values are quoted, or an all-digit `run_id` (or a `run_name` like `20260910`) is YAML-coerced to an int or a date.

**`tracking_uri` is deliberately not inherited**, and the consequence is documented rather than implied. Evals go to whatever `$MLFLOW_TRACKING_URI` names. When the PTQ tracked to a different server — the usual case, since `modelopttools:eval-config` points evals at `mlflow.frontier-evals` while `hf_ptq --mlflow` typically writes to `mlflow-modelopt` — the inherited name creates a *same-named, empty* experiment on the eval server, and `modelopt_run_url` is the only route back to the PTQ run. Evals of one checkpoint still group under a stable name. Both cases are spelled out in Step 4 so nobody goes looking for the PTQ run beside the eval.

Also updated: `references/nel-next.md` (nel-next configures MLflow through its own `export_config.mlflow`) and `accessing-mlflow` (the `tags.modelopt_run_id` query that closes the loop — without it the tag is write-only).

### Usage

```bash
cat "$CHECKPOINT_PATH"/.experiment.json   # absent → name the experiment as usual
```

```yaml
export:
  mlflow:
    tracking_uri: ${oc.env:MLFLOW_TRACKING_URI}        # NOT the file's
    experiment_name: alice/hf_ptq/Qwen3.8-27B-NVFP4    # verbatim from .experiment.json
    tags:
      modelopt_run_name: '20260910-175422'
      modelopt_run_id: '7bec239a3a154970b062f3024a5ff20e'
      modelopt_run_url: 'https://<modelopt-mlflow-server>/#/experiments/36/runs/7bec239a3a154970b062f3024a5ff20e'
```

Finding every eval of a checkpoint a given PTQ run produced:

```python
MLflow:query_runs(experiment_id, "tags.modelopt_run_id = '<ptq_run_id>'")
```

### Testing

Docs-only, so it was tested by having an agent follow the new wording end to end and checking what NEL actually submitted.

A GPQA Diamond config (single repeat) was generated against an NVFP4 checkpoint carrying a `.experiment.json`, dry-run clean, then submitted on a SLURM cluster. Verified in the `export_config.yml` heredoc **inside the submitted `run.sub`** — the file the export job actually consumes, not just the source YAML:

```yaml
experiment_name: chenjiel/hf_ptq/Qwen3.8-27B-NVFP4        # inherited verbatim
tags:
  modelopt_run_name: 20260910-000000-synthetic-test-fixture
  modelopt_run_id: 00000000fake0000fake0000fake0000
  modelopt_run_url: https://<modelopt-mlflow-server>/#/experiments/999/runs/...
tracking_uri: https://<eval-mlflow-server>/    # env var, not the file's
```

This confirmed the open question behind the change: NEL accepts arbitrary `modelopt_*` keys in `export.mlflow.tags`. The `.experiment.json` used was a synthetic fixture, since the checkpoints predate #2374.

Repeated on a **second cluster with a second checkpoint** (different account, QoS-based scheduler, FP8 rather than NVFP4) and carried through to completion, so the result is confirmed as *stored by MLflow* rather than merely submitted. Canary scored `gpqa pass@1 symbolic_correct: 90.0` (card: 88.01) with `no_answer: 0.0`, then the auto-export wrote:

```
experiment        chenjiel/hf_ptq/Qwen3.8-27B-FP8   (id 2106)
run               eval-<invocation>-ns_gpqa          FINISHED
modelopt_run_name 20260910-000000-synthetic-test-fixture
modelopt_run_id   00000000fake0000fake0000fake0000
modelopt_run_url  https://<modelopt-mlflow-server>/#/experiments/999/runs/...
```

Experiment 2106 did not exist on the eval server beforehand — the export created it. That is the shadow-experiment case this PR documents, observed rather than predicted.

The same exercise corrected the first draft of the wording: it had claimed the rule makes a quantization and its evals "sit together on one server", which is false whenever the two servers differ. Confirmed by API — `chenjiel/hf_ptq/Qwen3.8-27B-NVFP4` returns `RESOURCE_DOES_NOT_EXIST` on `mlflow.frontier-evals`. Rewritten as described above.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — additive guidance; the absent-file path is unchanged.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — skill documentation; validated by a real submission, above.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ — agent-skill guidance, not a library/example feature.
- Did you get Claude approval on this PR?: ❌

### Additional Information

Follow-up to #2374.

Three adjacent problems were found while validating and deliberately **left out of scope** — happy to split them into their own PR:

1. `recipes/examples/example_eval.yaml` puts `sbatch_comment` under a top-level `cluster:` key, but the executor reads `cfg.execution.sbatch_comment` (`executors/slurm/executor.py:688`) and SKILL.md Step 1 says the same. As shipped the template silently drops the idle-GPU reaper exemption, so long evals get reaped.
2. Step 4's `execution.gres` bullet names the wrong key for `internal/slurm/<cluster>` configs, which supply `gpus_per_node` and no `gres`; following it literally emits a redundant flag.
3. Step 3's `max_new_tokens` rules can contradict each other — "take the card's highest" can equal `max_model_len`, leaving no room for the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified MLflow evaluation configuration requirements, including literal experiment and sampling values, CPU partition settings, and ModelOpt provenance.
  - Documented validation and fallback behavior for unresolved `${...}` placeholders in provenance values.
  - Added guidance for querying cross-server evaluations by run ID and handling same-named local experiments.
  - Clarified that provenance files are optional, independent of quantization detection, and do not control deployment flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


