### PR TITLE
[6701308][OMNIML-5805] Correct ONNX PTQ documentation contracts

### DIFF
--- a/docs/source/guides/_onnx_quantization.rst
+++ b/docs/source/guides/_onnx_quantization.rst
@@ -37,7 +37,7 @@ Requirements
 Apply Post Training Quantization (PTQ)
 ======================================
 
-PTQ should be done with a calibration dataset. If calibration dataset is not provided, ModelOpt will use random scales for the QDQ nodes.
+PTQ should be done with a calibration dataset. Random calibration inputs are used when no calibration dataset is provided.
 
 Prepare calibration dataset
 ---------------------------

--- a/examples/onnx_ptq/README.md
+++ b/examples/onnx_ptq/README.md
@@ -111,7 +111,7 @@ The model can be quantized as an FP8, INT8 or INT4 model using either the CLI or
 
 > *For NVFP4 and MXFP8 ONNX, see the [PyTorch to ONNX example](../torch_onnx/).*
 
-> *Minimum opset requirements: int8 (13+), fp8 (21+), int4 (21+). ModelOpt will automatically upgrade lower opset versions to meet these requirements.*
+> *Minimum opset requirements: int8 (19+), fp8 (19+), int4 (21+). ModelOpt will automatically upgrade lower opset versions to meet these requirements.*
 
 #### Option 1: Command-line interface
 
@@ -119,7 +119,7 @@ The model can be quantized as an FP8, INT8 or INT4 model using either the CLI or
 python -m modelopt.onnx.quantization \
     --onnx_path=vit_base_patch16_224.onnx \
     --quantize_mode=<fp8|int8|int4> \
-    --calibration_data=calib.npy \
+    --calibration_data_path=calib.npy \
     --calibration_method=<max|entropy|awq_clip|rtn_dq> \
     --output_path=vit_base_patch16_224.quant.onnx
 ```
@@ -127,12 +127,14 @@ python -m modelopt.onnx.quantization \
 #### Option 2: Python API
 
 ```python
+import numpy as np
+
 from modelopt.onnx.quantization import quantize
 
 quantize(
     onnx_path="vit_base_patch16_224.onnx",
     quantize_mode="int8",       # fp8, int8, int4 etc.
-    calibration_data="calib.npy",
+    calibration_data=np.load("calib.npy"),
     calibration_method="max",   # max, entropy, awq_clip, rtn_dq etc.
     output_path="vit_base_patch16_224.quant.onnx",
 )
@@ -202,7 +204,7 @@ To enable per node calibration, add the `--calibrate_per_node` flag to your quan
 python -m modelopt.onnx.quantization \
     --onnx_path=vit_base_patch16_224.onnx \
     --quantize_mode=<int8/fp8> \
-    --calibration_data=calib.npy \
+    --calibration_data_path=calib.npy \
     --calibrate_per_node \
     --output_path=vit_base_patch16_224.quant.onnx
 ```
@@ -257,9 +259,9 @@ To access this feature in the ONNX quantization workflow, simply add `--autotune
 ```bash
 python -m modelopt.onnx.quantization \
     --onnx_path=vit_base_patch16_224.onnx \
-    --quantize_mode=<fp8|int8|int4> \
-    --calibration_data=calib.npy \
-    --calibration_method=<max|entropy|awq_clip|rtn_dq> \
+    --quantize_mode=<fp8|int8> \
+    --calibration_data_path=calib.npy \
+    --calibration_method=<max|entropy> \
     --output_path=vit_base_patch16_224.quant.onnx \
     --autotune=<quick,default,extensive>
 ```

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -779,7 +779,6 @@ def quantize(
         )
 
     if calibration_data_reader is None:
-        # Use random scales if calibration data is not supplied
         if calibration_data is None:
             calibration_data_reader = RandomDataProvider(onnx_path, calibration_shapes)
         else:

--- a/tests/examples/test_onnx_ptq.sh
+++ b/tests/examples/test_onnx_ptq.sh
@@ -152,7 +152,7 @@ for model_path in "${model_paths[@]}"; do
         python -m modelopt.onnx.quantization \
             --onnx_path=$model_dir/fp16/model.onnx \
             --quantize_mode=$quant_mode \
-            --calibration_data=$calib_data_path \
+            --calibration_data_path=$calib_data_path \
             --output_path=$model_dir/$quant_mode/model.quant.onnx \
             --calibration_eps=cuda
     done


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

Align the ONNX PTQ README, guide, and executable example with the implemented contracts:

- use the canonical `--calibration_data_path` CLI option;
- load `.npy` calibration data before passing it to the Python API;
- document the supported Autotune modes and calibration methods;
- correct the minimum opsets to INT8 19, FP8 19, and INT4 21; and
- describe the no-data fallback as random calibration inputs.

This also removes an inaccurate source comment without changing runtime behavior.

### Usage

```bash
python -m modelopt.onnx.quantization \
    --onnx_path=model.onnx \
    --quantize_mode=int8 \
    --calibration_data_path=calib.npy \
    --output_path=model.quant.onnx
```

### Testing

- `pre-commit run --files docs/source/guides/_onnx_quantization.rst examples/onnx_ptq/README.md modelopt/onnx/quantization/quantize.py tests/examples/test_onnx_ptq.sh`
- `bash -n tests/examples/test_onnx_ptq.sh`
- `CUDA_VISIBLE_DEVICES="" python -m pytest -o addopts="" -p no:cacheprovider --confcutdir=tests/unit/onnx/quantization -q tests/unit/onnx/quantization/test_autotune_quantization_integration.py` (4 passed)
- `nox -s docs` (passed; Sphinx built 881 HTML files)
- Focused before/after contract probe covering the documented CLI option, API data type, Autotune modes and methods, opset minimums, and random-input wording

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: N/A
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

Tracking: [6701308]

> 🤖 _Generated by Codex (AI agent)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that random calibration inputs are used when no calibration dataset is provided.
  - Updated ONNX post-training quantization examples with minimum opset requirements and the `calibration_data_path` argument.
  - Clarified Autotune support for FP8 and INT8 calibration methods using `max` or `entropy`.

- **Tests**
  - Updated quantization command examples to use the current calibration data path option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->