### PR TITLE
Close remaining DASC review gaps

### DIFF
--- a/docs/source/guides/6_sparsity.rst
+++ b/docs/source/guides/6_sparsity.rst
@@ -141,6 +141,9 @@ ordinary dense recurrent state before continuation.
         "epsilon": 1e-3,
         "static_gate_input": -0.3,
         "wmax_candidates": [32],
+        "min_perplexity_retention": 0.995,
+        "min_top1_agreement": 0.98,
+        "min_checkpoint_savings": 0.2,
         # Set this to the dtype used to store A_log and dt_bias in the checkpoint.
         "decay_parameter_storage_dtype": "bfloat16",
         "model_id": "org/model",
@@ -186,7 +189,9 @@ selected ``Wmax`` tokens. Both retain whole GDN heads, preserve convolution stat
 dense recurrence. KDA and serving-runtime integration are not supported by this initial API.
 The initial GDN adapter accepts the ``GatedDeltaNet`` and ``Qwen3NextGatedDeltaNet`` base classes,
 including ModelOpt-generated dynamic subclasses, and fails closed for unrelated implementations
-even when they expose similarly named decay tensors.
+even when they expose similarly named decay tensors. Megatron GDN policy export is currently limited
+to ``tensor_model_parallel_size=1`` and ``pipeline_model_parallel_size=1`` because a distributed
+policy would otherwise contain ambiguous rank-local head and layer indices.
 Re-running :func:`~modelopt.torch.sparsity.state_sparsity.calibrate` replaces the existing DASC
 mode-state entry and supersedes its stale policy without growing the checkpoint history. A policy
 with recoverable GDN geometry drift, decay drift, or temporarily unavailable decay tensors remains
@@ -201,6 +206,9 @@ rounding introduced by the declared storage dtype and the live tensor dtype. Whe
 distinct lossy inverse rounding bounds are composed in sequence; a duplicate dtype or an exact
 widening cast contributes no additional slack. Decay tensors that are live in BF16 or FP16 are
 still validated against that live dtype's rounding.
+Choose ``static_gate_input`` as a conservative lower bound, such as a low percentile measured on the
+calibration slices. Increasing it shortens the derived horizons and omits more heads; a value above
+gate inputs encountered at runtime can therefore discard state whose true retention is longer.
 
 .. _sparsity-concepts:
 

--- a/modelopt/torch/sparsity/state_sparsity/config.py
+++ b/modelopt/torch/sparsity/state_sparsity/config.py
@@ -118,7 +118,10 @@ class DASCConfig(ModeloptBaseConfig):
     )
     static_gate_input: float = ModeloptField(
         default=_DEFAULT_STATIC_GATE_INPUT,
-        description="Static gate input added to each GDN head's dt_bias.",
+        description=(
+            "Conservative lower-bound gate input added to each GDN head's dt_bias; larger values "
+            "shorten horizons and omit more heads."
+        ),
     )
     decay_parameter_storage_dtype: _DecayParameterStorageDtype = ModeloptField(
         default="float32",
@@ -256,6 +259,20 @@ class DASCPolicy(ModeloptBaseConfig):
     )
     layers: dict[str, DASCLayerPolicy] = Field(min_length=1)
     measurements: list[DASCCalibrationMeasurement] = Field(min_length=1)
+
+    @field_validator("epsilon")
+    @classmethod
+    def validate_epsilon(cls, epsilon: float) -> float:
+        """Require a finite decay threshold strictly between zero and one."""
+        _validate_analysis_arguments(epsilon=epsilon)
+        return epsilon
+
+    @field_validator("static_gate_input")
+    @classmethod
+    def validate_static_gate_input(cls, value: float) -> float:
+        """Require a finite representative gate input."""
+        _validate_analysis_arguments(static_gate_input=value)
+        return value
 
     @model_validator(mode="after")
     def validate_policy(self) -> "DASCPolicy":

--- a/modelopt/torch/sparsity/state_sparsity/conversion.py
+++ b/modelopt/torch/sparsity/state_sparsity/conversion.py
@@ -41,6 +41,7 @@ _DASC_POLICY_ATTRIBUTE = "_modelopt_dasc_policy"
 
 def _attach_policy(model: nn.Module, policy: DASCPolicy) -> None:
     """Attach a JSON-safe DASC policy to an unwrapped model."""
+    model = unwrap_model(model, force_unwrap=True)
     setattr(model, _DASC_POLICY_ATTRIBUTE, policy.model_dump(mode="json"))
 
 
@@ -142,8 +143,6 @@ def replace_dasc_mode(
     if not dasc_indices:
         raise ApplyModeError("Cannot replace DASC mode because the model has no DASC state")
     policy = build_dasc_policy(model, config, measurements)
-    if dasc_indices[-1] != len(state) - 1:
-        manager.update_last_state_before_new_mode(model)
 
     first_index = dasc_indices[0]
     state[first_index] = (

--- a/modelopt/torch/sparsity/state_sparsity/policy.py
+++ b/modelopt/torch/sparsity/state_sparsity/policy.py
@@ -43,8 +43,9 @@ from .config import (
 
 __all__ = ["analyze_gdn_decay", "compute_gdn_decay_horizons"]
 
+_MEGATRON_GDN_CLASS_PATH = ("megatron.core.ssm.gated_delta_net", "GatedDeltaNet")
 _SUPPORTED_GDN_CLASS_PATHS = (
-    ("megatron.core.ssm.gated_delta_net", "GatedDeltaNet"),
+    _MEGATRON_GDN_CLASS_PATH,
     ("transformers.models.qwen3_next.modeling_qwen3_next", "Qwen3NextGatedDeltaNet"),
 )
 _STORAGE_DTYPES: dict[_DecayParameterStorageDtype, torch.dtype] = {
@@ -171,8 +172,54 @@ def _reject_unconverted_gdn_subclasses(
     if unsupported_subclasses:
         raise ApplyModeError(
             "DASC found GDN subclasses that are not ModelOpt dynamic modules at: "
-            f"{', '.join(unsupported_subclasses)}; convert the module with ModelOpt or use a "
-            "supported class directly"
+            f"{', '.join(unsupported_subclasses)}; Megatron subclasses require a ModelOpt "
+            "NAS/prune dynamic conversion, while Transformers subclasses must currently use the "
+            "supported base class directly"
+        )
+
+
+def _reject_distributed_megatron_gdn(
+    identity_modules: list[tuple[str, nn.Module]],
+    supported_classes: tuple[type[nn.Module], ...],
+) -> None:
+    """Fail closed when a Megatron policy would contain rank-local head or layer geometry."""
+    module_name, class_name = _MEGATRON_GDN_CLASS_PATH
+    megatron_class = next(
+        (
+            candidate
+            for candidate in supported_classes
+            if candidate.__module__ == module_name and candidate.__name__ == class_name
+        ),
+        None,
+    )
+    if megatron_class is None:
+        return
+
+    megatron_modules = [
+        (name, module)
+        for name, module in identity_modules
+        if _has_supported_gdn_identity(module, (megatron_class,))
+    ]
+    if not megatron_modules:
+        return
+
+    parallel_sizes = set()
+    for name, module in megatron_modules:
+        config = getattr(module, "config", None)
+        tp_size = getattr(config, "tensor_model_parallel_size", None)
+        pp_size = getattr(config, "pipeline_model_parallel_size", None)
+        if not isinstance(tp_size, int) or not isinstance(pp_size, int):
+            raise ApplyModeError(
+                "DASC could not verify single-process Megatron parallelism for GDN module "
+                f"{name or '<root>'!r}"
+            )
+        parallel_sizes.add((tp_size, pp_size))
+
+    if parallel_sizes != {(1, 1)}:
+        raise ApplyModeError(
+            "DASC policy export supports Megatron GDN only with tensor_model_parallel_size=1 "
+            "and pipeline_model_parallel_size=1 because distributed policies would contain "
+            f"rank-local head or layer indices; found {sorted(parallel_sizes)}"
         )
 
 
@@ -188,6 +235,7 @@ def _get_gdn_modules(model: nn.Module) -> dict[str, nn.Module]:
     ]
     _reject_incomplete_gdn_modules(identity_modules)
     _reject_unconverted_gdn_subclasses(named_modules, supported_classes)
+    _reject_distributed_megatron_gdn(identity_modules, supported_classes)
     if not identity_modules:
         supported = ", ".join(
             f"{module_name}.{class_name}" for module_name, class_name in _SUPPORTED_GDN_CLASS_PATHS

--- a/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
+++ b/tests/unit/torch/sparsity/state_sparsity/test_dasc.py
@@ -18,6 +18,7 @@
 import copy
 import io
 import json
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -29,7 +30,7 @@ import modelopt.torch.sparsity.state_sparsity as mtss
 import modelopt.torch.sparsity.state_sparsity.policy as dasc_policy
 from modelopt.torch.opt.conversion import ApplyModeError, ModeloptStateManager
 from modelopt.torch.opt.dynamic import DynamicModule
-from modelopt.torch.sparsity.state_sparsity.conversion import replace_dasc_mode
+from modelopt.torch.sparsity.state_sparsity.conversion import replace_dasc_mode, restore_dasc_model
 from modelopt.torch.sparsity.state_sparsity.mode import DASCModeRegistry
 
 _resolve_supported_gdn_classes = dasc_policy._supported_gdn_classes.__wrapped__
@@ -180,6 +181,30 @@ def test_config_fails_closed(override):
     assert mtss.DASCConfig(**_config(wmax_candidates=[7])).wmax_candidates == [7]
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("epsilon", 0.0, r"epsilon must be finite and in \(0, 1\)"),
+        ("epsilon", float("nan"), r"epsilon must be finite and in \(0, 1\)"),
+        ("static_gate_input", float("inf"), "static_gate_input must be finite"),
+    ],
+)
+def test_policy_fails_closed_on_invalid_decay_analysis_arguments(field, value, message):
+    """Reject malformed attached-policy analysis inputs at the schema boundary."""
+    model = mtss.calibrate(
+        TinyGatedDeltaNetForCausalLM(), _config(wmax_candidates=[7]), [_candidate(7)]
+    )
+    policy = mtss.export_policy(model)
+    policy[field] = value
+
+    with pytest.raises(ValidationError, match=message):
+        mtss.DASCPolicy(**policy)
+
+    setattr(model, "_modelopt_dasc_policy", policy)
+    with pytest.raises(ApplyModeError, match="no valid attached DASC policy"):
+        mtss.export_policy(model)
+
+
 def test_perplexity_retention_accepts_parity_improvements():
     """Allow improvement measurements and thresholds instead of requiring clamping."""
     candidate = _candidate(7)
@@ -278,8 +303,9 @@ def test_calibration_fails_closed_on_measurements_and_model_mismatch():
     with pytest.raises(
         ApplyModeError,
         match=(
-            r"not ModelOpt dynamic modules at: stale; convert the module with ModelOpt or use a "
-            r"supported class directly$"
+            r"not ModelOpt dynamic modules at: stale; Megatron subclasses require a ModelOpt "
+            r"NAS/prune dynamic conversion, while Transformers subclasses must currently use the "
+            r"supported base class directly$"
         ),
     ):
         mtss.analyze_gdn_decay(mixed_subclass)
@@ -333,7 +359,7 @@ def test_declared_gdn_paths_resolve_when_framework_is_installed(module_name, cla
     assert issubclass(getattr(module, class_name), nn.Module)
 
 
-def test_generic_mode_application_reports_missing_measurements(monkeypatch):
+def test_generic_mode_application_reports_missing_measurements():
     """Give generic apply_mode callers an actionable calibration-evidence error."""
     assert DASCModeRegistry["dasc"].next_prohibited_modes == {"dasc"}
     assert DASCModeRegistry["dasc"].update_for_new_mode is not None
@@ -352,22 +378,27 @@ def test_generic_mode_application_reports_missing_measurements(monkeypatch):
             [_candidate(7)],
         )
 
+
+def test_recalibration_does_not_refresh_an_unrelated_trailing_mode(monkeypatch):
+    """Replace DASC state in place without invoking another mode's update hook."""
     model = mtss.calibrate(
         TinyGatedDeltaNetForCausalLM(), _config(wmax_candidates=[7]), [_candidate(7)]
     )
-    ModeloptStateManager(model).state_dict().append(("trailing-mode", {}))
-    refreshed = []
+    state = ModeloptStateManager(model).state_dict()
+    trailing_state = ("trailing-mode", {"config": {}, "metadata": {"sentinel": True}})
+    state.append(copy.deepcopy(trailing_state))
     monkeypatch.setattr(
         ModeloptStateManager,
         "update_last_state_before_new_mode",
-        lambda _manager, current_model: refreshed.append(current_model),
+        lambda *_args: pytest.fail("recalibration must not update an unrelated mode"),
     )
+
     replace_dasc_mode(
         model,
         mtss.DASCConfig(**_config(wmax_candidates=[7])),
         [_candidate(7)],
     )
-    assert refreshed == [model]
+    assert state[-1] == trailing_state
 
 
 def test_public_exports_and_wrapped_model_export():
@@ -388,6 +419,59 @@ def test_public_exports_and_wrapped_model_export():
 
     with pytest.raises(ApplyModeError, match="no valid attached DASC policy"):
         mtss.export_policy(TinyGatedDeltaNetForCausalLM())
+
+
+def test_restore_attaches_policy_to_the_unwrapped_model():
+    """Keep policy attachment and lookup symmetric for a wrapped restore entrypoint."""
+    calibrated = mtss.calibrate(
+        TinyGatedDeltaNetForCausalLM(), _config(wmax_candidates=[7]), [_candidate(7)]
+    )
+    state = mto.modelopt_state(calibrated)["modelopt_state_dict"][0][1]
+    wrapped = nn.DataParallel(TinyGatedDeltaNetForCausalLM())
+
+    restore_dasc_model(wrapped, mtss.DASCConfig(**state["config"]), state["metadata"])
+
+    assert mtss.export_policy(wrapped) == mtss.export_policy(calibrated)
+
+
+@pytest.mark.parametrize(("tp_size", "pp_size"), [(2, 1), (1, 2)])
+def test_megatron_policy_fails_closed_on_distributed_geometry(monkeypatch, tp_size, pp_size):
+    """Reject rank-local Megatron head or layer indices until policy geometry is global."""
+    megatron_gdn = type(
+        "GatedDeltaNet",
+        (GatedDeltaNet,),
+        {"__module__": "megatron.core.ssm.gated_delta_net"},
+    )
+    module = megatron_gdn()
+    module.config = SimpleNamespace(
+        tensor_model_parallel_size=tp_size,
+        pipeline_model_parallel_size=pp_size,
+    )
+    model = nn.Module()
+    model.linear_attn = module
+    monkeypatch.setattr(dasc_policy, "_supported_gdn_classes", lambda: (megatron_gdn,))
+
+    with pytest.raises(ApplyModeError, match="distributed policies would contain rank-local"):
+        mtss.analyze_gdn_decay(model)
+
+
+def test_megatron_policy_accepts_single_process_geometry(monkeypatch):
+    """Keep the Megatron adapter available when policy indices are globally unambiguous."""
+    megatron_gdn = type(
+        "GatedDeltaNet",
+        (GatedDeltaNet,),
+        {"__module__": "megatron.core.ssm.gated_delta_net"},
+    )
+    module = megatron_gdn()
+    module.config = SimpleNamespace(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+    )
+    model = nn.Module()
+    model.linear_attn = module
+    monkeypatch.setattr(dasc_policy, "_supported_gdn_classes", lambda: (megatron_gdn,))
+
+    assert mtss.analyze_gdn_decay(model)["linear_attn"]
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix and documentation.

Closes the remaining review gaps on #2375. Distributed Megatron GDN policy export now fails closed for tensor or pipeline parallel configurations whose head and layer indices would be rank-local. The patch also validates standalone policy decay inputs, keeps policy attachment wrapper-safe, avoids refreshing unrelated mode metadata during recalibration, clarifies subclass remediation, and documents gate direction and active quality defaults.

Two review suggestions are intentionally not implemented: a head-count ratio is not a universal byte-savings bound for heterogeneous state geometry, and nonlinear measured quality is not guaranteed to be monotonic with DASC-NR window size.

### Usage

No API changes. Megatron GDN calibration remains supported for TP=1 and PP=1 and fails closed otherwise.

### Testing

- python -m pytest -q tests/unit/torch/sparsity/state_sparsity/test_dasc.py: 60 passed, 1 optional Megatron skip
- python -m pytest -q tests/unit/torch/sparsity/state_sparsity tests/unit/torch/sparsity/weight_sparsity tests/unit/torch/sparsity/attention_sparsity: 338 passed, 1 optional Megatron skip
- pre-commit run on all five changed files: passed

### Before your PR is Ready for review

- Backward compatible: yes
- Copied code or new dependency: no
- New necessary tests: yes
- Changelog update: N/A; these are fixes to the same unreleased feature
- Claude approval: pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for decay-analysis settings, including finite epsilon values and static gate inputs within supported ranges.
  - Added safeguards to prevent policy generation for unsupported distributed Megatron configurations.

- **Bug Fixes**
  - Improved restoration and recalibration behavior when applying DASC policies.
  - Clarified error messages for unsupported GDN implementations.

- **Documentation**
  - Documented sparsity, perplexity-retention, agreement, and checkpoint-savings thresholds.
  - Clarified conservative gate selection and supported export configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->